### PR TITLE
Release: admin stats endpoint

### DIFF
--- a/apps/web/app/api/admin/stats/route.test.ts
+++ b/apps/web/app/api/admin/stats/route.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+
+vi.mock("@/lib/cache/redis", () => ({
+  getBadgeStats: vi.fn(),
+  rateLimit: vi.fn().mockResolvedValue({ allowed: true, current: 1, limit: 10 }),
+}));
+
+vi.mock("@/lib/http/client-ip", () => ({
+  getClientIp: vi.fn().mockReturnValue("127.0.0.1"),
+}));
+
+import { getBadgeStats, rateLimit } from "@/lib/cache/redis";
+
+const VALID_SECRET = "test-admin-secret-123";
+
+beforeEach(() => {
+  vi.stubEnv("ADMIN_SECRET", VALID_SECRET);
+  vi.mocked(getBadgeStats).mockResolvedValue({ total: 42, unique: 7 });
+  vi.mocked(rateLimit).mockResolvedValue({ allowed: true, current: 1, limit: 10 });
+});
+
+function makeRequest(secret?: string): NextRequest {
+  const url = "https://chapa.thecreativetoken.com/api/admin/stats";
+  const headers: Record<string, string> = {};
+  if (secret !== undefined) {
+    headers["Authorization"] = `Bearer ${secret}`;
+  }
+  return new NextRequest(url, { headers });
+}
+
+describe("GET /api/admin/stats", () => {
+  it("returns stats with valid secret", async () => {
+    const res = await GET(makeRequest(VALID_SECRET));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      badges: { total: 42, unique: 7 },
+    });
+  });
+
+  it("returns 401 when Authorization header is missing", async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when secret is wrong", async () => {
+    const res = await GET(makeRequest("wrong-secret"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when ADMIN_SECRET env var is not set", async () => {
+    vi.stubEnv("ADMIN_SECRET", "");
+    const res = await GET(makeRequest(VALID_SECRET));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    vi.mocked(rateLimit).mockResolvedValue({ allowed: false, current: 11, limit: 10 });
+    const res = await GET(makeRequest(VALID_SECRET));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns zeros when Redis is unavailable", async () => {
+    vi.mocked(getBadgeStats).mockResolvedValue({ total: 0, unique: 0 });
+    const res = await GET(makeRequest(VALID_SECRET));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.badges).toEqual({ total: 0, unique: 0 });
+  });
+
+  it("uses timing-safe comparison for secret", async () => {
+    // A secret that's the same length but different should still be rejected
+    const sameLength = "x".repeat(VALID_SECRET.length);
+    const res = await GET(makeRequest(sameLength));
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/web/app/api/admin/stats/route.ts
+++ b/apps/web/app/api/admin/stats/route.ts
@@ -1,0 +1,48 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { timingSafeEqual } from "node:crypto";
+import { getBadgeStats, rateLimit } from "@/lib/cache/redis";
+import { getClientIp } from "@/lib/http/client-ip";
+
+/**
+ * GET /api/admin/stats
+ *
+ * Returns badge generation stats (total + unique developers).
+ * Protected by a Bearer token checked against the ADMIN_SECRET env var.
+ */
+export async function GET(request: NextRequest) {
+  // Rate limit: 10 requests per IP per 60 seconds
+  const ip = getClientIp(request);
+  const rl = await rateLimit(`ratelimit:admin-stats:${ip}`, 10, 60);
+  if (!rl.allowed) {
+    return NextResponse.json(
+      { error: "Too many requests. Please try again later." },
+      { status: 429, headers: { "Retry-After": "60" } },
+    );
+  }
+
+  // Auth: Bearer token must match ADMIN_SECRET
+  const secret = process.env.ADMIN_SECRET?.trim();
+  if (!secret) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const authHeader = request.headers.get("Authorization") ?? "";
+  const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
+
+  if (!token || !safeEqual(token, secret)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const badges = await getBadgeStats();
+
+  return NextResponse.json(
+    { badges },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}
+
+/** Timing-safe string comparison to prevent timing attacks on the secret. */
+function safeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/admin/stats` — returns badge generation counts (total + unique) from Redis
- Protected by Bearer token against `ADMIN_SECRET` env var (timing-safe comparison)
- Rate limited to 10 req/min per IP

## Test plan
- [x] 7 unit tests covering auth, rate limiting, and Redis fallback
- [x] All 1843 tests pass
- [x] Typecheck clean
- [x] `ADMIN_SECRET` env var already added to Vercel production

🤖 Generated with [Claude Code](https://claude.com/claude-code)