### PR TITLE
Release: fix OG image + pre-launch polish

### DIFF
--- a/apps/web/lib/render/fonts.ts
+++ b/apps/web/lib/render/fonts.ts
@@ -3,24 +3,23 @@
  *
  * Lazily loads JetBrains Mono Bold and Plus Jakarta Sans SemiBold
  * as ArrayBuffers for use with Satori / ImageResponse.
- * Fonts are cached after first load.
+ * Fonts are cached after first successful load.
  */
 
-let _fonts: Promise<[ArrayBuffer, ArrayBuffer]> | null = null;
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 
-export function loadOgFonts(): Promise<[ArrayBuffer, ArrayBuffer]> {
-  if (!_fonts) {
-    _fonts = Promise.all([
-      fetch(
-        new URL("../../assets/fonts/JetBrainsMono-Bold.ttf", import.meta.url),
-      ).then((res) => res.arrayBuffer()),
-      fetch(
-        new URL(
-          "../../assets/fonts/PlusJakartaSans-SemiBold.ttf",
-          import.meta.url,
-        ),
-      ).then((res) => res.arrayBuffer()),
-    ]);
-  }
+let _fonts: [ArrayBuffer, ArrayBuffer] | null = null;
+
+export async function loadOgFonts(): Promise<[ArrayBuffer, ArrayBuffer]> {
+  if (_fonts) return _fonts;
+
+  const fontsDir = join(process.cwd(), "assets", "fonts");
+  const [heading, body] = await Promise.all([
+    readFile(join(fontsDir, "JetBrainsMono-Bold.ttf")),
+    readFile(join(fontsDir, "PlusJakartaSans-SemiBold.ttf")),
+  ]);
+
+  _fonts = [heading.buffer as ArrayBuffer, body.buffer as ArrayBuffer];
   return _fonts;
 }


### PR DESCRIPTION
## Summary
- **Fix broken OG image generation** — social card previews on X/Twitter were showing a generic placeholder instead of the badge image. Root cause: font loading used `fetch(new URL(..., import.meta.url))` which fails at runtime in Next.js server context. Switched to `readFile` with `process.cwd()`.
- **Fix llms.txt version reference** — updated "Impact Score v3" → "Impact v4 Profile"
- **Add metadata to /verify page** — missing title/description for SEO
- **UX polish** — enterprise nav link, embed snippet restyle, anchor scroll padding

## Key changes since last release
- `apps/web/lib/render/fonts.ts` — reliable font loading via `readFile`
- `apps/web/app/u/[handle]/opengraph-image.tsx` — error handling with fallback images
- `apps/web/app/llms.txt/route.ts` — v4 terminology
- `apps/web/app/verify/page.tsx` — metadata export

## Test plan
- [x] All 1396 tests pass
- [x] TypeScript compiles cleanly
- [x] ESLint passes
- [x] OG image returns 200 with valid 1200x630 PNG locally
- [ ] Verify OG image works on production after deploy
- [ ] Verify X card preview shows badge image

🤖 Generated with [Claude Code](https://claude.com/claude-code)