### PR TITLE
Release: fix refresh cache key + CDN cache busting on share page

### DIFF
--- a/apps/web/app/api/refresh/route.test.ts
+++ b/apps/web/app/api/refresh/route.test.ts
@@ -130,8 +130,8 @@ describe("POST /api/refresh", () => {
     const res = await POST(makeRequest("testuser"));
     expect(res.status).toBe(200);
 
-    // Should have deleted cache first
-    expect(cacheDel).toHaveBeenCalledWith("stats:testuser");
+    // Should have deleted cache first (must match client.ts cache key: stats:v2:<handle>)
+    expect(cacheDel).toHaveBeenCalledWith("stats:v2:testuser");
 
     // Should have fetched fresh stats with token
     expect(getStats).toHaveBeenCalledWith("testuser", "tok");

--- a/apps/web/app/api/refresh/route.ts
+++ b/apps/web/app/api/refresh/route.ts
@@ -59,7 +59,8 @@ export async function POST(request: NextRequest): Promise<Response> {
   }
 
   // Clear cached stats so getStats fetches fresh from GitHub
-  await cacheDel(`stats:${handle}`);
+  // Key must match lib/github/client.ts cache key: "stats:v2:<handle>"
+  await cacheDel(`stats:v2:${handle}`);
 
   // Fetch fresh stats with the user's OAuth token for better rate limits
   const stats = await getStats(handle, session.token);

--- a/apps/web/app/u/[handle]/page.tsx
+++ b/apps/web/app/u/[handle]/page.tsx
@@ -106,6 +106,10 @@ export default async function SharePage({ params }: SharePageProps) {
   const isOwner = sessionLogin !== null && sessionLogin === handle;
   const useInteractivePreview = hasCustomConfig(savedConfig) && stats && impact;
 
+  // Cache-busting param for the badge <img> on the share page.
+  // External embeds (README badges) use the CDN-cached URL without this param.
+  const badgeCacheBuster = stats?.fetchedAt ?? new Date().toISOString();
+
   const embedMarkdown = `![Chapa Badge](https://chapa.thecreativetoken.com/u/${handle}/badge.svg)`;
   const embedHtml = `<img src="https://chapa.thecreativetoken.com/u/${handle}/badge.svg" alt="Chapa Badge for ${handle}" width="600" />`;
 
@@ -153,7 +157,7 @@ export default async function SharePage({ params }: SharePageProps) {
             <div className="rounded-2xl border border-stroke bg-card p-4 shadow-lg shadow-amber/5">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
-                src={`/u/${encodeURIComponent(handle)}/badge.svg`}
+                src={`/u/${encodeURIComponent(handle)}/badge.svg?v=${encodeURIComponent(badgeCacheBuster)}`}
                 alt={`Chapa badge for ${handle}`}
                 width={1200}
                 height={630}


### PR DESCRIPTION
## Summary

- **fix(cache)**: Refresh endpoint (`/api/refresh`) was deleting wrong cache key (`stats:<handle>` instead of `stats:v2:<handle>`). Same bug as the supplemental handler fixed in the previous release.
- **fix(cache)**: Share page badge `<img>` now includes a cache-busting query param (`?v=<fetchedAt>`) so the owner always sees the fresh SVG instead of the 6-hour CDN-cached version. External embeds (README badges) still benefit from CDN caching.

## Test plan
- [ ] Re-run `chapa merge --emu-handle Juan-GonzalezPonce_avoltagh --insecure`
- [ ] Visit share page — badge SVG should show updated score matching profile breakdown
- [ ] "Refresh Badge" button should now correctly bust the Redis cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)