### PR TITLE
feat(landing): add 'Living Document' bullet to features section

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -37,6 +37,10 @@ const FEATURES = [
     description: "Every badge carries an HMAC hash seal. Click it to cryptographically verify the scores haven\u2019t been tampered with.",
   },
   {
+    title: "LIVING DOCUMENT",
+    description: "Your badge is a live image that re-renders from fresh GitHub data daily — embed it once and it keeps itself up to date.",
+  },
+  {
     title: "ONE-CLICK EMBED",
     description: "Markdown or HTML, paste anywhere that renders images.",
   },


### PR DESCRIPTION
Adds a new feature bullet explaining that badges are live images that
re-render from fresh GitHub data daily — embed once, stays up to date.

https://claude.ai/code/session_01Akg87QbnDvNq2Pc77kzzK2