### PR TITLE
feat(db): Phase 3 backfill script — Redis → Supabase

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
   "ignoreExportsUsedInFile": true,
+  "ignore": ["scripts/**"],
   "workspaces": {
     "apps/web": {
       "ignoreDependencies": [

--- a/scripts/backfill-parsers.ts
+++ b/scripts/backfill-parsers.ts
@@ -1,0 +1,140 @@
+/**
+ * Pure parsing/validation functions for the backfill script.
+ *
+ * Separated from backfill-supabase.ts so tests can run without
+ * requiring @upstash/redis or @supabase/supabase-js at the root.
+ */
+
+import type { MetricsSnapshot } from "@chapa/shared";
+import type { VerificationRecord } from "../apps/web/lib/verification/types";
+
+/**
+ * Parse a Redis sorted set member (JSON string) into a MetricsSnapshot.
+ * Returns null if the JSON is invalid or required fields are missing.
+ */
+export function parseRedisSnapshot(json: string): MetricsSnapshot | null {
+  try {
+    const parsed = JSON.parse(json);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      typeof parsed.date !== "string" ||
+      typeof parsed.commitsTotal !== "number" ||
+      typeof parsed.building !== "number" ||
+      typeof parsed.tier !== "string"
+    ) {
+      return null;
+    }
+    return parsed as MetricsSnapshot;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse a Redis `user:registered:<handle>` value into a user record.
+ * Returns null if the value is invalid.
+ */
+export function parseRedisUser(
+  value: unknown,
+): { handle: string; registeredAt: string } | null {
+  if (value == null || typeof value !== "object") return null;
+
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.handle !== "string" || !obj.handle) return null;
+
+  return {
+    handle: obj.handle.toLowerCase(),
+    registeredAt:
+      typeof obj.registeredAt === "string"
+        ? obj.registeredAt
+        : new Date().toISOString(),
+  };
+}
+
+/**
+ * Parse a Redis `verify:<hash>` value into a VerificationRecord.
+ * Returns null if the value is invalid.
+ */
+export function parseRedisVerification(
+  value: unknown,
+): VerificationRecord | null {
+  if (value == null || typeof value !== "object") return null;
+
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.handle !== "string") return null;
+  if (obj.dimensions == null || typeof obj.dimensions !== "object") return null;
+
+  return obj as unknown as VerificationRecord;
+}
+
+/**
+ * Convert a MetricsSnapshot to a Supabase row for metrics_snapshots table.
+ */
+export function snapshotToRow(
+  handle: string,
+  s: MetricsSnapshot,
+): Record<string, unknown> {
+  return {
+    handle: handle.toLowerCase(),
+    date: s.date,
+    captured_at: s.capturedAt,
+    commits_total: s.commitsTotal,
+    prs_merged_count: s.prsMergedCount,
+    prs_merged_weight: s.prsMergedWeight,
+    reviews_submitted: s.reviewsSubmittedCount,
+    issues_closed: s.issuesClosedCount,
+    repos_contributed: s.reposContributed,
+    active_days: s.activeDays,
+    lines_added: s.linesAdded,
+    lines_deleted: s.linesDeleted,
+    total_stars: s.totalStars,
+    total_forks: s.totalForks,
+    total_watchers: s.totalWatchers,
+    top_repo_share: s.topRepoShare,
+    max_commits_in_10min: s.maxCommitsIn10Min,
+    micro_commit_ratio: s.microCommitRatio ?? null,
+    docs_only_pr_ratio: s.docsOnlyPrRatio ?? null,
+    building: s.building,
+    guarding: s.guarding,
+    consistency: s.consistency,
+    breadth: s.breadth,
+    archetype: s.archetype,
+    profile_type: s.profileType,
+    composite_score: s.compositeScore,
+    adjusted_composite: s.adjustedComposite,
+    confidence: s.confidence,
+    tier: s.tier,
+    confidence_penalties:
+      s.confidencePenalties && s.confidencePenalties.length > 0
+        ? s.confidencePenalties
+        : null,
+  };
+}
+
+/**
+ * Convert a VerificationRecord to a Supabase row for verification_records table.
+ */
+export function verificationToRow(
+  hash: string,
+  r: VerificationRecord,
+): Record<string, unknown> {
+  return {
+    hash,
+    handle: r.handle.toLowerCase(),
+    display_name: r.displayName ?? null,
+    adjusted_composite: r.adjustedComposite,
+    confidence: r.confidence,
+    tier: r.tier,
+    archetype: r.archetype,
+    profile_type: r.profileType,
+    building: r.dimensions.building,
+    guarding: r.dimensions.guarding,
+    consistency: r.dimensions.consistency,
+    breadth: r.dimensions.breadth,
+    commits_total: r.commitsTotal,
+    prs_merged_count: r.prsMergedCount,
+    reviews_submitted: r.reviewsSubmittedCount,
+    generated_at: r.generatedAt,
+  };
+}

--- a/scripts/backfill-supabase.test.ts
+++ b/scripts/backfill-supabase.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseRedisSnapshot,
+  parseRedisUser,
+  parseRedisVerification,
+  snapshotToRow,
+  verificationToRow,
+} from "./backfill-parsers";
+import type { MetricsSnapshot } from "@chapa/shared";
+
+// ---------------------------------------------------------------------------
+// parseRedisSnapshot — converts JSON string from Redis sorted set member
+// ---------------------------------------------------------------------------
+
+describe("parseRedisSnapshot", () => {
+  const validSnapshot: MetricsSnapshot = {
+    date: "2025-06-15",
+    capturedAt: "2025-06-15T12:00:00.000Z",
+    commitsTotal: 200,
+    prsMergedCount: 30,
+    prsMergedWeight: 45.5,
+    reviewsSubmittedCount: 50,
+    issuesClosedCount: 10,
+    reposContributed: 8,
+    activeDays: 120,
+    linesAdded: 5000,
+    linesDeleted: 2000,
+    totalStars: 100,
+    totalForks: 20,
+    totalWatchers: 15,
+    topRepoShare: 0.4,
+    maxCommitsIn10Min: 3,
+    building: 70,
+    guarding: 50,
+    consistency: 60,
+    breadth: 40,
+    archetype: "Builder",
+    profileType: "collaborative",
+    compositeScore: 55,
+    adjustedComposite: 52,
+    confidence: 85,
+    tier: "Solid",
+  };
+
+  it("parses a valid JSON snapshot string", () => {
+    const result = parseRedisSnapshot(JSON.stringify(validSnapshot));
+    expect(result).toEqual(validSnapshot);
+  });
+
+  it("returns null for invalid JSON", () => {
+    expect(parseRedisSnapshot("not json")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseRedisSnapshot("")).toBeNull();
+  });
+
+  it("returns null when required field 'date' is missing", () => {
+    const { date: _, ...noDate } = validSnapshot;
+    expect(parseRedisSnapshot(JSON.stringify(noDate))).toBeNull();
+  });
+
+  it("returns null when required field 'commitsTotal' is missing", () => {
+    const { commitsTotal: _, ...noCommits } = validSnapshot;
+    expect(parseRedisSnapshot(JSON.stringify(noCommits))).toBeNull();
+  });
+
+  it("preserves optional fields when present", () => {
+    const withOptional = {
+      ...validSnapshot,
+      microCommitRatio: 0.15,
+      docsOnlyPrRatio: 0.05,
+      confidencePenalties: [{ flag: "burst_activity", penalty: 5 }],
+    };
+    const result = parseRedisSnapshot(JSON.stringify(withOptional));
+    expect(result).toEqual(withOptional);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseRedisUser — converts Redis user:registered:<handle> value
+// ---------------------------------------------------------------------------
+
+describe("parseRedisUser", () => {
+  it("parses a valid user object with handle and registeredAt", () => {
+    const value = { handle: "testuser", registeredAt: "2025-06-15T12:00:00.000Z" };
+    const result = parseRedisUser(value);
+    expect(result).toEqual({ handle: "testuser", registeredAt: "2025-06-15T12:00:00.000Z" });
+  });
+
+  it("returns null for null input", () => {
+    expect(parseRedisUser(null)).toBeNull();
+  });
+
+  it("returns null when handle is missing", () => {
+    expect(parseRedisUser({ registeredAt: "2025-06-15T12:00:00.000Z" })).toBeNull();
+  });
+
+  it("normalizes handle to lowercase", () => {
+    const result = parseRedisUser({ handle: "TestUser", registeredAt: "2025-06-15T12:00:00.000Z" });
+    expect(result?.handle).toBe("testuser");
+  });
+
+  it("defaults registeredAt to current ISO string when missing", () => {
+    const result = parseRedisUser({ handle: "testuser" });
+    expect(result).not.toBeNull();
+    expect(result!.handle).toBe("testuser");
+    // registeredAt should be a valid ISO string
+    expect(() => new Date(result!.registeredAt)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseRedisVerification — converts Redis verify:<hash> value
+// ---------------------------------------------------------------------------
+
+describe("parseRedisVerification", () => {
+  const validRecord = {
+    handle: "testuser",
+    displayName: "Test User",
+    adjustedComposite: 52,
+    confidence: 85,
+    tier: "Solid",
+    archetype: "Builder",
+    profileType: "collaborative",
+    dimensions: { building: 70, guarding: 50, consistency: 60, breadth: 40 },
+    commitsTotal: 200,
+    prsMergedCount: 30,
+    reviewsSubmittedCount: 50,
+    generatedAt: "2025-06-15",
+  };
+
+  it("parses a valid verification record", () => {
+    const result = parseRedisVerification(validRecord);
+    expect(result).toEqual(validRecord);
+  });
+
+  it("returns null for null input", () => {
+    expect(parseRedisVerification(null)).toBeNull();
+  });
+
+  it("returns null when handle is missing", () => {
+    const { handle: _, ...noHandle } = validRecord;
+    expect(parseRedisVerification(noHandle)).toBeNull();
+  });
+
+  it("returns null when dimensions is missing", () => {
+    const { dimensions: _, ...noDimensions } = validRecord;
+    expect(parseRedisVerification(noDimensions)).toBeNull();
+  });
+
+  it("handles missing displayName gracefully", () => {
+    const { displayName: _, ...noDisplayName } = validRecord;
+    const result = parseRedisVerification(noDisplayName);
+    expect(result).not.toBeNull();
+    expect(result!.displayName).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// snapshotToRow — converts MetricsSnapshot to Supabase row
+// ---------------------------------------------------------------------------
+
+describe("snapshotToRow", () => {
+  const snapshot: MetricsSnapshot = {
+    date: "2025-06-15",
+    capturedAt: "2025-06-15T12:00:00.000Z",
+    commitsTotal: 200,
+    prsMergedCount: 30,
+    prsMergedWeight: 45.5,
+    reviewsSubmittedCount: 50,
+    issuesClosedCount: 10,
+    reposContributed: 8,
+    activeDays: 120,
+    linesAdded: 5000,
+    linesDeleted: 2000,
+    totalStars: 100,
+    totalForks: 20,
+    totalWatchers: 15,
+    topRepoShare: 0.4,
+    maxCommitsIn10Min: 3,
+    building: 70,
+    guarding: 50,
+    consistency: 60,
+    breadth: 40,
+    archetype: "Builder",
+    profileType: "collaborative",
+    compositeScore: 55,
+    adjustedComposite: 52,
+    confidence: 85,
+    tier: "Solid",
+  };
+
+  it("maps camelCase fields to snake_case columns", () => {
+    const row = snapshotToRow("TestUser", snapshot);
+    expect(row.handle).toBe("testuser");
+    expect(row.commits_total).toBe(200);
+    expect(row.prs_merged_count).toBe(30);
+    expect(row.adjusted_composite).toBe(52);
+    expect(row.profile_type).toBe("collaborative");
+  });
+
+  it("normalizes handle to lowercase", () => {
+    const row = snapshotToRow("TestUser", snapshot);
+    expect(row.handle).toBe("testuser");
+  });
+
+  it("sets optional fields to null when missing", () => {
+    const row = snapshotToRow("user", snapshot);
+    expect(row.micro_commit_ratio).toBeNull();
+    expect(row.docs_only_pr_ratio).toBeNull();
+    expect(row.confidence_penalties).toBeNull();
+  });
+
+  it("preserves optional fields when present", () => {
+    const withOptional: MetricsSnapshot = {
+      ...snapshot,
+      microCommitRatio: 0.15,
+      confidencePenalties: [{ flag: "burst_activity", penalty: 5 }],
+    };
+    const row = snapshotToRow("user", withOptional);
+    expect(row.micro_commit_ratio).toBe(0.15);
+    expect(row.confidence_penalties).toEqual([{ flag: "burst_activity", penalty: 5 }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verificationToRow — converts VerificationRecord to Supabase row
+// ---------------------------------------------------------------------------
+
+describe("verificationToRow", () => {
+  const record = {
+    handle: "TestUser",
+    displayName: "Test User",
+    adjustedComposite: 52,
+    confidence: 85,
+    tier: "Solid",
+    archetype: "Builder",
+    profileType: "collaborative",
+    dimensions: { building: 70, guarding: 50, consistency: 60, breadth: 40 },
+    commitsTotal: 200,
+    prsMergedCount: 30,
+    reviewsSubmittedCount: 50,
+    generatedAt: "2025-06-15",
+  };
+
+  it("maps fields to snake_case and flattens dimensions", () => {
+    const row = verificationToRow("abc123", record);
+    expect(row.hash).toBe("abc123");
+    expect(row.handle).toBe("testuser");
+    expect(row.display_name).toBe("Test User");
+    expect(row.building).toBe(70);
+    expect(row.guarding).toBe(50);
+    expect(row.consistency).toBe(60);
+    expect(row.breadth).toBe(40);
+    expect(row.generated_at).toBe("2025-06-15");
+  });
+
+  it("sets display_name to null when missing", () => {
+    const { displayName: _, ...noDisplayName } = record;
+    const row = verificationToRow("abc123", noDisplayName as typeof record);
+    expect(row.display_name).toBeNull();
+  });
+});

--- a/scripts/backfill-supabase.ts
+++ b/scripts/backfill-supabase.ts
@@ -1,0 +1,298 @@
+#!/usr/bin/env tsx
+/**
+ * Phase 3: Backfill existing Redis data into Supabase.
+ *
+ * Scans production Redis for permanent data (metric snapshots, user registry,
+ * verification records) and inserts into Supabase Postgres tables.
+ *
+ * Usage:
+ *   tsx scripts/backfill-supabase.ts              # full backfill
+ *   tsx scripts/backfill-supabase.ts --dry-run    # preview without writing
+ *
+ * Requires env vars: UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN,
+ *                    SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+ *
+ * Idempotent — uses ON CONFLICT DO NOTHING / ignoreDuplicates.
+ * Safe to re-run at any time.
+ *
+ * Refs #354
+ */
+
+import { Redis } from "@upstash/redis";
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import {
+  parseRedisSnapshot,
+  parseRedisUser,
+  parseRedisVerification,
+  snapshotToRow,
+  verificationToRow,
+} from "./backfill-parsers";
+
+// ---------------------------------------------------------------------------
+// Backfill logic
+// ---------------------------------------------------------------------------
+
+const BATCH_SIZE = 50;
+
+async function scanAllKeys(redis: Redis, pattern: string): Promise<string[]> {
+  const keys: string[] = [];
+  let cursor = 0;
+  do {
+    const [nextCursor, batch] = await redis.scan(cursor, {
+      match: pattern,
+      count: 100,
+    });
+    keys.push(...batch);
+    cursor =
+      typeof nextCursor === "string" ? parseInt(nextCursor, 10) : nextCursor;
+  } while (cursor !== 0);
+  return keys;
+}
+
+async function backfillSnapshots(
+  redis: Redis,
+  supabase: SupabaseClient,
+  dryRun: boolean,
+): Promise<{ scanned: number; inserted: number; errors: number }> {
+  console.log("\n--- Backfilling metric snapshots ---");
+
+  const keys = await scanAllKeys(redis, "history:*");
+  console.log(`Found ${keys.length} history keys`);
+
+  let scanned = 0;
+  let inserted = 0;
+  let errors = 0;
+
+  for (const key of keys) {
+    const handle = key.replace("history:", "");
+    const members = await redis.zrange<string[]>(key, 0, -1);
+
+    for (const memberJson of members) {
+      scanned++;
+      const snapshot = parseRedisSnapshot(memberJson);
+      if (!snapshot) {
+        console.warn(`  [SKIP] Invalid snapshot in ${key}`);
+        errors++;
+        continue;
+      }
+
+      if (dryRun) {
+        inserted++;
+        continue;
+      }
+
+      try {
+        const { error } = await supabase
+          .from("metrics_snapshots")
+          .upsert(snapshotToRow(handle, snapshot), {
+            onConflict: "handle,date",
+            ignoreDuplicates: true,
+          });
+        if (error) throw error;
+        inserted++;
+      } catch (err) {
+        console.error(
+          `  [ERROR] ${handle}/${snapshot.date}: ${(err as Error).message}`,
+        );
+        errors++;
+      }
+    }
+
+    if (scanned % 100 === 0 && scanned > 0) {
+      console.log(`  Progress: ${scanned} snapshots processed...`);
+    }
+  }
+
+  console.log(
+    `  Done: ${scanned} scanned, ${inserted} inserted, ${errors} errors`,
+  );
+  return { scanned, inserted, errors };
+}
+
+async function backfillUsers(
+  redis: Redis,
+  supabase: SupabaseClient,
+  dryRun: boolean,
+): Promise<{ scanned: number; inserted: number; errors: number }> {
+  console.log("\n--- Backfilling user registry ---");
+
+  const keys = await scanAllKeys(redis, "user:registered:*");
+  console.log(`Found ${keys.length} registered user keys`);
+
+  let scanned = 0;
+  let inserted = 0;
+  let errors = 0;
+
+  for (let i = 0; i < keys.length; i += BATCH_SIZE) {
+    const batch = keys.slice(i, i + BATCH_SIZE);
+    const rows: { handle: string }[] = [];
+
+    for (const key of batch) {
+      scanned++;
+      const value = await redis.get(key);
+      const parsed = parseRedisUser(value);
+      if (!parsed) {
+        console.warn(`  [SKIP] Invalid user data in ${key}`);
+        errors++;
+        continue;
+      }
+      rows.push({ handle: parsed.handle });
+    }
+
+    if (dryRun) {
+      inserted += rows.length;
+      continue;
+    }
+
+    if (rows.length > 0) {
+      try {
+        const { error } = await supabase
+          .from("users")
+          .upsert(rows, { onConflict: "handle", ignoreDuplicates: true });
+        if (error) throw error;
+        inserted += rows.length;
+      } catch (err) {
+        console.error(`  [ERROR] batch insert: ${(err as Error).message}`);
+        errors += rows.length;
+      }
+    }
+  }
+
+  console.log(
+    `  Done: ${scanned} scanned, ${inserted} inserted, ${errors} errors`,
+  );
+  return { scanned, inserted, errors };
+}
+
+async function backfillVerifications(
+  redis: Redis,
+  supabase: SupabaseClient,
+  dryRun: boolean,
+): Promise<{ scanned: number; inserted: number; errors: number }> {
+  console.log("\n--- Backfilling verification records ---");
+
+  const keys = await scanAllKeys(redis, "verify:*");
+  const hashKeys = keys.filter((k) => !k.startsWith("verify-handle:"));
+  console.log(
+    `Found ${keys.length} verify keys (${hashKeys.length} hash keys, ${keys.length - hashKeys.length} handle indexes skipped)`,
+  );
+
+  let scanned = 0;
+  let inserted = 0;
+  let errors = 0;
+
+  for (const key of hashKeys) {
+    scanned++;
+    const hash = key.replace("verify:", "");
+
+    const value = await redis.get(key);
+    const record = parseRedisVerification(value);
+    if (!record) {
+      console.warn(`  [SKIP] Invalid verification in ${key}`);
+      errors++;
+      continue;
+    }
+
+    if (dryRun) {
+      inserted++;
+      continue;
+    }
+
+    try {
+      const { error } = await supabase
+        .from("verification_records")
+        .upsert(verificationToRow(hash, record), {
+          onConflict: "hash",
+          ignoreDuplicates: true,
+        });
+      if (error) throw error;
+      inserted++;
+    } catch (err) {
+      console.error(`  [ERROR] ${hash}: ${(err as Error).message}`);
+      errors++;
+    }
+  }
+
+  console.log(
+    `  Done: ${scanned} scanned, ${inserted} inserted, ${errors} errors`,
+  );
+  return { scanned, inserted, errors };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+
+  console.log("=== Chapa: Backfill Redis → Supabase ===");
+  console.log(`Mode: ${dryRun ? "DRY RUN (no writes)" : "LIVE"}`);
+
+  // Connect to Redis
+  const redisUrl = process.env.UPSTASH_REDIS_REST_URL?.trim();
+  const redisToken = process.env.UPSTASH_REDIS_REST_TOKEN?.trim();
+  if (!redisUrl || !redisToken) {
+    console.error(
+      "Missing UPSTASH_REDIS_REST_URL or UPSTASH_REDIS_REST_TOKEN",
+    );
+    process.exit(1);
+  }
+
+  const redis = new Redis({
+    url: redisUrl,
+    token: redisToken,
+    retry: { retries: 2, backoff: (n) => n * 1000 },
+  });
+
+  // Connect to Supabase
+  const supabaseUrl = process.env.SUPABASE_URL?.trim();
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY?.trim();
+  if (!supabaseUrl || !supabaseKey) {
+    console.error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+    process.exit(1);
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseKey, {
+    auth: { persistSession: false },
+  });
+
+  // Run all three backfills
+  const snapshots = await backfillSnapshots(redis, supabase, dryRun);
+  const users = await backfillUsers(redis, supabase, dryRun);
+  const verifications = await backfillVerifications(redis, supabase, dryRun);
+
+  // Summary
+  console.log("\n=== Summary ===");
+  console.log(
+    `Snapshots:     ${snapshots.inserted}/${snapshots.scanned} (${snapshots.errors} errors)`,
+  );
+  console.log(
+    `Users:         ${users.inserted}/${users.scanned} (${users.errors} errors)`,
+  );
+  console.log(
+    `Verifications: ${verifications.inserted}/${verifications.scanned} (${verifications.errors} errors)`,
+  );
+
+  const totalErrors = snapshots.errors + users.errors + verifications.errors;
+  if (totalErrors > 0) {
+    console.warn(`\n${totalErrors} total errors — check logs above`);
+    process.exit(1);
+  }
+
+  console.log("\nBackfill complete");
+}
+
+// Only run main when executed directly (not imported by tests)
+const isDirectRun =
+  typeof process !== "undefined" &&
+  process.argv[1] &&
+  (process.argv[1].endsWith("backfill-supabase.ts") ||
+    process.argv[1].endsWith("backfill-supabase"));
+
+if (isDirectRun) {
+  main().catch((err) => {
+    console.error("Fatal error:", err);
+    process.exit(1);
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     include: [
       "apps/**/*.test.{ts,tsx}",
       "packages/**/*.test.{ts,tsx}",
+      "scripts/**/*.test.ts",
     ],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Summary
- Adds `scripts/backfill-supabase.ts` to copy all permanent Redis data into Supabase Postgres
- Backfills 3 data types: metric snapshots (`history:*`), user registry (`user:registered:*`), verification records (`verify:*`)
- Idempotent via `ON CONFLICT DO NOTHING` — safe to re-run
- Supports `--dry-run` mode for previewing without writes
- Pure parsing/validation logic in `scripts/backfill-parsers.ts` with 22 unit tests
- Updates `vitest.config.ts` to include `scripts/` in test discovery

## Usage
```bash
# Preview (no writes)
tsx scripts/backfill-supabase.ts --dry-run

# Full backfill
tsx scripts/backfill-supabase.ts
```

Requires `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY` env vars.

## Test plan
- [x] 22 unit tests for parsers + row converters
- [x] Full test suite passes (2250 tests, 136 files)
- [x] TypeScript clean
- [ ] Run `--dry-run` against production Redis to verify key scanning
- [ ] Run live backfill after merge

Fixes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)