### PR TITLE
fix(db): handle Upstash auto-deserialized objects in backfill

### DIFF
--- a/scripts/backfill-parsers.ts
+++ b/scripts/backfill-parsers.ts
@@ -9,12 +9,13 @@ import type { MetricsSnapshot } from "@chapa/shared";
 import type { VerificationRecord } from "../apps/web/lib/verification/types";
 
 /**
- * Parse a Redis sorted set member (JSON string) into a MetricsSnapshot.
- * Returns null if the JSON is invalid or required fields are missing.
+ * Parse a Redis sorted set member into a MetricsSnapshot.
+ * Accepts either a JSON string or a pre-parsed object (Upstash auto-deserializes).
+ * Returns null if the input is invalid or required fields are missing.
  */
-export function parseRedisSnapshot(json: string): MetricsSnapshot | null {
+export function parseRedisSnapshot(input: string | unknown): MetricsSnapshot | null {
   try {
-    const parsed = JSON.parse(json);
+    const parsed = typeof input === "string" ? JSON.parse(input) : input;
     if (
       typeof parsed !== "object" ||
       parsed === null ||

--- a/scripts/backfill-supabase.test.ts
+++ b/scripts/backfill-supabase.test.ts
@@ -75,6 +75,16 @@ describe("parseRedisSnapshot", () => {
     const result = parseRedisSnapshot(JSON.stringify(withOptional));
     expect(result).toEqual(withOptional);
   });
+
+  it("accepts a pre-parsed object (Upstash auto-deserializes)", () => {
+    const result = parseRedisSnapshot(validSnapshot);
+    expect(result).toEqual(validSnapshot);
+  });
+
+  it("returns null for non-object non-string input", () => {
+    expect(parseRedisSnapshot(42 as unknown as string)).toBeNull();
+    expect(parseRedisSnapshot(null as unknown as string)).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/backfill-supabase.ts
+++ b/scripts/backfill-supabase.ts
@@ -65,11 +65,12 @@ async function backfillSnapshots(
 
   for (const key of keys) {
     const handle = key.replace("history:", "");
-    const members = await redis.zrange<string[]>(key, 0, -1);
+    // Upstash auto-deserializes JSON — members are objects, not strings
+    const members = await redis.zrange<unknown[]>(key, 0, -1);
 
-    for (const memberJson of members) {
+    for (const member of members) {
       scanned++;
-      const snapshot = parseRedisSnapshot(memberJson);
+      const snapshot = parseRedisSnapshot(member);
       if (!snapshot) {
         console.warn(`  [SKIP] Invalid snapshot in ${key}`);
         errors++;


### PR DESCRIPTION
## Summary
- Upstash Redis auto-deserializes JSON sorted set members, returning objects instead of strings
- Updated `parseRedisSnapshot` to accept both `string` and pre-parsed `object` input
- Updated `zrange` type annotation from `string[]` to `unknown[]` in backfill script
- Added 2 new tests for pre-parsed object handling

## Context
Discovered during live backfill run — all 10 snapshots were being skipped because `JSON.parse()` was called on already-parsed objects. After this fix, the backfill ran successfully: 10 snapshots, 7 users, 37 verifications migrated to Supabase.

## Test plan
- [x] 24 unit tests pass (22 existing + 2 new)
- [x] Full suite: 2252 tests, 136 files
- [x] Backfill verified against production data

Refs #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)