### PR TITLE
docs: add Supabase migration plan for historical data storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ NEXT_PUBLIC_BASE_URL=http://localhost:3001
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 
+# Supabase (optional — database features degrade gracefully without it)
+SUPABASE_URL=              # Supabase project URL (server-side only)
+SUPABASE_SERVICE_ROLE_KEY= # Service role key (server-side only, never NEXT_PUBLIC_)
+
 # PostHog (optional)
 NEXT_PUBLIC_POSTHOG_KEY=
 NEXT_PUBLIC_POSTHOG_HOST=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ Must be easy to swap/remove:
 - SVG rendering: `apps/web/lib/render/*`, `apps/web/app/u/[handle]/badge.svg/route.ts`
 - Share page: `apps/web/app/u/[handle]/page.tsx`, `apps/web/components/*`
 - Lifetime history: `apps/web/lib/history/*`
+- Data access (Supabase): `apps/web/lib/db/*`
 - Admin dashboard: `apps/web/app/admin/*`, `apps/web/components/AdminDashboardClient.tsx`
 - Global command bar: `apps/web/components/GlobalCommandBar.tsx`, `apps/web/components/terminal/command-registry.ts`
 - Tooltips: `apps/web/components/InfoTooltip.tsx`, `apps/web/components/BadgeOverlay.tsx`
@@ -192,6 +193,9 @@ NEXT_PUBLIC_BASE_URL=      # Base URL for OAuth redirect (e.g., https://chapa.th
 
 UPSTASH_REDIS_REST_URL=    # Upstash Redis
 UPSTASH_REDIS_REST_TOKEN=  # Upstash Redis
+
+SUPABASE_URL=              # Supabase project URL (optional — database features degrade gracefully)
+SUPABASE_SERVICE_ROLE_KEY= # Service role key (server-side only, never NEXT_PUBLIC_)
 
 NEXT_PUBLIC_POSTHOG_KEY=   # PostHog analytics
 NEXT_PUBLIC_POSTHOG_HOST=  # PostHog ingestion host

--- a/apps/web/app/api/health/route.test.ts
+++ b/apps/web/app/api/health/route.test.ts
@@ -4,8 +4,13 @@ vi.mock("@/lib/cache/redis", () => ({
   pingRedis: vi.fn(),
 }));
 
+vi.mock("@/lib/db/supabase", () => ({
+  pingSupabase: vi.fn(),
+}));
+
 import { GET } from "./route";
 import { pingRedis } from "@/lib/cache/redis";
+import { pingSupabase } from "@/lib/db/supabase";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -14,6 +19,7 @@ beforeEach(() => {
 describe("GET /api/health", () => {
   it("returns 200 with status 'ok' when Redis is reachable", async () => {
     vi.mocked(pingRedis).mockResolvedValueOnce("ok");
+    vi.mocked(pingSupabase).mockResolvedValueOnce("ok");
 
     const response = await GET();
     const body = await response.json();
@@ -21,12 +27,14 @@ describe("GET /api/health", () => {
     expect(response.status).toBe(200);
     expect(body.status).toBe("ok");
     expect(body.dependencies.redis).toBe("ok");
+    expect(body.dependencies.supabase).toBe("ok");
     expect(body.timestamp).toBeDefined();
     expect(body.version).toBeUndefined();
   });
 
   it("returns 503 with status 'degraded' when Redis ping fails", async () => {
     vi.mocked(pingRedis).mockResolvedValueOnce("error");
+    vi.mocked(pingSupabase).mockResolvedValueOnce("ok");
 
     const response = await GET();
     const body = await response.json();
@@ -38,6 +46,7 @@ describe("GET /api/health", () => {
 
   it("returns 503 with status 'degraded' when Redis client is null (missing env vars)", async () => {
     vi.mocked(pingRedis).mockResolvedValueOnce("unavailable");
+    vi.mocked(pingSupabase).mockResolvedValueOnce("ok");
 
     const response = await GET();
     const body = await response.json();
@@ -47,8 +56,33 @@ describe("GET /api/health", () => {
     expect(body.dependencies.redis).toBe("unavailable");
   });
 
+  it("stays 'ok' when Supabase is unavailable (optional in Phase 1)", async () => {
+    vi.mocked(pingRedis).mockResolvedValueOnce("ok");
+    vi.mocked(pingSupabase).mockResolvedValueOnce("unavailable");
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("ok");
+    expect(body.dependencies.supabase).toBe("unavailable");
+  });
+
+  it("stays 'ok' when Supabase errors (optional in Phase 1)", async () => {
+    vi.mocked(pingRedis).mockResolvedValueOnce("ok");
+    vi.mocked(pingSupabase).mockResolvedValueOnce("error");
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("ok");
+    expect(body.dependencies.supabase).toBe("error");
+  });
+
   it("always returns a valid timestamp", async () => {
     vi.mocked(pingRedis).mockResolvedValueOnce("ok");
+    vi.mocked(pingSupabase).mockResolvedValueOnce("ok");
 
     const response = await GET();
     const body = await response.json();

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -1,9 +1,14 @@
 import { NextResponse } from "next/server";
 import { pingRedis } from "@/lib/cache/redis";
+import { pingSupabase } from "@/lib/db/supabase";
 
 export async function GET() {
-  const redisStatus = await pingRedis();
+  const [redisStatus, supabaseStatus] = await Promise.all([
+    pingRedis(),
+    pingSupabase(),
+  ]);
 
+  // Only Redis affects degraded status in Phase 1 — Supabase is optional
   const status = redisStatus === "ok" ? "ok" : "degraded";
   const httpStatus = status === "ok" ? 200 : 503;
 
@@ -13,6 +18,7 @@ export async function GET() {
       timestamp: new Date().toISOString(),
       dependencies: {
         redis: redisStatus,
+        supabase: supabaseStatus,
       },
     },
     { status: httpStatus }

--- a/apps/web/lib/db/snapshots.test.ts
+++ b/apps/web/lib/db/snapshots.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { makeSnapshot } from "../test-helpers/fixtures";
+
+// ---------------------------------------------------------------------------
+// Mock Supabase client — builder pattern stubs
+// ---------------------------------------------------------------------------
+
+const mockUpsert = vi.fn();
+const mockSelect = vi.fn();
+const mockEq = vi.fn();
+const mockGte = vi.fn();
+const mockLte = vi.fn();
+const mockOrder = vi.fn();
+const mockLimit = vi.fn();
+const mockMaybeSingle = vi.fn();
+
+function chainBuilder() {
+  const chain: Record<string, unknown> = {};
+  chain.select = (...args: unknown[]) => {
+    mockSelect(...args);
+    return chain;
+  };
+  chain.eq = (...args: unknown[]) => {
+    mockEq(...args);
+    return chain;
+  };
+  chain.gte = (...args: unknown[]) => {
+    mockGte(...args);
+    return chain;
+  };
+  chain.lte = (...args: unknown[]) => {
+    mockLte(...args);
+    return chain;
+  };
+  chain.order = (...args: unknown[]) => {
+    mockOrder(...args);
+    return chain;
+  };
+  chain.limit = (...args: unknown[]) => {
+    mockLimit(...args);
+    return chain;
+  };
+  chain.maybeSingle = () => {
+    mockMaybeSingle();
+    return chain;
+  };
+  chain.upsert = mockUpsert;
+  // Terminal — resolves as a thenable
+  chain.then = undefined;
+  return chain;
+}
+
+let terminalResolve: { data: unknown; error: unknown; status?: number };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockFrom = vi.fn((): any => {
+  const chain = chainBuilder();
+  // Make the chain thenable so await works
+  chain.then = (
+    resolve: (v: unknown) => void,
+    reject: (e: unknown) => void,
+  ) => {
+    if (terminalResolve.error) reject(terminalResolve.error);
+    else resolve(terminalResolve);
+  };
+  // maybeSingle also returns thenable
+  chain.maybeSingle = () => {
+    mockMaybeSingle();
+    return {
+      then: (
+        resolve: (v: unknown) => void,
+        reject: (e: unknown) => void,
+      ) => {
+        if (terminalResolve.error) reject(terminalResolve.error);
+        else resolve(terminalResolve);
+      },
+    };
+  };
+  return chain;
+});
+
+vi.mock("./supabase", () => ({
+  getSupabase: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { getSupabase } from "./supabase";
+import {
+  dbInsertSnapshot,
+  dbGetSnapshots,
+  dbGetLatestSnapshot,
+  dbGetSnapshotCount,
+} from "./snapshots";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  terminalResolve = { data: [], error: null };
+});
+
+// ---------------------------------------------------------------------------
+// dbInsertSnapshot
+// ---------------------------------------------------------------------------
+
+describe("dbInsertSnapshot", () => {
+  it("calls upsert with snake_case row data", async () => {
+    mockUpsert.mockResolvedValue({ error: null, status: 201 });
+    const snapshot = makeSnapshot();
+
+    const result = await dbInsertSnapshot("TestUser", snapshot);
+
+    expect(result).toBe(true);
+    expect(mockFrom).toHaveBeenCalledWith("metrics_snapshots");
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        handle: "testuser",
+        date: snapshot.date,
+        commits_total: snapshot.commitsTotal,
+        building: snapshot.building,
+        archetype: snapshot.archetype,
+      }),
+      { onConflict: "handle,date", ignoreDuplicates: true },
+    );
+  });
+
+  it("returns false for duplicate (status 200)", async () => {
+    mockUpsert.mockResolvedValue({ error: null, status: 200 });
+    const result = await dbInsertSnapshot("testuser", makeSnapshot());
+    expect(result).toBe(false);
+  });
+
+  it("returns false when DB is unavailable", async () => {
+    vi.mocked(getSupabase).mockReturnValueOnce(null);
+    const result = await dbInsertSnapshot("testuser", makeSnapshot());
+    expect(result).toBe(false);
+  });
+
+  it("returns false on error without throwing", async () => {
+    mockUpsert.mockResolvedValue({
+      error: new Error("conflict"),
+      status: 409,
+    });
+    const result = await dbInsertSnapshot("testuser", makeSnapshot());
+    expect(result).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dbGetSnapshots
+// ---------------------------------------------------------------------------
+
+describe("dbGetSnapshots", () => {
+  it("returns mapped snapshots ordered by date asc", async () => {
+    const row = {
+      date: "2025-06-15",
+      captured_at: "2025-06-15T14:30:00.000Z",
+      commits_total: 150,
+      prs_merged_count: 30,
+      prs_merged_weight: 45,
+      reviews_submitted: 20,
+      issues_closed: 10,
+      repos_contributed: 8,
+      active_days: 200,
+      lines_added: 5000,
+      lines_deleted: 2000,
+      total_stars: 100,
+      total_forks: 25,
+      total_watchers: 50,
+      top_repo_share: 0.4,
+      max_commits_in_10min: 3,
+      micro_commit_ratio: null,
+      docs_only_pr_ratio: null,
+      building: 75,
+      guarding: 60,
+      consistency: 80,
+      breadth: 55,
+      archetype: "Builder",
+      profile_type: "collaborative",
+      composite_score: 67.5,
+      adjusted_composite: 60.75,
+      confidence: 90,
+      tier: "High",
+      confidence_penalties: null,
+    };
+
+    terminalResolve = { data: [row], error: null };
+
+    const result = await dbGetSnapshots("TestUser", "2025-06-14", "2025-06-16");
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.commitsTotal).toBe(150);
+    expect(result[0]!.archetype).toBe("Builder");
+    expect(mockEq).toHaveBeenCalledWith("handle", "testuser");
+    expect(mockGte).toHaveBeenCalledWith("date", "2025-06-14");
+    expect(mockLte).toHaveBeenCalledWith("date", "2025-06-16");
+  });
+
+  it("omits date filters when not provided", async () => {
+    terminalResolve = { data: [], error: null };
+
+    await dbGetSnapshots("testuser");
+
+    expect(mockGte).not.toHaveBeenCalled();
+    expect(mockLte).not.toHaveBeenCalled();
+  });
+
+  it("returns empty array when DB is unavailable", async () => {
+    vi.mocked(getSupabase).mockReturnValueOnce(null);
+    const result = await dbGetSnapshots("testuser");
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array on query error", async () => {
+    terminalResolve = { data: null, error: new Error("timeout") };
+    const result = await dbGetSnapshots("testuser");
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dbGetLatestSnapshot
+// ---------------------------------------------------------------------------
+
+describe("dbGetLatestSnapshot", () => {
+  it("returns the latest snapshot via order desc + limit 1", async () => {
+    const row = {
+      date: "2025-06-15",
+      captured_at: "2025-06-15T14:30:00.000Z",
+      commits_total: 150,
+      prs_merged_count: 30,
+      prs_merged_weight: 45,
+      reviews_submitted: 20,
+      issues_closed: 10,
+      repos_contributed: 8,
+      active_days: 200,
+      lines_added: 5000,
+      lines_deleted: 2000,
+      total_stars: 100,
+      total_forks: 25,
+      total_watchers: 50,
+      top_repo_share: 0.4,
+      max_commits_in_10min: 3,
+      micro_commit_ratio: null,
+      docs_only_pr_ratio: null,
+      building: 75,
+      guarding: 60,
+      consistency: 80,
+      breadth: 55,
+      archetype: "Builder",
+      profile_type: "collaborative",
+      composite_score: 67.5,
+      adjusted_composite: 60.75,
+      confidence: 90,
+      tier: "High",
+      confidence_penalties: null,
+    };
+
+    terminalResolve = { data: row, error: null };
+
+    const result = await dbGetLatestSnapshot("TestUser");
+
+    expect(result).not.toBeNull();
+    expect(result!.date).toBe("2025-06-15");
+    expect(mockOrder).toHaveBeenCalledWith("date", { ascending: false });
+    expect(mockLimit).toHaveBeenCalledWith(1);
+    expect(mockMaybeSingle).toHaveBeenCalled();
+  });
+
+  it("returns null when no snapshots exist", async () => {
+    terminalResolve = { data: null, error: null };
+    const result = await dbGetLatestSnapshot("testuser");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when DB is unavailable", async () => {
+    vi.mocked(getSupabase).mockReturnValueOnce(null);
+    const result = await dbGetLatestSnapshot("testuser");
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dbGetSnapshotCount
+// ---------------------------------------------------------------------------
+
+describe("dbGetSnapshotCount", () => {
+  it("returns count from head query", async () => {
+    terminalResolve = { data: null, error: null };
+    // Override the chain to return count
+    mockFrom.mockReturnValueOnce({
+      select: () => ({
+        eq: () =>
+          Promise.resolve({ count: 42, error: null }),
+      }),
+    });
+
+    const result = await dbGetSnapshotCount("TestUser");
+    expect(result).toBe(42);
+  });
+
+  it("returns 0 when DB is unavailable", async () => {
+    vi.mocked(getSupabase).mockReturnValueOnce(null);
+    const result = await dbGetSnapshotCount("testuser");
+    expect(result).toBe(0);
+  });
+
+  it("returns 0 on query error", async () => {
+    mockFrom.mockReturnValueOnce({
+      select: () => ({
+        eq: () =>
+          Promise.resolve({ count: null, error: new Error("query failed") }),
+      }),
+    });
+
+    const result = await dbGetSnapshotCount("testuser");
+    expect(result).toBe(0);
+  });
+});

--- a/apps/web/lib/db/snapshots.ts
+++ b/apps/web/lib/db/snapshots.ts
@@ -62,6 +62,10 @@ function rowToSnapshot(row: SnapshotRow): MetricsSnapshot {
     totalForks: row.total_forks,
     totalWatchers: row.total_watchers,
     topRepoShare: row.top_repo_share,
+    // Design decision: default to 0, not undefined. maxCommitsIn10Min is
+    // required (not optional) in MetricsSnapshot. Impact scoring expects a
+    // number — undefined would cause NaN in burst-commit penalty calculations.
+    // The DB column is nullable only for rows inserted before this field existed.
     maxCommitsIn10Min: row.max_commits_in_10min ?? 0,
     ...(row.micro_commit_ratio != null && {
       microCommitRatio: row.micro_commit_ratio,

--- a/apps/web/lib/db/snapshots.ts
+++ b/apps/web/lib/db/snapshots.ts
@@ -1,0 +1,286 @@
+/**
+ * Supabase data access — metrics_snapshots table.
+ *
+ * Replaces Redis `history:<handle>` sorted sets.
+ * All operations fail-open (return sensible defaults when DB is unavailable).
+ * Return types match the existing Redis-backed history API for drop-in compatibility.
+ */
+
+import type { MetricsSnapshot } from "@/lib/history/types";
+import { getSupabase } from "./supabase";
+
+// ---------------------------------------------------------------------------
+// Row ↔ Type mapping
+// ---------------------------------------------------------------------------
+
+interface SnapshotRow {
+  date: string;
+  captured_at: string;
+  commits_total: number;
+  prs_merged_count: number;
+  prs_merged_weight: number;
+  reviews_submitted: number;
+  issues_closed: number;
+  repos_contributed: number;
+  active_days: number;
+  lines_added: number;
+  lines_deleted: number;
+  total_stars: number;
+  total_forks: number;
+  total_watchers: number;
+  top_repo_share: number;
+  max_commits_in_10min: number | null;
+  micro_commit_ratio: number | null;
+  docs_only_pr_ratio: number | null;
+  building: number;
+  guarding: number;
+  consistency: number;
+  breadth: number;
+  archetype: string;
+  profile_type: string;
+  composite_score: number;
+  adjusted_composite: number;
+  confidence: number;
+  tier: string;
+  confidence_penalties: Array<{ flag: string; penalty: number }> | null;
+}
+
+function rowToSnapshot(row: SnapshotRow): MetricsSnapshot {
+  return {
+    date: row.date,
+    capturedAt: row.captured_at,
+    commitsTotal: row.commits_total,
+    prsMergedCount: row.prs_merged_count,
+    prsMergedWeight: row.prs_merged_weight,
+    reviewsSubmittedCount: row.reviews_submitted,
+    issuesClosedCount: row.issues_closed,
+    reposContributed: row.repos_contributed,
+    activeDays: row.active_days,
+    linesAdded: row.lines_added,
+    linesDeleted: row.lines_deleted,
+    totalStars: row.total_stars,
+    totalForks: row.total_forks,
+    totalWatchers: row.total_watchers,
+    topRepoShare: row.top_repo_share,
+    maxCommitsIn10Min: row.max_commits_in_10min ?? 0,
+    ...(row.micro_commit_ratio != null && {
+      microCommitRatio: row.micro_commit_ratio,
+    }),
+    ...(row.docs_only_pr_ratio != null && {
+      docsOnlyPrRatio: row.docs_only_pr_ratio,
+    }),
+    building: row.building,
+    guarding: row.guarding,
+    consistency: row.consistency,
+    breadth: row.breadth,
+    archetype: row.archetype as MetricsSnapshot["archetype"],
+    profileType: row.profile_type as MetricsSnapshot["profileType"],
+    compositeScore: row.composite_score,
+    adjustedComposite: row.adjusted_composite,
+    confidence: row.confidence,
+    tier: row.tier as MetricsSnapshot["tier"],
+    ...(row.confidence_penalties && row.confidence_penalties.length > 0
+      ? {
+          confidencePenalties: row.confidence_penalties as MetricsSnapshot["confidencePenalties"],
+        }
+      : {}),
+  };
+}
+
+function snapshotToRow(
+  handle: string,
+  s: MetricsSnapshot,
+): Record<string, unknown> {
+  return {
+    handle: handle.toLowerCase(),
+    date: s.date,
+    captured_at: s.capturedAt,
+    commits_total: s.commitsTotal,
+    prs_merged_count: s.prsMergedCount,
+    prs_merged_weight: s.prsMergedWeight,
+    reviews_submitted: s.reviewsSubmittedCount,
+    issues_closed: s.issuesClosedCount,
+    repos_contributed: s.reposContributed,
+    active_days: s.activeDays,
+    lines_added: s.linesAdded,
+    lines_deleted: s.linesDeleted,
+    total_stars: s.totalStars,
+    total_forks: s.totalForks,
+    total_watchers: s.totalWatchers,
+    top_repo_share: s.topRepoShare,
+    max_commits_in_10min: s.maxCommitsIn10Min,
+    micro_commit_ratio: s.microCommitRatio ?? null,
+    docs_only_pr_ratio: s.docsOnlyPrRatio ?? null,
+    building: s.building,
+    guarding: s.guarding,
+    consistency: s.consistency,
+    breadth: s.breadth,
+    archetype: s.archetype,
+    profile_type: s.profileType,
+    composite_score: s.compositeScore,
+    adjusted_composite: s.adjustedComposite,
+    confidence: s.confidence,
+    tier: s.tier,
+    confidence_penalties:
+      s.confidencePenalties && s.confidencePenalties.length > 0
+        ? s.confidencePenalties
+        : null,
+  };
+}
+
+// Select clause for all snapshot columns (excludes id and handle)
+const SNAPSHOT_COLUMNS = [
+  "date",
+  "captured_at",
+  "commits_total",
+  "prs_merged_count",
+  "prs_merged_weight",
+  "reviews_submitted",
+  "issues_closed",
+  "repos_contributed",
+  "active_days",
+  "lines_added",
+  "lines_deleted",
+  "total_stars",
+  "total_forks",
+  "total_watchers",
+  "top_repo_share",
+  "max_commits_in_10min",
+  "micro_commit_ratio",
+  "docs_only_pr_ratio",
+  "building",
+  "guarding",
+  "consistency",
+  "breadth",
+  "archetype",
+  "profile_type",
+  "composite_score",
+  "adjusted_composite",
+  "confidence",
+  "tier",
+  "confidence_penalties",
+].join(", ");
+
+// ---------------------------------------------------------------------------
+// Public API — matches existing history.ts signatures
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert a snapshot. Uses ON CONFLICT DO NOTHING for date-based dedup.
+ * Returns true if inserted, false if duplicate or on error.
+ */
+export async function dbInsertSnapshot(
+  handle: string,
+  snapshot: MetricsSnapshot,
+): Promise<boolean> {
+  const db = getSupabase();
+  if (!db) return false;
+
+  try {
+    const { error, status } = await db
+      .from("metrics_snapshots")
+      .upsert(snapshotToRow(handle, snapshot), {
+        onConflict: "handle,date",
+        ignoreDuplicates: true,
+      });
+
+    if (error) throw error;
+    // status 201 = inserted, 200 = duplicate (ignored)
+    return status === 201;
+  } catch (error) {
+    console.error(
+      "[db] dbInsertSnapshot failed:",
+      (error as Error).message,
+    );
+    return false;
+  }
+}
+
+/**
+ * Get snapshots for a user, optionally filtered by date range.
+ * Ordered by date ascending (oldest first) — matches Redis ZRANGE behavior.
+ */
+export async function dbGetSnapshots(
+  handle: string,
+  from?: string,
+  to?: string,
+): Promise<MetricsSnapshot[]> {
+  const db = getSupabase();
+  if (!db) return [];
+
+  try {
+    let query = db
+      .from("metrics_snapshots")
+      .select(SNAPSHOT_COLUMNS)
+      .eq("handle", handle.toLowerCase())
+      .order("date", { ascending: true });
+
+    if (from) query = query.gte("date", from);
+    if (to) query = query.lte("date", to);
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    return (data ?? []).map((row) => rowToSnapshot(row as unknown as SnapshotRow));
+  } catch (error) {
+    console.error("[db] dbGetSnapshots failed:", (error as Error).message);
+    return [];
+  }
+}
+
+/**
+ * Get the most recent snapshot for a user.
+ * Returns null if no snapshots exist or on error.
+ */
+export async function dbGetLatestSnapshot(
+  handle: string,
+): Promise<MetricsSnapshot | null> {
+  const db = getSupabase();
+  if (!db) return null;
+
+  try {
+    const { data, error } = await db
+      .from("metrics_snapshots")
+      .select(SNAPSHOT_COLUMNS)
+      .eq("handle", handle.toLowerCase())
+      .order("date", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (error) throw error;
+    if (!data) return null;
+
+    return rowToSnapshot(data as unknown as SnapshotRow);
+  } catch (error) {
+    console.error(
+      "[db] dbGetLatestSnapshot failed:",
+      (error as Error).message,
+    );
+    return null;
+  }
+}
+
+/**
+ * Get the total number of snapshots for a user.
+ * Returns 0 on error or when DB is unavailable.
+ */
+export async function dbGetSnapshotCount(handle: string): Promise<number> {
+  const db = getSupabase();
+  if (!db) return 0;
+
+  try {
+    const { count, error } = await db
+      .from("metrics_snapshots")
+      .select("*", { count: "exact", head: true })
+      .eq("handle", handle.toLowerCase());
+
+    if (error) throw error;
+    return count ?? 0;
+  } catch (error) {
+    console.error(
+      "[db] dbGetSnapshotCount failed:",
+      (error as Error).message,
+    );
+    return 0;
+  }
+}

--- a/apps/web/lib/db/supabase.test.ts
+++ b/apps/web/lib/db/supabase.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockCreateClient = vi.fn();
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: (...args: unknown[]) => mockCreateClient(...args),
+}));
+
+import { getSupabase, _resetClient } from "./supabase";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _resetClient();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("getSupabase", () => {
+  it("returns null when SUPABASE_URL is missing", () => {
+    vi.stubEnv("SUPABASE_URL", "");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "test-key");
+
+    expect(getSupabase()).toBeNull();
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  it("returns null when SUPABASE_SERVICE_ROLE_KEY is missing", () => {
+    vi.stubEnv("SUPABASE_URL", "https://test.supabase.co");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "");
+
+    expect(getSupabase()).toBeNull();
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  it("creates a client with trimmed env vars", () => {
+    const fakeClient = { from: vi.fn() };
+    mockCreateClient.mockReturnValue(fakeClient);
+
+    vi.stubEnv("SUPABASE_URL", "  https://test.supabase.co  ");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "  sk-test-key  ");
+
+    const client = getSupabase();
+
+    expect(client).toBe(fakeClient);
+    expect(mockCreateClient).toHaveBeenCalledWith(
+      "https://test.supabase.co",
+      "sk-test-key",
+      { auth: { persistSession: false } },
+    );
+  });
+
+  it("returns the same singleton on subsequent calls", () => {
+    const fakeClient = { from: vi.fn() };
+    mockCreateClient.mockReturnValue(fakeClient);
+
+    vi.stubEnv("SUPABASE_URL", "https://test.supabase.co");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "sk-test-key");
+
+    const first = getSupabase();
+    const second = getSupabase();
+
+    expect(first).toBe(second);
+    expect(mockCreateClient).toHaveBeenCalledTimes(1);
+  });
+
+  it("reinitializes after _resetClient()", () => {
+    const fakeClient = { from: vi.fn() };
+    mockCreateClient.mockReturnValue(fakeClient);
+
+    vi.stubEnv("SUPABASE_URL", "https://test.supabase.co");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "sk-test-key");
+
+    getSupabase();
+    _resetClient();
+    getSupabase();
+
+    expect(mockCreateClient).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/lib/db/supabase.ts
+++ b/apps/web/lib/db/supabase.ts
@@ -30,6 +30,23 @@ export function getSupabase(): SupabaseClient | null {
   return _client;
 }
 
+/**
+ * Lightweight health check — same pattern as pingRedis().
+ * Returns "ok" if a trivial query succeeds, "unavailable" if env vars are
+ * missing, or "error" if the query fails.
+ */
+export async function pingSupabase(): Promise<"ok" | "error" | "unavailable"> {
+  const db = getSupabase();
+  if (!db) return "unavailable";
+
+  try {
+    const { error } = await db.from("users").select("id").limit(1);
+    return error ? "error" : "ok";
+  } catch {
+    return "error";
+  }
+}
+
 /** Reset the singleton — for tests only. */
 export function _resetClient(): void {
   _client = undefined;

--- a/apps/web/lib/db/supabase.ts
+++ b/apps/web/lib/db/supabase.ts
@@ -1,0 +1,36 @@
+/**
+ * Supabase Postgres client — lazy singleton for server-side data access.
+ *
+ * Uses the service role key (bypasses RLS) since all access is server-to-server.
+ * Returns null when env vars are missing for graceful degradation.
+ */
+
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+
+let _client: SupabaseClient | null | undefined;
+
+export function getSupabase(): SupabaseClient | null {
+  if (_client !== undefined) return _client;
+
+  const url = process.env.SUPABASE_URL?.trim();
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY?.trim();
+
+  if (!url || !key) {
+    console.warn(
+      "[db] SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY is missing — database disabled",
+    );
+    _client = null;
+    return null;
+  }
+
+  _client = createClient(url, key, {
+    auth: { persistSession: false },
+  });
+
+  return _client;
+}
+
+/** Reset the singleton — for tests only. */
+export function _resetClient(): void {
+  _client = undefined;
+}

--- a/apps/web/lib/db/users.test.ts
+++ b/apps/web/lib/db/users.test.ts
@@ -1,22 +1,43 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ---------------------------------------------------------------------------
-// Mock Supabase client
+// Mock Supabase client — tracks arguments for every chain method
 // ---------------------------------------------------------------------------
 
 const mockUpsert = vi.fn();
 const mockSelect = vi.fn();
 const mockOrder = vi.fn();
+const mockRange = vi.fn();
+
+let listResolve: { data: unknown; error: unknown };
+let countResolve: { count: unknown; error: unknown };
 
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars */
 const mockFrom = vi.fn((_table: string): any => ({
   upsert: mockUpsert,
   select: (...args: unknown[]) => {
     mockSelect(...args);
+    // Head count query (.select("*", { count: "exact", head: true }))
+    if (args.length === 2 && (args[1] as any)?.head === true) {
+      return Promise.resolve(countResolve);
+    }
+    // List query (.select("handle, registered_at"))
     return {
       order: (...orderArgs: unknown[]) => {
         mockOrder(...orderArgs);
-        return Promise.resolve({ data: [], error: null });
+        return {
+          range: (...rangeArgs: unknown[]) => {
+            mockRange(...rangeArgs);
+            return Promise.resolve(listResolve);
+          },
+          then: (
+            resolve: (v: unknown) => void,
+            reject: (e: unknown) => void,
+          ) => {
+            if (listResolve.error) reject(listResolve.error);
+            else resolve(listResolve);
+          },
+        };
       },
     };
   },
@@ -31,6 +52,8 @@ import { dbUpsertUser, dbGetUsers, dbGetUserCount } from "./users";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  listResolve = { data: [], error: null };
+  countResolve = { count: 0, error: null };
 });
 
 // ---------------------------------------------------------------------------
@@ -75,11 +98,7 @@ describe("dbGetUsers", () => {
       { handle: "bob", registered_at: "2025-06-14T10:00:00Z" },
     ];
 
-    mockFrom.mockReturnValueOnce({
-      select: () => ({
-        order: () => Promise.resolve({ data: rows, error: null }),
-      }),
-    });
+    listResolve = { data: rows, error: null };
 
     const result = await dbGetUsers();
 
@@ -87,6 +106,10 @@ describe("dbGetUsers", () => {
       { handle: "alice", registeredAt: "2025-06-15T10:00:00Z" },
       { handle: "bob", registeredAt: "2025-06-14T10:00:00Z" },
     ]);
+    expect(mockSelect).toHaveBeenCalledWith("handle, registered_at");
+    expect(mockOrder).toHaveBeenCalledWith("registered_at", {
+      ascending: false,
+    });
   });
 
   it("returns empty array when DB is unavailable", async () => {
@@ -97,15 +120,37 @@ describe("dbGetUsers", () => {
   });
 
   it("returns empty array on query error", async () => {
-    mockFrom.mockReturnValueOnce({
-      select: () => ({
-        order: () =>
-          Promise.resolve({ data: null, error: new Error("query failed") }),
-      }),
-    });
+    listResolve = { data: null, error: new Error("query failed") };
 
     const result = await dbGetUsers();
     expect(result).toEqual([]);
+  });
+
+  it("applies limit and offset via .range() when provided", async () => {
+    listResolve = {
+      data: [{ handle: "alice", registered_at: "2025-06-15T10:00:00Z" }],
+      error: null,
+    };
+
+    await dbGetUsers({ limit: 10, offset: 20 });
+
+    expect(mockRange).toHaveBeenCalledWith(20, 29); // range is inclusive
+  });
+
+  it("applies limit with default offset 0 when only limit provided", async () => {
+    listResolve = { data: [], error: null };
+
+    await dbGetUsers({ limit: 10 });
+
+    expect(mockRange).toHaveBeenCalledWith(0, 9);
+  });
+
+  it("returns all rows when no options provided (backward compat)", async () => {
+    listResolve = { data: [], error: null };
+
+    await dbGetUsers();
+
+    expect(mockRange).not.toHaveBeenCalled();
   });
 });
 
@@ -115,12 +160,14 @@ describe("dbGetUsers", () => {
 
 describe("dbGetUserCount", () => {
   it("returns the count from a head query", async () => {
-    mockFrom.mockReturnValueOnce({
-      select: () => Promise.resolve({ count: 42, error: null }),
-    });
+    countResolve = { count: 42, error: null };
 
     const result = await dbGetUserCount();
     expect(result).toBe(42);
+    expect(mockSelect).toHaveBeenCalledWith("*", {
+      count: "exact",
+      head: true,
+    });
   });
 
   it("returns 0 when DB is unavailable", async () => {
@@ -131,10 +178,7 @@ describe("dbGetUserCount", () => {
   });
 
   it("returns 0 on query error", async () => {
-    mockFrom.mockReturnValueOnce({
-      select: () =>
-        Promise.resolve({ count: null, error: new Error("query failed") }),
-    });
+    countResolve = { count: null, error: new Error("query failed") };
 
     const result = await dbGetUserCount();
     expect(result).toBe(0);

--- a/apps/web/lib/db/users.test.ts
+++ b/apps/web/lib/db/users.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock Supabase client
+// ---------------------------------------------------------------------------
+
+const mockUpsert = vi.fn();
+const mockSelect = vi.fn();
+const mockOrder = vi.fn();
+
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars */
+const mockFrom = vi.fn((_table: string): any => ({
+  upsert: mockUpsert,
+  select: (...args: unknown[]) => {
+    mockSelect(...args);
+    return {
+      order: (...orderArgs: unknown[]) => {
+        mockOrder(...orderArgs);
+        return Promise.resolve({ data: [], error: null });
+      },
+    };
+  },
+}));
+
+vi.mock("./supabase", () => ({
+  getSupabase: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { getSupabase } from "./supabase";
+import { dbUpsertUser, dbGetUsers, dbGetUserCount } from "./users";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// dbUpsertUser
+// ---------------------------------------------------------------------------
+
+describe("dbUpsertUser", () => {
+  it("upserts user with lowercase handle", async () => {
+    mockUpsert.mockResolvedValue({ error: null });
+
+    await dbUpsertUser("TestUser");
+
+    expect(mockFrom).toHaveBeenCalledWith("users");
+    expect(mockUpsert).toHaveBeenCalledWith(
+      { handle: "testuser" },
+      { onConflict: "handle", ignoreDuplicates: true },
+    );
+  });
+
+  it("does not throw when upsert fails", async () => {
+    mockUpsert.mockRejectedValue(new Error("DB down"));
+
+    await expect(dbUpsertUser("testuser")).resolves.toBeUndefined();
+  });
+
+  it("returns void when DB is unavailable", async () => {
+    vi.mocked(getSupabase).mockReturnValueOnce(null);
+
+    await expect(dbUpsertUser("testuser")).resolves.toBeUndefined();
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dbGetUsers
+// ---------------------------------------------------------------------------
+
+describe("dbGetUsers", () => {
+  it("returns mapped user rows ordered by registered_at desc", async () => {
+    const rows = [
+      { handle: "alice", registered_at: "2025-06-15T10:00:00Z" },
+      { handle: "bob", registered_at: "2025-06-14T10:00:00Z" },
+    ];
+
+    mockFrom.mockReturnValueOnce({
+      select: () => ({
+        order: () => Promise.resolve({ data: rows, error: null }),
+      }),
+    });
+
+    const result = await dbGetUsers();
+
+    expect(result).toEqual([
+      { handle: "alice", registeredAt: "2025-06-15T10:00:00Z" },
+      { handle: "bob", registeredAt: "2025-06-14T10:00:00Z" },
+    ]);
+  });
+
+  it("returns empty array when DB is unavailable", async () => {
+    vi.mocked(getSupabase).mockReturnValueOnce(null);
+
+    const result = await dbGetUsers();
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array on query error", async () => {
+    mockFrom.mockReturnValueOnce({
+      select: () => ({
+        order: () =>
+          Promise.resolve({ data: null, error: new Error("query failed") }),
+      }),
+    });
+
+    const result = await dbGetUsers();
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dbGetUserCount
+// ---------------------------------------------------------------------------
+
+describe("dbGetUserCount", () => {
+  it("returns the count from a head query", async () => {
+    mockFrom.mockReturnValueOnce({
+      select: () => Promise.resolve({ count: 42, error: null }),
+    });
+
+    const result = await dbGetUserCount();
+    expect(result).toBe(42);
+  });
+
+  it("returns 0 when DB is unavailable", async () => {
+    vi.mocked(getSupabase).mockReturnValueOnce(null);
+
+    const result = await dbGetUserCount();
+    expect(result).toBe(0);
+  });
+
+  it("returns 0 on query error", async () => {
+    mockFrom.mockReturnValueOnce({
+      select: () =>
+        Promise.resolve({ count: null, error: new Error("query failed") }),
+    });
+
+    const result = await dbGetUserCount();
+    expect(result).toBe(0);
+  });
+});

--- a/apps/web/lib/db/users.ts
+++ b/apps/web/lib/db/users.ts
@@ -1,0 +1,77 @@
+/**
+ * Supabase data access — users table.
+ *
+ * Replaces Redis `user:registered:<handle>` keys.
+ * All operations fail-open (return sensible defaults when DB is unavailable).
+ */
+
+import { getSupabase } from "./supabase";
+
+/**
+ * Register a user (upsert — idempotent).
+ * Handles are stored lowercase for consistent lookups.
+ */
+export async function dbUpsertUser(handle: string): Promise<void> {
+  const db = getSupabase();
+  if (!db) return;
+
+  try {
+    await db
+      .from("users")
+      .upsert(
+        { handle: handle.toLowerCase() },
+        { onConflict: "handle", ignoreDuplicates: true },
+      );
+  } catch (error) {
+    console.error("[db] dbUpsertUser failed:", (error as Error).message);
+  }
+}
+
+/**
+ * Get all registered users, ordered by registration date (newest first).
+ * Returns empty array when DB is unavailable.
+ */
+export async function dbGetUsers(): Promise<
+  { handle: string; registeredAt: string }[]
+> {
+  const db = getSupabase();
+  if (!db) return [];
+
+  try {
+    const { data, error } = await db
+      .from("users")
+      .select("handle, registered_at")
+      .order("registered_at", { ascending: false });
+
+    if (error) throw error;
+
+    return (data ?? []).map((row) => ({
+      handle: row.handle,
+      registeredAt: row.registered_at,
+    }));
+  } catch (error) {
+    console.error("[db] dbGetUsers failed:", (error as Error).message);
+    return [];
+  }
+}
+
+/**
+ * Get total registered user count.
+ * Returns 0 when DB is unavailable.
+ */
+export async function dbGetUserCount(): Promise<number> {
+  const db = getSupabase();
+  if (!db) return 0;
+
+  try {
+    const { count, error } = await db
+      .from("users")
+      .select("*", { count: "exact", head: true });
+
+    if (error) throw error;
+    return count ?? 0;
+  } catch (error) {
+    console.error("[db] dbGetUserCount failed:", (error as Error).message);
+    return 0;
+  }
+}

--- a/apps/web/lib/db/verification.test.ts
+++ b/apps/web/lib/db/verification.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { VerificationRecord } from "@/lib/verification/types";
+
+// ---------------------------------------------------------------------------
+// Mock Supabase client
+// ---------------------------------------------------------------------------
+
+const mockUpsert = vi.fn();
+const mockDelete = vi.fn();
+let terminalResolve: { data: unknown; error: unknown };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockFrom = vi.fn((): any => {
+  const chain: Record<string, unknown> = {};
+  chain.upsert = mockUpsert;
+  chain.select = () => chain;
+  chain.eq = () => chain;
+  chain.gt = () => chain;
+  chain.lt = () => chain;
+  chain.delete = () => {
+    mockDelete();
+    return chain;
+  };
+  chain.maybeSingle = () => ({
+    then: (
+      resolve: (v: unknown) => void,
+      reject: (e: unknown) => void,
+    ) => {
+      if (terminalResolve.error) reject(terminalResolve.error);
+      else resolve(terminalResolve);
+    },
+  });
+  // For delete().select() chain
+  chain.then = (
+    resolve: (v: unknown) => void,
+    reject: (e: unknown) => void,
+  ) => {
+    if (terminalResolve.error) reject(terminalResolve.error);
+    else resolve(terminalResolve);
+  };
+  return chain;
+});
+
+vi.mock("./supabase", () => ({
+  getSupabase: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { getSupabase } from "./supabase";
+import {
+  dbStoreVerification,
+  dbGetVerification,
+  dbCleanExpiredVerifications,
+} from "./verification";
+
+const record: VerificationRecord = {
+  handle: "testuser",
+  displayName: "Test User",
+  adjustedComposite: 52,
+  confidence: 85,
+  tier: "Solid",
+  archetype: "Builder",
+  profileType: "collaborative",
+  dimensions: { building: 70, guarding: 50, consistency: 60, breadth: 40 },
+  commitsTotal: 200,
+  prsMergedCount: 30,
+  reviewsSubmittedCount: 50,
+  generatedAt: "2025-06-15",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  terminalResolve = { data: null, error: null };
+});
+
+// ---------------------------------------------------------------------------
+// dbStoreVerification
+// ---------------------------------------------------------------------------
+
+describe("dbStoreVerification", () => {
+  it("upserts the record with flattened dimensions", async () => {
+    mockUpsert.mockResolvedValue({ error: null });
+
+    await dbStoreVerification("abc12345", record);
+
+    expect(mockFrom).toHaveBeenCalledWith("verification_records");
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hash: "abc12345",
+        handle: "testuser",
+        display_name: "Test User",
+        building: 70,
+        guarding: 50,
+        consistency: 60,
+        breadth: 40,
+        adjusted_composite: 52,
+        generated_at: "2025-06-15",
+      }),
+      { onConflict: "hash" },
+    );
+  });
+
+  it("normalizes handle to lowercase", async () => {
+    mockUpsert.mockResolvedValue({ error: null });
+    const upperRecord = { ...record, handle: "TestUser" };
+
+    await dbStoreVerification("abc12345", upperRecord);
+
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ handle: "testuser" }),
+      expect.any(Object),
+    );
+  });
+
+  it("does not throw on error", async () => {
+    mockUpsert.mockResolvedValue({ error: new Error("DB down") });
+
+    await expect(
+      dbStoreVerification("abc12345", record),
+    ).resolves.toBeUndefined();
+  });
+
+  it("returns void when DB is unavailable", async () => {
+    vi.mocked(getSupabase).mockReturnValueOnce(null);
+
+    await expect(
+      dbStoreVerification("abc12345", record),
+    ).resolves.toBeUndefined();
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dbGetVerification
+// ---------------------------------------------------------------------------
+
+describe("dbGetVerification", () => {
+  it("returns the verification record on hit", async () => {
+    const row = {
+      hash: "abc12345",
+      handle: "testuser",
+      display_name: "Test User",
+      adjusted_composite: 52,
+      confidence: 85,
+      tier: "Solid",
+      archetype: "Builder",
+      profile_type: "collaborative",
+      building: 70,
+      guarding: 50,
+      consistency: 60,
+      breadth: 40,
+      commits_total: 200,
+      prs_merged_count: 30,
+      reviews_submitted: 50,
+      generated_at: "2025-06-15",
+    };
+    terminalResolve = { data: row, error: null };
+
+    const result = await dbGetVerification("abc12345");
+
+    expect(result).toEqual(record);
+  });
+
+  it("returns null on miss", async () => {
+    terminalResolve = { data: null, error: null };
+    const result = await dbGetVerification("nonexistent");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when DB is unavailable", async () => {
+    vi.mocked(getSupabase).mockReturnValueOnce(null);
+    const result = await dbGetVerification("abc12345");
+    expect(result).toBeNull();
+  });
+
+  it("returns null on error without throwing", async () => {
+    terminalResolve = { data: null, error: new Error("DB error") };
+    const result = await dbGetVerification("abc12345");
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dbCleanExpiredVerifications
+// ---------------------------------------------------------------------------
+
+describe("dbCleanExpiredVerifications", () => {
+  it("returns count of deleted rows", async () => {
+    terminalResolve = { data: [{ id: 1 }, { id: 2 }], error: null };
+
+    const result = await dbCleanExpiredVerifications();
+    expect(result).toBe(2);
+    expect(mockDelete).toHaveBeenCalled();
+  });
+
+  it("returns 0 when DB is unavailable", async () => {
+    vi.mocked(getSupabase).mockReturnValueOnce(null);
+    const result = await dbCleanExpiredVerifications();
+    expect(result).toBe(0);
+  });
+
+  it("returns 0 on error without throwing", async () => {
+    terminalResolve = { data: null, error: new Error("delete failed") };
+    const result = await dbCleanExpiredVerifications();
+    expect(result).toBe(0);
+  });
+});

--- a/apps/web/lib/db/verification.ts
+++ b/apps/web/lib/db/verification.ts
@@ -1,0 +1,178 @@
+/**
+ * Supabase data access — verification_records table.
+ *
+ * Replaces Redis `verify:<hash>` + `verify-handle:<handle>` keys.
+ * All operations fail-open (return sensible defaults when DB is unavailable).
+ */
+
+import type { VerificationRecord } from "@/lib/verification/types";
+import { getSupabase } from "./supabase";
+
+// ---------------------------------------------------------------------------
+// Row ↔ Type mapping
+// ---------------------------------------------------------------------------
+
+interface VerificationRow {
+  hash: string;
+  handle: string;
+  display_name: string | null;
+  adjusted_composite: number;
+  confidence: number;
+  tier: string;
+  archetype: string;
+  profile_type: string;
+  building: number;
+  guarding: number;
+  consistency: number;
+  breadth: number;
+  commits_total: number;
+  prs_merged_count: number;
+  reviews_submitted: number;
+  generated_at: string;
+}
+
+function rowToRecord(row: VerificationRow): VerificationRecord {
+  return {
+    handle: row.handle,
+    ...(row.display_name != null && { displayName: row.display_name }),
+    adjustedComposite: row.adjusted_composite,
+    confidence: row.confidence,
+    tier: row.tier,
+    archetype: row.archetype,
+    profileType: row.profile_type,
+    dimensions: {
+      building: row.building,
+      guarding: row.guarding,
+      consistency: row.consistency,
+      breadth: row.breadth,
+    },
+    commitsTotal: row.commits_total,
+    prsMergedCount: row.prs_merged_count,
+    reviewsSubmittedCount: row.reviews_submitted,
+    generatedAt: row.generated_at,
+  };
+}
+
+const RECORD_COLUMNS = [
+  "hash",
+  "handle",
+  "display_name",
+  "adjusted_composite",
+  "confidence",
+  "tier",
+  "archetype",
+  "profile_type",
+  "building",
+  "guarding",
+  "consistency",
+  "breadth",
+  "commits_total",
+  "prs_merged_count",
+  "reviews_submitted",
+  "generated_at",
+].join(", ");
+
+// ---------------------------------------------------------------------------
+// Public API — matches existing store.ts signatures
+// ---------------------------------------------------------------------------
+
+/**
+ * Store a verification record. Upserts on hash conflict (latest wins).
+ */
+export async function dbStoreVerification(
+  hash: string,
+  record: VerificationRecord,
+): Promise<void> {
+  const db = getSupabase();
+  if (!db) return;
+
+  try {
+    const { error } = await db.from("verification_records").upsert(
+      {
+        hash,
+        handle: record.handle.toLowerCase(),
+        display_name: record.displayName ?? null,
+        adjusted_composite: record.adjustedComposite,
+        confidence: record.confidence,
+        tier: record.tier,
+        archetype: record.archetype,
+        profile_type: record.profileType,
+        building: record.dimensions.building,
+        guarding: record.dimensions.guarding,
+        consistency: record.dimensions.consistency,
+        breadth: record.dimensions.breadth,
+        commits_total: record.commitsTotal,
+        prs_merged_count: record.prsMergedCount,
+        reviews_submitted: record.reviewsSubmittedCount,
+        generated_at: record.generatedAt,
+        // expires_at uses DB default: now() + 30 days
+      },
+      { onConflict: "hash" },
+    );
+
+    if (error) throw error;
+  } catch (error) {
+    console.error(
+      "[db] dbStoreVerification failed:",
+      (error as Error).message,
+    );
+  }
+}
+
+/**
+ * Retrieve a verification record by hash.
+ * Returns null on miss, expired record, or error.
+ */
+export async function dbGetVerification(
+  hash: string,
+): Promise<VerificationRecord | null> {
+  const db = getSupabase();
+  if (!db) return null;
+
+  try {
+    const { data, error } = await db
+      .from("verification_records")
+      .select(RECORD_COLUMNS)
+      .eq("hash", hash)
+      .gt("expires_at", new Date().toISOString())
+      .maybeSingle();
+
+    if (error) throw error;
+    if (!data) return null;
+
+    return rowToRecord(data as unknown as VerificationRow);
+  } catch (error) {
+    console.error(
+      "[db] dbGetVerification failed:",
+      (error as Error).message,
+    );
+    return null;
+  }
+}
+
+/**
+ * Delete expired verification records.
+ * Intended to be called from cron (warm-cache).
+ * Returns the number of deleted rows, or 0 on error.
+ */
+export async function dbCleanExpiredVerifications(): Promise<number> {
+  const db = getSupabase();
+  if (!db) return 0;
+
+  try {
+    const { data, error } = await db
+      .from("verification_records")
+      .delete()
+      .lt("expires_at", new Date().toISOString())
+      .select("id");
+
+    if (error) throw error;
+    return data?.length ?? 0;
+  } catch (error) {
+    console.error(
+      "[db] dbCleanExpiredVerifications failed:",
+      (error as Error).message,
+    );
+    return 0;
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@chapa/shared": "workspace:*",
     "@resvg/resvg-js": "^2.6.2",
+    "@supabase/supabase-js": "^2.95.3",
     "@upstash/redis": "^1.36.2",
     "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.3.1",

--- a/docs/supabase-migration-plan.md
+++ b/docs/supabase-migration-plan.md
@@ -1,0 +1,487 @@
+# Supabase Migration Plan
+
+> Migrate permanent/historical data from Upstash Redis to Supabase Postgres.
+> Redis remains for caching, rate limiting, and ephemeral state.
+
+**Status:** Draft
+**Created:** 2026-02-17
+**Target:** Incremental (no big-bang cutover)
+
+---
+
+## 1. What's Moving and What's Staying
+
+### Moving to Supabase Postgres
+
+| Data | Current Redis key | TTL | Why move |
+|------|-------------------|-----|----------|
+| Metric snapshots | `history:<handle>` (sorted set) | None (permanent) | Core historical data, needs indexing, querying, and unbounded retention |
+| User registry | `user:registered:<handle>` (JSON) | None (permanent) | Permanent records, need relational queries (admin dashboard) |
+| Verification records | `verify:<hash>`, `verify-handle:<handle>` | 30 days | Benefits from SQL queries; Postgres `TIMESTAMPTZ` + cron handles TTL |
+
+### Staying in Redis (Upstash)
+
+| Data | Redis key | Why keep |
+|------|-----------|---------|
+| Stats cache | `stats:v2:<handle>`, `stats:stale:<handle>` | Ephemeral, TTL-based, classic cache use case |
+| Rate limiting | `ratelimit:*` | Fixed-window counters, needs atomic INCR+EXPIRE |
+| Badge counters | `stats:badges_generated`, `stats:unique_badges` | HyperLogLog + INCR, Redis-native operations |
+| Supplemental stats | `supplemental:<handle>` | Ephemeral, 6h TTL |
+
+---
+
+## 2. Database Schema
+
+### `users` table
+
+```sql
+CREATE TABLE users (
+  id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  handle        TEXT NOT NULL UNIQUE,
+  registered_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_users_registered_at ON users (registered_at DESC);
+```
+
+**Notes:**
+- `handle` is stored lowercase (matches current `toLowerCase()` behavior in `registerUser()`)
+- `id` provides a stable FK target; `handle` is the natural key
+- Replaces Redis keys `user:registered:<handle>`
+
+### `metrics_snapshots` table
+
+```sql
+CREATE TABLE metrics_snapshots (
+  id                  BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  handle              TEXT NOT NULL,
+  date                DATE NOT NULL,
+  captured_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  -- Stats subset
+  commits_total       INT NOT NULL,
+  prs_merged_count    INT NOT NULL,
+  prs_merged_weight   REAL NOT NULL,
+  reviews_submitted   INT NOT NULL,
+  issues_closed       INT NOT NULL,
+  repos_contributed   INT NOT NULL,
+  active_days         INT NOT NULL,
+  lines_added         INT NOT NULL,
+  lines_deleted       INT NOT NULL,
+  total_stars         INT NOT NULL,
+  total_forks         INT NOT NULL,
+  total_watchers      INT NOT NULL,
+  top_repo_share      REAL NOT NULL,
+
+  -- Explanatory stats (optional)
+  max_commits_in_10min INT,
+  micro_commit_ratio   REAL,
+  docs_only_pr_ratio   REAL,
+
+  -- Impact dimensions & classification
+  building            REAL NOT NULL,
+  guarding            REAL NOT NULL,
+  consistency         REAL NOT NULL,
+  breadth             REAL NOT NULL,
+  archetype           TEXT NOT NULL,
+  profile_type        TEXT NOT NULL,
+  composite_score     REAL NOT NULL,
+  adjusted_composite  REAL NOT NULL,
+  confidence          REAL NOT NULL,
+  tier                TEXT NOT NULL,
+
+  -- Confidence penalties (JSONB array, null when empty)
+  confidence_penalties JSONB,
+
+  CONSTRAINT uq_snapshot_per_day UNIQUE (handle, date)
+);
+
+-- Primary query: get snapshots for a handle in date range
+CREATE INDEX idx_snapshots_handle_date ON metrics_snapshots (handle, date DESC);
+```
+
+**Notes:**
+- `UNIQUE (handle, date)` enforces the existing one-snapshot-per-day dedup at the DB level
+- No FK to `users` — snapshots can exist for handles that haven't gone through OAuth (public badge route)
+- Flattened columns instead of JSONB blob — enables indexed queries on dimensions, archetype, tier
+- `confidence_penalties` stays JSONB because it's a variable-length array rarely queried
+- **No 365-row cap** — Postgres handles unbounded history cheaply. Add a retention policy later if needed
+
+### `verification_records` table
+
+```sql
+CREATE TABLE verification_records (
+  id                  BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  hash                TEXT NOT NULL UNIQUE,
+  handle              TEXT NOT NULL,
+  display_name        TEXT,
+  adjusted_composite  REAL NOT NULL,
+  confidence          REAL NOT NULL,
+  tier                TEXT NOT NULL,
+  archetype           TEXT NOT NULL,
+  profile_type        TEXT NOT NULL,
+  building            REAL NOT NULL,
+  guarding            REAL NOT NULL,
+  consistency         REAL NOT NULL,
+  breadth             REAL NOT NULL,
+  commits_total       INT NOT NULL,
+  prs_merged_count    INT NOT NULL,
+  reviews_submitted   INT NOT NULL,
+  generated_at        DATE NOT NULL,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at          TIMESTAMPTZ NOT NULL DEFAULT (now() + INTERVAL '30 days')
+);
+
+CREATE INDEX idx_verification_handle ON verification_records (handle);
+CREATE INDEX idx_verification_expires ON verification_records (expires_at);
+```
+
+**Notes:**
+- `expires_at` replaces Redis TTL. Clean up with a daily cron: `DELETE FROM verification_records WHERE expires_at < now()`
+- `hash` is UNIQUE — same as current Redis key structure
+- Index on `handle` replaces the `verify-handle:<handle>` reverse lookup key
+
+---
+
+## 3. Implementation Phases
+
+### Phase 1: Foundation (no behavioral changes)
+
+**Goal:** Set up Supabase client, create tables, add tests. Nothing reads from or writes to Postgres yet in production paths.
+
+#### Tasks
+
+1. **Install Supabase client**
+   - `pnpm add @supabase/supabase-js` (in `apps/web`)
+   - Add env vars: `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` (server-side only, never `NEXT_PUBLIC_`)
+
+2. **Create Supabase client module**
+   - New file: `apps/web/lib/db/supabase.ts`
+   - Lazy singleton pattern (matches current Redis approach)
+   - Service role key for server-side operations (no RLS needed — all access is server-to-server)
+
+3. **Run migrations in Supabase dashboard**
+   - Create `users`, `metrics_snapshots`, `verification_records` tables using SQL above
+   - Optionally store migration SQL in `supabase/migrations/` for version control
+
+4. **Create data access layer**
+   - New file: `apps/web/lib/db/users.ts` — `upsertUser()`, `getUsers()`, `getUserCount()`
+   - New file: `apps/web/lib/db/snapshots.ts` — `insertSnapshot()`, `getSnapshots()`, `getLatestSnapshot()`, `getSnapshotCount()`
+   - New file: `apps/web/lib/db/verification.ts` — `storeVerification()`, `getVerification()`, `cleanExpiredVerifications()`
+   - All functions return the same types as their Redis counterparts (drop-in interface compatibility)
+
+5. **Write tests for data access layer**
+   - Mock `@supabase/supabase-js` at module level
+   - Test insert, upsert-on-conflict, date-range queries, cleanup
+
+#### Files created
+```
+apps/web/lib/db/supabase.ts
+apps/web/lib/db/users.ts
+apps/web/lib/db/snapshots.ts
+apps/web/lib/db/verification.ts
+apps/web/lib/db/users.test.ts
+apps/web/lib/db/snapshots.test.ts
+apps/web/lib/db/verification.test.ts
+```
+
+#### Files modified
+```
+apps/web/package.json   (add @supabase/supabase-js)
+```
+
+---
+
+### Phase 2: Dual-write (write to both, read from Redis)
+
+**Goal:** Start populating Postgres alongside Redis. No read paths change. If Postgres writes fail, nothing breaks (fire-and-forget, same as current Redis writes).
+
+#### Tasks
+
+1. **Update `recordSnapshot()` in `apps/web/lib/history/history.ts`**
+   - After the Redis write, also call `insertSnapshot()` from the new DB layer
+   - Fire-and-forget (`.catch(() => {})`) — Postgres failure must not affect badge serving
+
+2. **Update `registerUser()` in `apps/web/lib/cache/redis.ts`**
+   - After Redis write, also call `upsertUser()` from DB layer
+   - Same fire-and-forget pattern
+
+3. **Update `storeVerificationRecord()` in `apps/web/lib/verification/store.ts`**
+   - After Redis writes, also call `storeVerification()` from DB layer
+
+4. **Add verification cleanup to warm-cache cron**
+   - Call `cleanExpiredVerifications()` at the end of the cron run
+   - Replaces Redis TTL-based expiry for verification records
+
+#### Files modified
+```
+apps/web/lib/history/history.ts         (dual-write snapshots)
+apps/web/lib/cache/redis.ts             (dual-write user registration)
+apps/web/lib/verification/store.ts      (dual-write verification)
+apps/web/app/api/cron/warm-cache/route.ts (add verification cleanup)
+```
+
+---
+
+### Phase 3: Backfill existing data
+
+**Goal:** Migrate all existing Redis data into Postgres so both stores have identical records.
+
+#### Tasks
+
+1. **Write a one-time backfill script**
+   - New file: `scripts/backfill-supabase.ts`
+   - Scans all `history:<handle>` sorted sets via `SCAN` + `ZRANGE`
+   - Scans all `user:registered:<handle>` keys
+   - Scans all `verify:<hash>` keys
+   - Batch-inserts into Postgres with `ON CONFLICT DO NOTHING`
+   - Logs progress and errors
+
+2. **Run the backfill**
+   - Execute locally against production Redis + Supabase (with env vars)
+   - Verify row counts match Redis key counts
+
+3. **Validate data integrity**
+   - Spot-check 10-20 handles: compare Redis snapshot count vs Postgres row count
+   - Compare latest snapshot values for correctness
+
+#### Files created
+```
+scripts/backfill-supabase.ts
+```
+
+---
+
+### Phase 4: Switch reads to Postgres
+
+**Goal:** All read paths now use Postgres. Redis writes continue temporarily as fallback.
+
+#### Tasks
+
+1. **Update `apps/web/lib/history/history.ts`**
+   - `getSnapshots()` reads from Postgres instead of Redis `ZRANGE`
+   - `getLatestSnapshot()` reads from Postgres instead of Redis `ZRANGE REV`
+   - `getSnapshotCount()` reads from Postgres instead of Redis `ZCARD`
+   - Keep Redis write in `recordSnapshot()` as fallback (removed in Phase 5)
+
+2. **Update `apps/web/lib/verification/store.ts`**
+   - `getVerificationRecord()` reads from Postgres instead of Redis `GET`
+
+3. **Update admin users endpoint** (`apps/web/app/api/admin/users/route.ts`)
+   - Query `users` table instead of scanning `user:registered:*` keys
+   - This unlocks: sorting by registration date, pagination, count queries
+
+4. **Update existing tests**
+   - Tests for history, verification, and admin now mock Supabase instead of Redis
+   - Redis mocks remain for cache/rate-limit tests
+
+5. **Remove the 365-snapshot pruning** (`pruneSnapshots()`)
+   - No longer needed — Postgres handles unbounded history
+
+#### Files modified
+```
+apps/web/lib/history/history.ts          (read from Postgres)
+apps/web/lib/history/history.test.ts     (update mocks)
+apps/web/lib/verification/store.ts       (read from Postgres)
+apps/web/lib/verification/store.test.ts  (update mocks)
+apps/web/app/api/admin/users/route.ts    (query Postgres)
+apps/web/app/api/admin/users/route.test.ts (update mocks)
+```
+
+---
+
+### Phase 5: Remove Redis for migrated data
+
+**Goal:** Clean up dual-write code and Redis keys for migrated data. Redis only handles caching, rate limiting, and ephemeral state.
+
+#### Tasks
+
+1. **Remove Redis writes for migrated data**
+   - `recordSnapshot()` — remove Redis sorted set write, keep only Postgres
+   - `registerUser()` — remove Redis key write, keep only Postgres
+   - `storeVerificationRecord()` — remove Redis writes, keep only Postgres
+
+2. **Remove Redis read functions that are no longer called**
+   - `getRawRedis()` export (if no longer needed for sorted set ops)
+   - Any dead helper functions in `redis.ts`
+
+3. **Clean up Redis keys in production**
+   - Script or manual: delete `history:*`, `user:registered:*`, `verify:*`, `verify-handle:*` keys
+   - Do this **after** Phase 4 has been stable in production for at least 1 week
+
+4. **Remove `pruneSnapshots()` function entirely**
+   - Already unused after Phase 4, now delete the code
+
+5. **Update `CLAUDE.md`**
+   - Document Supabase as the store for permanent data
+   - Update env var list with `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`
+   - Update code ownership areas
+
+#### Files modified
+```
+apps/web/lib/history/history.ts     (remove Redis writes + pruning)
+apps/web/lib/cache/redis.ts         (remove registerUser, getRawRedis if unused)
+apps/web/lib/verification/store.ts  (remove Redis writes)
+CLAUDE.md                           (update docs)
+```
+
+---
+
+## 4. Supabase Client Setup
+
+```typescript
+// apps/web/lib/db/supabase.ts
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+
+let client: SupabaseClient | null = null;
+
+export function getSupabase(): SupabaseClient | null {
+  if (client) return client;
+
+  const url = process.env.SUPABASE_URL?.trim();
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY?.trim();
+
+  if (!url || !key) return null;
+
+  client = createClient(url, key, {
+    auth: { persistSession: false },
+  });
+
+  return client;
+}
+
+// Test helper
+export function _resetClient(): void {
+  client = null;
+}
+```
+
+**Notes:**
+- Service role key bypasses RLS — appropriate for server-side-only access
+- Returns `null` when env vars are missing (graceful degradation, same as Redis)
+- `persistSession: false` — no auth state needed for server-to-server
+
+---
+
+## 5. Interface Compatibility
+
+The new Postgres functions must return the same types as the current Redis-backed functions. This makes the switchover in Phase 4 a matter of changing imports, not reshaping data.
+
+| Current function | Current module | New module | Return type (unchanged) |
+|-----------------|----------------|------------|------------------------|
+| `recordSnapshot()` | `lib/history/history.ts` | `lib/db/snapshots.ts` | `Promise<boolean>` |
+| `getSnapshots()` | `lib/history/history.ts` | `lib/db/snapshots.ts` | `Promise<MetricsSnapshot[]>` |
+| `getLatestSnapshot()` | `lib/history/history.ts` | `lib/db/snapshots.ts` | `Promise<MetricsSnapshot \| null>` |
+| `getSnapshotCount()` | `lib/history/history.ts` | `lib/db/snapshots.ts` | `Promise<number>` |
+| `registerUser()` | `lib/cache/redis.ts` | `lib/db/users.ts` | `Promise<void>` |
+| `storeVerificationRecord()` | `lib/verification/store.ts` | `lib/db/verification.ts` | `Promise<void>` |
+| `getVerificationRecord()` | `lib/verification/store.ts` | `lib/db/verification.ts` | `Promise<VerificationRecord \| null>` |
+
+---
+
+## 6. Row-to-Type Mapping
+
+Postgres rows use `snake_case`. TypeScript types use `camelCase`. The data access layer handles conversion:
+
+```typescript
+// Example: Postgres row → MetricsSnapshot
+function rowToSnapshot(row: SnapshotRow): MetricsSnapshot {
+  return {
+    date: row.date,
+    capturedAt: row.captured_at,
+    commitsTotal: row.commits_total,
+    prsMergedCount: row.prs_merged_count,
+    prsMergedWeight: row.prs_merged_weight,
+    reviewsSubmittedCount: row.reviews_submitted,
+    issuesClosedCount: row.issues_closed,
+    reposContributed: row.repos_contributed,
+    activeDays: row.active_days,
+    linesAdded: row.lines_added,
+    linesDeleted: row.lines_deleted,
+    totalStars: row.total_stars,
+    totalForks: row.total_forks,
+    totalWatchers: row.total_watchers,
+    topRepoShare: row.top_repo_share,
+    maxCommitsIn10Min: row.max_commits_in_10min ?? undefined,
+    microCommitRatio: row.micro_commit_ratio ?? undefined,
+    docsOnlyPrRatio: row.docs_only_pr_ratio ?? undefined,
+    building: row.building,
+    guarding: row.guarding,
+    consistency: row.consistency,
+    breadth: row.breadth,
+    archetype: row.archetype,
+    profileType: row.profile_type,
+    compositeScore: row.composite_score,
+    adjustedComposite: row.adjusted_composite,
+    confidence: row.confidence,
+    tier: row.tier,
+    ...(row.confidence_penalties
+      ? { confidencePenalties: row.confidence_penalties }
+      : {}),
+  };
+}
+```
+
+---
+
+## 7. Environment Variables
+
+Add to `.env.local` and Vercel:
+
+```bash
+SUPABASE_URL=              # Supabase project URL (https://<ref>.supabase.co)
+SUPABASE_SERVICE_ROLE_KEY= # Service role key (server-side only, never NEXT_PUBLIC_)
+```
+
+**Security:**
+- Service role key is server-only — never expose via `NEXT_PUBLIC_` prefix
+- `.trim()` both values (standard env var safety practice)
+- Add to `.env.example` for documentation
+
+---
+
+## 8. Risk Mitigation
+
+| Risk | Mitigation |
+|------|-----------|
+| Supabase downtime during dual-write | Fire-and-forget writes — Postgres failures don't affect badge serving |
+| Data mismatch after backfill | Validation script compares Redis vs Postgres counts and latest values |
+| Latency increase on reads (Phase 4) | Supabase region matches Vercel region; add connection pooling via Supavisor |
+| Breaking existing tests | Phase 1 adds new tests; Phase 4 updates existing tests; no test goes unmocked |
+| Accidental Redis data deletion | Phase 5 cleanup happens 1+ week after Phase 4 is stable |
+| Rollback needed | Until Phase 5, Redis still has all data — revert imports to Redis-backed functions |
+
+---
+
+## 9. What This Unlocks
+
+Once complete, these become trivial to build:
+
+- **Cross-user queries**: "Top 10 Builders this month" — `SELECT ... ORDER BY building DESC LIMIT 10`
+- **Unbounded history**: Remove the 365-day cap, keep years of data at negligible cost
+- **Admin analytics**: User growth over time, archetype distribution, tier breakdown — all SQL
+- **Leaderboards**: Indexed queries on `adjusted_composite`, `archetype`, `tier`
+- **Data export**: `pg_dump`, CSV export from Supabase dashboard, or API
+- **Retention policies**: `DELETE WHERE date < now() - INTERVAL '2 years'` (if ever needed)
+
+---
+
+## 10. Migration Checklist
+
+- [ ] **Phase 1:** Install `@supabase/supabase-js`, create client module, create tables, write data access layer + tests
+- [ ] **Phase 2:** Add dual-write to `recordSnapshot`, `registerUser`, `storeVerificationRecord`; add verification cleanup to cron
+- [ ] **Phase 3:** Run backfill script, validate data integrity
+- [ ] **Phase 4:** Switch reads to Postgres, update tests, remove 365-snapshot cap
+- [ ] **Phase 5:** Remove Redis writes for migrated data, clean up Redis keys, update `CLAUDE.md`
+
+---
+
+## Appendix: Files Changed by Phase
+
+| Phase | New files | Modified files |
+|-------|-----------|---------------|
+| 1 | `lib/db/supabase.ts`, `lib/db/users.ts`, `lib/db/snapshots.ts`, `lib/db/verification.ts`, `lib/db/*.test.ts` | `package.json` |
+| 2 | — | `lib/history/history.ts`, `lib/cache/redis.ts`, `lib/verification/store.ts`, `api/cron/warm-cache/route.ts` |
+| 3 | `scripts/backfill-supabase.ts` | — |
+| 4 | — | `lib/history/history.ts`, `lib/history/history.test.ts`, `lib/verification/store.ts`, `lib/verification/store.test.ts`, `api/admin/users/route.ts`, `api/admin/users/route.test.ts` |
+| 5 | — | `lib/history/history.ts`, `lib/cache/redis.ts`, `lib/verification/store.ts`, `CLAUDE.md` |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@resvg/resvg-js':
         specifier: ^2.6.2
         version: 2.6.2
+      '@supabase/supabase-js':
+        specifier: ^2.95.3
+        version: 2.95.3
       '@upstash/redis':
         specifier: ^1.36.2
         version: 1.36.2
@@ -738,8 +741,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/core@2.5.1':
-    resolution: {integrity: sha512-Dwlc+3HAZqpgTYq0MUyZABjFkcrKTePwuiFVLjahGD8cx3enqihmpAmdgNFO1R4m/sIe5afjJrA25Prqy4NXlA==}
+  '@opentelemetry/core@2.5.0':
+    resolution: {integrity: sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -768,8 +771,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/resources@2.5.1':
-    resolution: {integrity: sha512-BViBCdE/GuXRlp9k7nS1w6wJvY5fnFX5XvuEtWsTAOQFIO89Eru7lGW3WbfbxtCuZ/GbrJfAziXG0w0dpxL7eQ==}
+  '@opentelemetry/resources@2.5.0':
+    resolution: {integrity: sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
@@ -1067,6 +1070,30 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@supabase/auth-js@2.95.3':
+    resolution: {integrity: sha512-vD2YoS8E2iKIX0F7EwXTmqhUpaNsmbU6X2R0/NdFcs02oEfnHyNP/3M716f3wVJ2E5XHGiTFXki6lRckhJ0Thg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.95.3':
+    resolution: {integrity: sha512-uTuOAKzs9R/IovW1krO0ZbUHSJnsnyJElTXIRhjJTqymIVGcHzkAYnBCJqd7468Fs/Foz1BQ7Dv6DCl05lr7ig==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/postgrest-js@2.95.3':
+    resolution: {integrity: sha512-LTrRBqU1gOovxRm1vRXPItSMPBmEFqrfTqdPTRtzOILV4jPSueFz6pES5hpb4LRlkFwCPRmv3nQJ5N625V2Xrg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.95.3':
+    resolution: {integrity: sha512-D7EAtfU3w6BEUxDACjowWNJo/ZRo7sDIuhuOGKHIm9FHieGeoJV5R6GKTLtga/5l/6fDr2u+WcW/m8I9SYmaIw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/storage-js@2.95.3':
+    resolution: {integrity: sha512-4GxkJiXI3HHWjxpC3sDx1BVrV87O0hfX+wvJdqGv67KeCu+g44SPnII8y0LL/Wr677jB7tpjAxKdtVWf+xhc9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.95.3':
+    resolution: {integrity: sha512-Fukw1cUTQ6xdLiHDJhKKPu6svEPaCEDvThqCne3OaQyZvuq2qjhJAd91kJu3PXLG18aooCgYBaB6qQz35hhABg==}
+    engines: {node: '>=20.0.0'}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1208,6 +1235,9 @@ packages:
   '@types/node@25.2.3':
     resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
 
+  '@types/phoenix@1.6.7':
+    resolution: {integrity: sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -1218,6 +1248,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.55.0':
     resolution: {integrity: sha512-1y/MVSz0NglV1ijHC8OT49mPJ4qhPYjiK08YUQVbIOyu+5k862LKUHFkpKHWu//zmr7hDR2rhwUm6gnCGNmGBQ==}
@@ -2108,6 +2141,10 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -3131,6 +3168,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -3648,7 +3697,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.39.0
 
-  '@opentelemetry/core@2.5.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.39.0
@@ -3685,10 +3734,10 @@ snapshots:
       '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.39.0
 
-  '@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/resources@2.5.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.5.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.39.0
 
   '@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.0)':
@@ -3880,6 +3929,44 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@supabase/auth-js@2.95.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.95.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/postgrest-js@2.95.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.95.3':
+    dependencies:
+      '@types/phoenix': 1.6.7
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/storage-js@2.95.3':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.95.3':
+    dependencies:
+      '@supabase/auth-js': 2.95.3
+      '@supabase/functions-js': 2.95.3
+      '@supabase/postgrest-js': 2.95.3
+      '@supabase/realtime-js': 2.95.3
+      '@supabase/storage-js': 2.95.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -4000,6 +4087,8 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/phoenix@1.6.7': {}
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -4010,6 +4099,10 @@ snapshots:
 
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.2.3
 
   '@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -5054,6 +5147,8 @@ snapshots:
 
   husky@9.1.7: {}
 
+  iceberg-js@0.8.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -5553,7 +5648,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.208.0
       '@opentelemetry/exporter-logs-otlp-http': 0.208.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.5.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
       '@posthog/core': 1.22.0
       '@posthog/types': 1.347.2
@@ -6204,6 +6299,8 @@ snapshots:
   word-wrap@1.2.5: {}
 
   ws@7.5.10: {}
+
+  ws@8.19.0: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/supabase/migrations/001_create_tables.sql
+++ b/supabase/migrations/001_create_tables.sql
@@ -1,0 +1,97 @@
+-- Chapa: migrate permanent data from Redis to Supabase Postgres
+-- See docs/supabase-migration-plan.md for full context.
+
+-- ---------------------------------------------------------------------------
+-- users — replaces Redis `user:registered:<handle>` keys
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS users (
+  id            BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  handle        TEXT NOT NULL UNIQUE,
+  registered_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_registered_at ON users (registered_at DESC);
+
+-- ---------------------------------------------------------------------------
+-- metrics_snapshots — replaces Redis `history:<handle>` sorted sets
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS metrics_snapshots (
+  id                   BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  handle               TEXT NOT NULL,
+  date                 DATE NOT NULL,
+  captured_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  -- Stats subset
+  commits_total        INT NOT NULL,
+  prs_merged_count     INT NOT NULL,
+  prs_merged_weight    REAL NOT NULL,
+  reviews_submitted    INT NOT NULL,
+  issues_closed        INT NOT NULL,
+  repos_contributed    INT NOT NULL,
+  active_days          INT NOT NULL,
+  lines_added          INT NOT NULL,
+  lines_deleted        INT NOT NULL,
+  total_stars          INT NOT NULL,
+  total_forks          INT NOT NULL,
+  total_watchers       INT NOT NULL,
+  top_repo_share       REAL NOT NULL,
+
+  -- Explanatory stats (optional)
+  max_commits_in_10min INT,
+  micro_commit_ratio   REAL,
+  docs_only_pr_ratio   REAL,
+
+  -- Impact dimensions & classification
+  building             REAL NOT NULL,
+  guarding             REAL NOT NULL,
+  consistency          REAL NOT NULL,
+  breadth              REAL NOT NULL,
+  archetype            TEXT NOT NULL,
+  profile_type         TEXT NOT NULL,
+  composite_score      REAL NOT NULL,
+  adjusted_composite   REAL NOT NULL,
+  confidence           REAL NOT NULL,
+  tier                 TEXT NOT NULL,
+
+  -- Confidence penalties (JSONB array, null when empty)
+  confidence_penalties JSONB,
+
+  CONSTRAINT uq_snapshot_per_day UNIQUE (handle, date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_snapshots_handle_date
+  ON metrics_snapshots (handle, date DESC);
+
+-- ---------------------------------------------------------------------------
+-- verification_records — replaces Redis `verify:<hash>` + `verify-handle:<handle>`
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS verification_records (
+  id                  BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  hash                TEXT NOT NULL UNIQUE,
+  handle              TEXT NOT NULL,
+  display_name        TEXT,
+  adjusted_composite  REAL NOT NULL,
+  confidence          REAL NOT NULL,
+  tier                TEXT NOT NULL,
+  archetype           TEXT NOT NULL,
+  profile_type        TEXT NOT NULL,
+  building            REAL NOT NULL,
+  guarding            REAL NOT NULL,
+  consistency         REAL NOT NULL,
+  breadth             REAL NOT NULL,
+  commits_total       INT NOT NULL,
+  prs_merged_count    INT NOT NULL,
+  reviews_submitted   INT NOT NULL,
+  generated_at        DATE NOT NULL,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at          TIMESTAMPTZ NOT NULL DEFAULT (now() + INTERVAL '30 days')
+);
+
+CREATE INDEX IF NOT EXISTS idx_verification_handle
+  ON verification_records (handle);
+
+CREATE INDEX IF NOT EXISTS idx_verification_expires
+  ON verification_records (expires_at);


### PR DESCRIPTION
Move permanent/historical data (metric snapshots, user registry,
verification records) from Upstash Redis to Supabase Postgres.
Redis stays for caching, rate limiting, and ephemeral state.

Includes 5-phase incremental migration with schema design,
interface compatibility table, risk mitigation, and backfill strategy.

https://claude.ai/code/session_01Mop2m5NFCMv4VA87dh195X