### PR TITLE
Release: migrate middleware.ts to proxy.ts

### DIFF
--- a/apps/web/proxy.test.ts
+++ b/apps/web/proxy.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { shouldRedirect } from "./middleware";
+import { shouldRedirect } from "./proxy";
 
 describe("shouldRedirect", () => {
   describe("when COMING_SOON is false", () => {

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -22,7 +22,7 @@ export function shouldRedirect(pathname: string, comingSoon: boolean): boolean {
   return !ALLOW_PATTERNS.some((re) => re.test(pathname));
 }
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const comingSoon = process.env.COMING_SOON?.trim() === "true";
   if (shouldRedirect(request.nextUrl.pathname, comingSoon)) {
     const url = request.nextUrl.clone();
@@ -36,7 +36,7 @@ export const config = {
   matcher: [
     /*
      * Match all routes except Next.js internals and static assets.
-     * Middleware still checks the allowlist above for belt-and-suspenders safety.
+     * Proxy still checks the allowlist above for belt-and-suspenders safety.
      */
     "/((?!_next/static|_next/image).*)",
   ],


### PR DESCRIPTION
## Summary

- Rename `middleware.ts` → `proxy.ts` per Next.js 16 convention (deprecated `middleware` file)
- Rename exported function `middleware` → `proxy`
- No behavioral changes — same route gate logic

Fixes #88

## Test plan

- [x] 729 tests passing
- [x] Typecheck + lint clean
- [x] Build registers `ƒ Proxy (Middleware)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)