### PR TITLE
Release: CLI login UX fix + device auth hotfix

### DIFF
--- a/docs/cli-guide.md
+++ b/docs/cli-guide.md
@@ -103,26 +103,36 @@ Options:
 
 The CLI uses browser-based authentication — similar to `npm login` or `gh auth login`. No personal GitHub token is needed.
 
+> **Important: Use your personal GitHub account.** The login step requires your **personal** GitHub account (the one linked to your Chapa badge), not your work/EMU account. If you're on a work computer where the default browser is logged into your EMU account, copy the URL and open it in:
+> - A **different browser** where your personal GitHub is logged in (e.g., Safari if you use Chrome for work)
+> - An **incognito/private window** and log in with your personal GitHub credentials
+
 ### Log in
 
 ```bash
 npx chapa-cli login
 ```
 
-This will:
-
-1. Open your browser to the Chapa authorization page
-2. Ask you to sign in with your personal GitHub account (if not already signed in)
-3. Click **"Authorize CLI"** to approve
-4. The CLI automatically detects the approval and saves your credentials
+The CLI will display a URL — copy it and open it in the browser where your **personal** GitHub account is logged in:
 
 ```
-Opening browser for authentication...
-If your browser didn't open, visit:
+Open this URL in a browser where your personal GitHub account is logged in:
+
   https://chapa.thecreativetoken.com/cli/authorize?session=...
 
-Waiting for approval...
+Tip: If your default browser has your work (EMU) account,
+     use a different browser or an incognito/private window.
 
+Waiting for approval...
+```
+
+Once you open the URL:
+
+1. Sign in with your **personal** GitHub account (if not already signed in)
+2. Click **"Authorize CLI"** to approve
+3. The CLI automatically detects the approval and saves your credentials
+
+```
 Logged in as juan294!
 Credentials saved to ~/.chapa/credentials.json
 ```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chapa-cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Merge GitHub EMU contributions into your Chapa developer impact badge",
   "type": "module",
   "bin": {

--- a/packages/cli/src/login.ts
+++ b/packages/cli/src/login.ts
@@ -2,29 +2,16 @@
  * Device authorization flow for Chapa CLI.
  *
  * 1. Generate a session ID (UUID)
- * 2. Open browser to the Chapa authorize page
+ * 2. Display authorize URL for user to open in their personal browser
  * 3. Poll the server until the user approves
  * 4. Save the token locally
  */
 
 import { randomUUID } from "node:crypto";
-import { exec } from "node:child_process";
 import { saveConfig } from "./config.js";
 
 export const POLL_INTERVAL_MS = 2000;
 export const MAX_POLL_ATTEMPTS = 150; // 5 minutes at 2s intervals
-
-function openBrowser(url: string): void {
-  const cmd =
-    process.platform === "win32"
-      ? `start "" "${url}"`
-      : process.platform === "darwin"
-        ? `open "${url}"`
-        : `xdg-open "${url}"`;
-  exec(cmd, () => {
-    // Ignore errors — user can open manually
-  });
-}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -41,10 +28,10 @@ export async function login(serverUrl: string): Promise<void> {
   const sessionId = randomUUID();
   const authorizeUrl = `${baseUrl}/cli/authorize?session=${sessionId}`;
 
-  console.log("Opening browser for authentication...");
-  console.log(`If your browser didn't open, visit:\n  ${authorizeUrl}\n`);
-  openBrowser(authorizeUrl);
-
+  console.log("\nOpen this URL in a browser where your personal GitHub account is logged in:");
+  console.log(`\n  ${authorizeUrl}\n`);
+  console.log("Tip: If your default browser has your work (EMU) account,");
+  console.log("     use a different browser or an incognito/private window.\n");
   console.log("Waiting for approval...");
 
   for (let i = 0; i < MAX_POLL_ATTEMPTS; i++) {


### PR DESCRIPTION
## Summary
- **fix(cli): don't auto-open browser on login** — Shows URL for manual copy instead of auto-opening, with tip about using personal account browser. Bumped to v0.2.1.
- **fix(infra): allow /cli/* through COMING_SOON gate** — CLI authorize page was blocked by the coming-soon proxy.
- **feat(cli): device auth flow** — Eliminated personal token requirement (v0.2.0).
- **docs**: Updated CLI guide and README for new auth flow.
- Various other docs, chore, and refactor commits since last release.

## Test plan
- [x] All 1182 tests pass
- [x] Typecheck clean
- [x] Lint clean
- [x] CI green on develop (5/5 workflows)
- [x] `chapa-cli@0.2.1` published to npm
- [ ] User verifies `chapa login` shows URL without auto-opening browser
- [ ] User verifies `/cli/authorize` loads on production (not blocked by coming-soon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)