### PR TITLE
Hotfix: allow /cli/* through COMING_SOON gate

### DIFF
--- a/apps/web/proxy.test.ts
+++ b/apps/web/proxy.test.ts
@@ -69,5 +69,9 @@ describe("shouldRedirect", () => {
     it("does not redirect sitemap.xml", () => {
       expect(shouldRedirect("/sitemap.xml", true)).toBe(false);
     });
+
+    it("does not redirect CLI authorize page", () => {
+      expect(shouldRedirect("/cli/authorize", true)).toBe(false);
+    });
   });
 });

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -8,6 +8,7 @@ const ALLOW_PATTERNS: RegExp[] = [
   /^\/coming-soon$/,
   /^\/u\/[^/]+\/badge\.svg$/,
   /^\/api(\/|$)/,
+  /^\/cli(\/|$)/,
   /^\/_next(\/|$)/,
   /^\/favicon\./,
   /^\/logo/,


### PR DESCRIPTION
## Summary

- `/cli/authorize` was being redirected to the coming-soon page, blocking `chapa login`
- Added `/cli/` pattern to the proxy allowlist

One-line fix + test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)