### PR TITLE
Release: CLI device auth fix + v0.2.2

### DIFF
--- a/apps/web/app/api/cli/auth/approve/route.test.ts
+++ b/apps/web/app/api/cli/auth/approve/route.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/auth/github", () => ({
+  readSessionCookie: vi.fn(),
+}));
+
+vi.mock("@/lib/cache/redis", () => ({
+  cacheSet: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { readSessionCookie } from "@/lib/auth/github";
+import { cacheSet } from "@/lib/cache/redis";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(body: unknown, cookie?: string): Request {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (cookie) headers["cookie"] = cookie;
+
+  return new Request("https://chapa.thecreativetoken.com/api/cli/auth/approve", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("NEXTAUTH_SECRET", "test-secret");
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /api/cli/auth/approve", () => {
+  it("returns 503 when Redis write fails", async () => {
+    vi.mocked(readSessionCookie).mockReturnValue({
+      token: "ghp_fake",
+      login: "testuser",
+      name: "Test User",
+      avatar_url: "https://example.com/avatar.png",
+    });
+    vi.mocked(cacheSet).mockResolvedValue(false);
+
+    const res = await POST(
+      makeRequest(
+        { sessionId: "1feae8e3-6bc0-47da-84aa-0e24e2510454" },
+        "chapa_session=valid",
+      ),
+    );
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toMatch(/unavailable/i);
+  });
+
+  it("returns 200 with success when Redis write succeeds", async () => {
+    vi.mocked(readSessionCookie).mockReturnValue({
+      token: "ghp_fake",
+      login: "testuser",
+      name: "Test User",
+      avatar_url: "https://example.com/avatar.png",
+    });
+    vi.mocked(cacheSet).mockResolvedValue(true);
+
+    const res = await POST(
+      makeRequest(
+        { sessionId: "1feae8e3-6bc0-47da-84aa-0e24e2510454" },
+        "chapa_session=valid",
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.handle).toBe("testuser");
+  });
+
+  it("returns 401 when session cookie is invalid", async () => {
+    vi.mocked(readSessionCookie).mockReturnValue(null);
+
+    const res = await POST(
+      makeRequest(
+        { sessionId: "1feae8e3-6bc0-47da-84aa-0e24e2510454" },
+        "chapa_session=invalid",
+      ),
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid session ID format", async () => {
+    vi.mocked(readSessionCookie).mockReturnValue({
+      token: "ghp_fake",
+      login: "testuser",
+      name: "Test User",
+      avatar_url: "https://example.com/avatar.png",
+    });
+
+    const res = await POST(
+      makeRequest({ sessionId: "not-a-uuid" }, "chapa_session=valid"),
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 when NEXTAUTH_SECRET is missing", async () => {
+    vi.stubEnv("NEXTAUTH_SECRET", "");
+
+    const res = await POST(
+      makeRequest(
+        { sessionId: "1feae8e3-6bc0-47da-84aa-0e24e2510454" },
+        "chapa_session=valid",
+      ),
+    );
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/web/app/api/cli/auth/approve/route.ts
+++ b/apps/web/app/api/cli/auth/approve/route.ts
@@ -34,11 +34,18 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   // 3. Store approval in Redis
-  await cacheSet(
+  const stored = await cacheSet(
     `cli:device:${sessionId}`,
     { status: "approved", handle: session.login },
     DEVICE_SESSION_TTL,
   );
+
+  if (!stored) {
+    return NextResponse.json(
+      { error: "Service temporarily unavailable. Please try again." },
+      { status: 503 },
+    );
+  }
 
   return NextResponse.json({ success: true, handle: session.login });
 }

--- a/apps/web/lib/cache/redis.ts
+++ b/apps/web/lib/cache/redis.ts
@@ -59,15 +59,15 @@ export async function cacheGet<T>(key: string): Promise<T | null> {
 /**
  * Set a cached value with optional TTL.
  * Defaults to 6 hours (21 600 seconds). Pass 0 for no expiry (persistent).
- * Silently no-ops if Redis is unavailable.
+ * Returns `true` on success, `false` if Redis is unavailable or write fails.
  */
 export async function cacheSet<T>(
   key: string,
   value: T,
   ttlSeconds: number = 21600,
-): Promise<void> {
+): Promise<boolean> {
   const redis = getRedis();
-  if (!redis) return;
+  if (!redis) return false;
 
   try {
     if (ttlSeconds > 0) {
@@ -75,8 +75,10 @@ export async function cacheSet<T>(
     } else {
       await redis.set(key, value);
     }
+    return true;
   } catch (error) {
     console.error("[cache] cacheSet failed:", (error as Error).message);
+    return false;
   }
 }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chapa-cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Merge GitHub EMU contributions into your Chapa developer impact badge",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- **fix(cli):** Surface Redis failure in device auth instead of silent no-op — `cacheSet()` returns boolean, approve endpoint returns 503 on failure, CLI shows progress dots + error status
- **chore(cli):** Bump CLI version to 0.2.2 (already published to npm)

## Commits since last release
```
864e996 chore(cli): bump version to 0.2.2
96ef6dc fix(cli): surface Redis failure in device auth instead of silent no-op
6305620 fix(cli): don't auto-open browser on login, show URL to copy instead
359e341 fix(infra): allow /cli/* routes through COMING_SOON gate
e8b0d6f docs(cli): update manual for v0.2.0 device auth flow
5d4e4de feat(cli): implement device auth flow, eliminate personal token requirement
f36d1e7 docs(cli): update docs to match v0.1.4, fix token resolution claims
```

## Test plan
- [x] All 1190 tests pass
- [x] Typecheck clean
- [x] CI green on develop (all 5 workflows)
- [x] Redis health check: `ok` on production
- [x] CLI v0.2.2 published to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)