### PR TITLE
feat(db): Phase 2 — dual-write to Redis + Supabase

### DIFF
--- a/apps/web/lib/cache/redis.ts
+++ b/apps/web/lib/cache/redis.ts
@@ -10,6 +10,7 @@
  */
 
 import { Redis } from "@upstash/redis";
+import { dbUpsertUser } from "@/lib/db/users";
 
 // ---------------------------------------------------------------------------
 // Lazy singleton
@@ -299,6 +300,9 @@ export async function registerUser(handle: string): Promise<void> {
       handle: lowerHandle,
       registeredAt: new Date().toISOString(),
     });
+
+    // Dual-write to Supabase (fire-and-forget)
+    dbUpsertUser(handle).catch(() => {});
   } catch {
     // Fire-and-forget — user registration is non-critical
   }

--- a/apps/web/lib/history/history.ts
+++ b/apps/web/lib/history/history.ts
@@ -1,4 +1,5 @@
 import { getRawRedis } from "@/lib/cache/redis";
+import { dbInsertSnapshot } from "@/lib/db/snapshots";
 import type { MetricsSnapshot } from "./types";
 
 /** Redis key prefix for history sorted sets. */
@@ -49,6 +50,9 @@ export async function recordSnapshot(
 
     // Fire-and-forget: prune old entries to prevent unbounded growth
     pruneSnapshots(handle, MAX_SNAPSHOTS).catch(() => {});
+
+    // Dual-write to Supabase (fire-and-forget)
+    dbInsertSnapshot(handle, snapshot).catch(() => {});
 
     return true;
   } catch (error) {


### PR DESCRIPTION
## Summary

- **Snapshots**: `recordSnapshot()` now also calls `dbInsertSnapshot()` (fire-and-forget)
- **User registration**: `registerUser()` now also calls `dbUpsertUser()` (fire-and-forget)
- **Verification**: `storeVerificationRecord()` now also calls `dbStoreVerification()` (independent of Redis)
- **Cron cleanup**: warm-cache cron now calls `dbCleanExpiredVerifications()` and reports count in response

All Supabase writes are non-blocking. Failures are caught silently. Read paths remain unchanged (Redis-only). This is Phase 2 of the [Supabase migration plan](docs/supabase-migration-plan.md).

## Files changed (8)

| File | Change |
|------|--------|
| `lib/history/history.ts` | Dual-write snapshots to Supabase |
| `lib/cache/redis.ts` | Dual-write user registration to Supabase |
| `lib/verification/store.ts` | Dual-write verification to Supabase (independent of Redis) |
| `api/cron/warm-cache/route.ts` | Add expired verification cleanup |
| `*.test.ts` (4 files) | Tests for all dual-write behaviors |

## Test plan

- [x] All 135 test files pass (2228 tests)
- [x] Typecheck clean
- [x] Lint clean
- [x] Dual-write tests verify Supabase is called after Redis write
- [x] Fire-and-forget tests verify Supabase failures don't affect behavior
- [x] Cron cleanup tests verify expired verification deletion

Fixes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)