### PR TITLE
feat(db): Phase 5 — remove Redis writes for permanent data

### DIFF
--- a/apps/web/app/api/refresh/route.test.ts
+++ b/apps/web/app/api/refresh/route.test.ts
@@ -42,8 +42,8 @@ vi.mock("@/lib/history/snapshot", () => ({
   buildSnapshot: vi.fn(() => ({ date: "2025-01-01" })),
 }));
 
-vi.mock("@/lib/history/history", () => ({
-  recordSnapshot: vi.fn(() => Promise.resolve(true)),
+vi.mock("@/lib/db/snapshots", () => ({
+  dbInsertSnapshot: vi.fn(() => Promise.resolve(true)),
 }));
 
 import { requireSession } from "@/lib/auth/require-session";

--- a/apps/web/app/api/refresh/route.ts
+++ b/apps/web/app/api/refresh/route.ts
@@ -5,7 +5,7 @@ import { getStats } from "@/lib/github/client";
 import { computeImpactV4 } from "@/lib/impact/v4";
 import { isValidHandle } from "@/lib/validation";
 import { buildSnapshot } from "@/lib/history/snapshot";
-import { recordSnapshot } from "@/lib/history/history";
+import { dbInsertSnapshot } from "@/lib/db/snapshots";
 
 /**
  * POST /api/refresh?handle=:handle
@@ -63,7 +63,7 @@ export async function POST(request: NextRequest): Promise<Response> {
   const impact = computeImpactV4(stats);
 
   // Record daily metrics snapshot (fire-and-forget, deduplicates by date)
-  recordSnapshot(handle, buildSnapshot(stats, impact)).catch(() => {});
+  dbInsertSnapshot(handle, buildSnapshot(stats, impact)).catch(() => {});
 
   return NextResponse.json({ stats, impact });
 }

--- a/apps/web/app/u/[handle]/badge.svg/route.test.ts
+++ b/apps/web/app/u/[handle]/badge.svg/route.test.ts
@@ -75,8 +75,8 @@ vi.mock("@/lib/history/snapshot", () => ({
   buildSnapshot: vi.fn(() => ({ date: "2025-01-01" })),
 }));
 
-vi.mock("@/lib/history/history", () => ({
-  recordSnapshot: vi.fn(() => Promise.resolve(true)),
+vi.mock("@/lib/db/snapshots", () => ({
+  dbInsertSnapshot: vi.fn(() => Promise.resolve(true)),
 }));
 
 vi.mock("@/lib/http/client-ip", () => ({

--- a/apps/web/app/u/[handle]/badge.svg/route.ts
+++ b/apps/web/app/u/[handle]/badge.svg/route.ts
@@ -8,7 +8,7 @@ import { isValidHandle } from "@/lib/validation";
 import { escapeXml } from "@/lib/render/escape";
 import { rateLimit, trackBadgeGenerated } from "@/lib/cache/redis";
 import { buildSnapshot } from "@/lib/history/snapshot";
-import { recordSnapshot } from "@/lib/history/history";
+import { dbInsertSnapshot } from "@/lib/db/snapshots";
 import { generateVerificationCode } from "@/lib/verification/hmac";
 import { storeVerificationRecord } from "@/lib/verification/store";
 import type { VerificationRecord } from "@/lib/verification/types";
@@ -131,7 +131,7 @@ export async function GET(
     ops.push(trackBadgeGenerated(handle));
     ops.push(notifyFirstBadge(handle, impact));
     ops.push(
-      recordSnapshot(handle, buildSnapshot(stats, impact)).then(() => {}),
+      dbInsertSnapshot(handle, buildSnapshot(stats, impact)).then(() => {}),
     );
 
     return Promise.allSettled(ops);

--- a/apps/web/lib/cache/redis.ts
+++ b/apps/web/lib/cache/redis.ts
@@ -10,7 +10,6 @@
  */
 
 import { Redis } from "@upstash/redis";
-import { dbUpsertUser } from "@/lib/db/users";
 
 // ---------------------------------------------------------------------------
 // Lazy singleton
@@ -34,15 +33,6 @@ function getRedis(): Redis | null {
 
   _redis = new Redis({ url, token, retry: { retries: 0, backoff: () => 0 } });
   return _redis;
-}
-
-/**
- * Expose the raw Upstash Redis client for operations not covered by the
- * convenience helpers (e.g. sorted set commands used by history storage).
- * Returns `null` when Redis credentials are missing.
- */
-export function getRawRedis(): Redis | null {
-  return getRedis();
 }
 
 // ---------------------------------------------------------------------------
@@ -276,35 +266,6 @@ export async function getBadgeStats(): Promise<BadgeStats> {
     };
   } catch {
     return { total: 0, unique: 0 };
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Permanent user registry (no TTL — survives all cache expirations)
-// ---------------------------------------------------------------------------
-
-/**
- * Register a user in the permanent registry.
- * Writes `user:registered:<handle>` with no TTL so the admin dashboard
- * always knows who has used Chapa, even after stats caches expire.
- *
- * Fire-and-forget safe — never throws, silently no-ops if Redis is down.
- */
-export async function registerUser(handle: string): Promise<void> {
-  const redis = getRedis();
-  if (!redis) return;
-
-  const lowerHandle = handle.toLowerCase();
-  try {
-    await redis.set(`user:registered:${lowerHandle}`, {
-      handle: lowerHandle,
-      registeredAt: new Date().toISOString(),
-    });
-
-    // Dual-write to Supabase (fire-and-forget)
-    dbUpsertUser(handle).catch(() => {});
-  } catch {
-    // Fire-and-forget — user registration is non-critical
   }
 }
 

--- a/apps/web/lib/github/client.ts
+++ b/apps/web/lib/github/client.ts
@@ -1,6 +1,7 @@
 import { fetchStats } from "./stats";
 import { mergeStats } from "./merge";
-import { cacheGet, cacheSet, registerUser } from "../cache/redis";
+import { cacheGet, cacheSet } from "../cache/redis";
+import { dbUpsertUser } from "@/lib/db/users";
 import type { StatsData, SupplementalStats } from "@chapa/shared";
 
 const CACHE_TTL = 21600; // 6 hours
@@ -83,8 +84,8 @@ async function _fetchAndCache(
   await cacheSet(cacheKey, stats, CACHE_TTL);
   await cacheSet(staleKey, stats, STALE_TTL);
 
-  // Record in permanent registry (fire-and-forget, no TTL)
-  void registerUser(handle);
+  // Record in permanent user registry (fire-and-forget)
+  void dbUpsertUser(handle).catch(() => {});
 
   return stats;
 }

--- a/apps/web/lib/history/history.test.ts
+++ b/apps/web/lib/history/history.test.ts
@@ -2,25 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { makeSnapshot } from "../test-helpers/fixtures";
 
 // ---------------------------------------------------------------------------
-// Mock Redis — sorted set operations (Upstash uses zrange with options)
-// ---------------------------------------------------------------------------
-
-const mockZadd = vi.fn();
-const mockZrange = vi.fn();
-const mockZcard = vi.fn();
-const mockZremrangebyrank = vi.fn();
-
-vi.mock("@/lib/cache/redis", () => ({
-  getRawRedis: vi.fn(() => ({
-    zadd: mockZadd,
-    zrange: mockZrange,
-    zcard: mockZcard,
-    zremrangebyrank: mockZremrangebyrank,
-  })),
-}));
-
-// ---------------------------------------------------------------------------
-// Mock Supabase DB layer
+// Mock Supabase DB layer (sole data store — Phase 5)
 // ---------------------------------------------------------------------------
 
 vi.mock("@/lib/db/snapshots", () => ({
@@ -31,14 +13,11 @@ vi.mock("@/lib/db/snapshots", () => ({
 }));
 
 import {
-  recordSnapshot,
   getSnapshots,
   getLatestSnapshot,
   getSnapshotCount,
-  pruneSnapshots,
 } from "./history";
 import {
-  dbInsertSnapshot,
   dbGetSnapshots,
   dbGetLatestSnapshot,
   dbGetSnapshotCount,
@@ -46,79 +25,6 @@ import {
 
 beforeEach(() => {
   vi.clearAllMocks();
-});
-
-// ---------------------------------------------------------------------------
-// recordSnapshot
-// ---------------------------------------------------------------------------
-
-describe("recordSnapshot", () => {
-  it("skips write if snapshot for today already exists", async () => {
-    // zrange returns a non-empty array → duplicate exists
-    mockZrange.mockResolvedValue(["existing-member"]);
-
-    const result = await recordSnapshot("TestUser", makeSnapshot());
-
-    expect(result).toBe(false);
-    expect(mockZadd).not.toHaveBeenCalled();
-  });
-
-  it("writes snapshot to sorted set when no duplicate exists", async () => {
-    mockZrange.mockResolvedValue([]); // no existing entry
-    mockZadd.mockResolvedValue(1);
-
-    const snapshot = makeSnapshot();
-    const result = await recordSnapshot("TestUser", snapshot);
-
-    expect(result).toBe(true);
-    expect(mockZadd).toHaveBeenCalledWith(
-      "history:testuser",
-      {
-        score: expect.any(Number),
-        member: JSON.stringify(snapshot),
-      },
-    );
-  });
-
-  it("normalizes handle to lowercase for the key", async () => {
-    mockZrange.mockResolvedValue([]);
-    mockZadd.mockResolvedValue(1);
-
-    await recordSnapshot("TestUser", makeSnapshot());
-
-    // Dedup check uses lowercase key
-    expect(mockZrange).toHaveBeenCalledWith(
-      "history:testuser",
-      expect.any(Number),
-      expect.any(Number),
-      { byScore: true, count: 1, offset: 0 },
-    );
-  });
-
-  it("uses date's midnight UTC timestamp as score", async () => {
-    mockZrange.mockResolvedValue([]);
-    mockZadd.mockResolvedValue(1);
-
-    const snapshot = makeSnapshot({ date: "2025-06-15" });
-    await recordSnapshot("TestUser", snapshot);
-
-    const expectedScore = new Date("2025-06-15T00:00:00.000Z").getTime() / 1000;
-    expect(mockZadd).toHaveBeenCalledWith(
-      "history:testuser",
-      {
-        score: expectedScore,
-        member: JSON.stringify(snapshot),
-      },
-    );
-  });
-
-  it("returns false and does not throw on Redis error", async () => {
-    mockZrange.mockRejectedValue(new Error("connection failed"));
-
-    const result = await recordSnapshot("TestUser", makeSnapshot());
-
-    expect(result).toBe(false);
-  });
 });
 
 // ---------------------------------------------------------------------------
@@ -152,14 +58,6 @@ describe("getSnapshots", () => {
 
     expect(dbGetSnapshots).toHaveBeenCalledWith("TestUser", undefined, undefined);
   });
-
-  it("does not call Redis for reads", async () => {
-    vi.mocked(dbGetSnapshots).mockResolvedValue([]);
-
-    await getSnapshots("TestUser");
-
-    expect(mockZrange).not.toHaveBeenCalled();
-  });
 });
 
 // ---------------------------------------------------------------------------
@@ -184,14 +82,6 @@ describe("getLatestSnapshot", () => {
 
     expect(result).toBeNull();
   });
-
-  it("does not call Redis for reads", async () => {
-    vi.mocked(dbGetLatestSnapshot).mockResolvedValue(null);
-
-    await getLatestSnapshot("TestUser");
-
-    expect(mockZrange).not.toHaveBeenCalled();
-  });
 });
 
 // ---------------------------------------------------------------------------
@@ -215,134 +105,20 @@ describe("getSnapshotCount", () => {
 
     expect(result).toBe(0);
   });
-
-  it("does not call Redis for reads", async () => {
-    vi.mocked(dbGetSnapshotCount).mockResolvedValue(0);
-
-    await getSnapshotCount("TestUser");
-
-    expect(mockZcard).not.toHaveBeenCalled();
-  });
 });
 
 // ---------------------------------------------------------------------------
-// pruneSnapshots (standalone — still exists, removed from recordSnapshot)
+// Verify no Redis exports remain (recordSnapshot, pruneSnapshots removed)
 // ---------------------------------------------------------------------------
 
-describe("pruneSnapshots", () => {
-  it("removes oldest entries when count exceeds maxEntries", async () => {
-    mockZcard.mockResolvedValue(400);
-    mockZremrangebyrank.mockResolvedValue(35);
-
-    await pruneSnapshots("TestUser", 365);
-
-    // Should remove from rank 0 to (400 - 365 - 1) = 34
-    expect(mockZremrangebyrank).toHaveBeenCalledWith("history:testuser", 0, 34);
+describe("module exports", () => {
+  it("does not export recordSnapshot (removed in Phase 5)", async () => {
+    const mod = await import("./history");
+    expect(mod).not.toHaveProperty("recordSnapshot");
   });
 
-  it("does nothing when count is at or below maxEntries", async () => {
-    mockZcard.mockResolvedValue(365);
-
-    await pruneSnapshots("TestUser", 365);
-
-    expect(mockZremrangebyrank).not.toHaveBeenCalled();
-  });
-
-  it("does nothing when count is below maxEntries", async () => {
-    mockZcard.mockResolvedValue(100);
-
-    await pruneSnapshots("TestUser", 365);
-
-    expect(mockZremrangebyrank).not.toHaveBeenCalled();
-  });
-
-  it("normalizes handle to lowercase for the key", async () => {
-    mockZcard.mockResolvedValue(400);
-    mockZremrangebyrank.mockResolvedValue(35);
-
-    await pruneSnapshots("TestUser", 365);
-
-    expect(mockZcard).toHaveBeenCalledWith("history:testuser");
-    expect(mockZremrangebyrank).toHaveBeenCalledWith("history:testuser", 0, 34);
-  });
-
-  it("does not throw on Redis error", async () => {
-    mockZcard.mockRejectedValue(new Error("connection failed"));
-
-    // Should not throw
-    await expect(pruneSnapshots("TestUser", 365)).resolves.toBeUndefined();
-  });
-
-  it("does not throw when zremrangebyrank fails", async () => {
-    mockZcard.mockResolvedValue(400);
-    mockZremrangebyrank.mockRejectedValue(new Error("write error"));
-
-    await expect(pruneSnapshots("TestUser", 365)).resolves.toBeUndefined();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// recordSnapshot — no longer calls pruneSnapshots (Phase 4)
-// ---------------------------------------------------------------------------
-
-describe("recordSnapshot — no prune after write (Phase 4)", () => {
-  it("does NOT call pruneSnapshots after a successful write", async () => {
-    mockZrange.mockResolvedValue([]); // no existing entry
-    mockZadd.mockResolvedValue(1);
-
-    const result = await recordSnapshot("TestUser", makeSnapshot());
-
-    expect(result).toBe(true);
-    // Prune-related Redis calls should NOT happen from recordSnapshot
-    // (zcard is only called by pruneSnapshots)
-    expect(mockZcard).not.toHaveBeenCalled();
-    expect(mockZremrangebyrank).not.toHaveBeenCalled();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// recordSnapshot — Supabase dual-write
-// ---------------------------------------------------------------------------
-
-describe("recordSnapshot — Supabase dual-write", () => {
-  it("calls dbInsertSnapshot after a successful Redis write", async () => {
-    mockZrange.mockResolvedValue([]);
-    mockZadd.mockResolvedValue(1);
-
-    const snapshot = makeSnapshot();
-    await recordSnapshot("TestUser", snapshot);
-
-    await vi.waitFor(() => {
-      expect(vi.mocked(dbInsertSnapshot)).toHaveBeenCalledWith(
-        "TestUser",
-        snapshot,
-      );
-    });
-  });
-
-  it("does not call dbInsertSnapshot when Redis dedup skips write", async () => {
-    mockZrange.mockResolvedValue(["existing-member"]);
-
-    await recordSnapshot("TestUser", makeSnapshot());
-
-    expect(vi.mocked(dbInsertSnapshot)).not.toHaveBeenCalled();
-  });
-
-  it("still returns true when Supabase write fails (fire-and-forget)", async () => {
-    mockZrange.mockResolvedValue([]);
-    mockZadd.mockResolvedValue(1);
-    vi.mocked(dbInsertSnapshot).mockRejectedValue(new Error("Supabase down"));
-
-    const result = await recordSnapshot("TestUser", makeSnapshot());
-
-    expect(result).toBe(true);
-  });
-
-  it("does not call dbInsertSnapshot when Redis itself fails", async () => {
-    mockZrange.mockRejectedValue(new Error("Redis down"));
-
-    await recordSnapshot("TestUser", makeSnapshot());
-
-    expect(vi.mocked(dbInsertSnapshot)).not.toHaveBeenCalled();
+  it("does not export pruneSnapshots (removed in Phase 5)", async () => {
+    const mod = await import("./history");
+    expect(mod).not.toHaveProperty("pruneSnapshots");
   });
 });

--- a/apps/web/lib/history/history.ts
+++ b/apps/web/lib/history/history.ts
@@ -1,68 +1,13 @@
-import { getRawRedis } from "@/lib/cache/redis";
 import {
-  dbInsertSnapshot,
   dbGetSnapshots,
   dbGetLatestSnapshot,
   dbGetSnapshotCount,
 } from "@/lib/db/snapshots";
 import type { MetricsSnapshot } from "./types";
 
-/** Redis key prefix for history sorted sets. */
-const KEY_PREFIX = "history:";
-
-/** Build the Redis key for a user's history. */
-function historyKey(handle: string): string {
-  return `${KEY_PREFIX}${handle.toLowerCase()}`;
-}
-
-/** Convert a YYYY-MM-DD date to Unix timestamp (midnight UTC, seconds). */
-function dateToScore(date: string): number {
-  return new Date(`${date}T00:00:00.000Z`).getTime() / 1000;
-}
-
-/**
- * Record a snapshot in the user's history sorted set.
- *
- * Deduplicates by checking if any member with today's date score already
- * exists (via ZRANGE BYSCORE with LIMIT 1). This ensures at most one
- * snapshot per user per day, even if `capturedAt` timestamps differ.
- *
- * Returns `true` if written, `false` if skipped (duplicate) or on error.
- */
-export async function recordSnapshot(
-  handle: string,
-  snapshot: MetricsSnapshot,
-): Promise<boolean> {
-  const redis = getRawRedis();
-  if (!redis) return false;
-
-  const key = historyKey(handle);
-  const score = dateToScore(snapshot.date);
-
-  try {
-    // Check if any snapshot for this date already exists
-    const existing = await redis.zrange(key, score, score, {
-      byScore: true,
-      count: 1,
-      offset: 0,
-    });
-    if (existing && existing.length > 0) return false;
-
-    await redis.zadd(key, { score, member: JSON.stringify(snapshot) });
-
-    // Dual-write to Supabase (fire-and-forget)
-    dbInsertSnapshot(handle, snapshot).catch(() => {});
-
-    return true;
-  } catch (error) {
-    console.error("[history] recordSnapshot failed:", (error as Error).message);
-    return false;
-  }
-}
-
 /**
  * Get all snapshots for a user, optionally filtered by date range.
- * Reads from Supabase (Phase 4).
+ * Reads from Supabase.
  *
  * @param handle - GitHub handle (case-insensitive)
  * @param from - Start date (YYYY-MM-DD), inclusive. Omit for all-time.
@@ -78,7 +23,7 @@ export async function getSnapshots(
 
 /**
  * Get the most recent snapshot for a user.
- * Reads from Supabase (Phase 4).
+ * Reads from Supabase.
  * Returns `null` if no snapshots exist or on error.
  */
 export async function getLatestSnapshot(
@@ -89,40 +34,9 @@ export async function getLatestSnapshot(
 
 /**
  * Get the total number of snapshots stored for a user.
- * Reads from Supabase (Phase 4).
+ * Reads from Supabase.
  * Returns 0 on error or if DB is unavailable.
  */
 export async function getSnapshotCount(handle: string): Promise<number> {
   return dbGetSnapshotCount(handle);
-}
-
-/**
- * Prune oldest snapshots from a user's history sorted set.
- *
- * Uses ZREMRANGEBYRANK to remove entries from the low end (oldest scores)
- * when the total count exceeds `maxEntries`. This prevents unbounded growth
- * of history sorted sets over time.
- *
- * Note: No longer called from recordSnapshot (Phase 4 — Postgres has no row cap).
- * Kept for direct invocation until Phase 5 removes Redis history entirely.
- */
-export async function pruneSnapshots(
-  handle: string,
-  maxEntries: number,
-): Promise<void> {
-  const redis = getRawRedis();
-  if (!redis) return;
-
-  const key = historyKey(handle);
-
-  try {
-    const count = await redis.zcard(key);
-    if (count <= maxEntries) return;
-
-    // Remove oldest entries: ranks 0 through (count - maxEntries - 1)
-    const removeCount = count - maxEntries;
-    await redis.zremrangebyrank(key, 0, removeCount - 1);
-  } catch (error) {
-    console.error("[history] pruneSnapshots failed:", (error as Error).message);
-  }
 }

--- a/apps/web/lib/verification/store.test.ts
+++ b/apps/web/lib/verification/store.test.ts
@@ -1,17 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-vi.mock("@/lib/cache/redis", () => ({
-  cacheGet: vi.fn(),
-  cacheSet: vi.fn(),
-}));
-
 vi.mock("@/lib/db/verification", () => ({
   dbStoreVerification: vi.fn(() => Promise.resolve()),
   dbGetVerification: vi.fn(() => Promise.resolve(null)),
 }));
 
 import { storeVerificationRecord, getVerificationRecord } from "./store";
-import { cacheSet } from "@/lib/cache/redis";
 import { dbStoreVerification, dbGetVerification } from "@/lib/db/verification";
 import type { VerificationRecord } from "./types";
 
@@ -34,50 +28,37 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+// ---------------------------------------------------------------------------
+// storeVerificationRecord — writes to Supabase only (Phase 5)
+// ---------------------------------------------------------------------------
+
 describe("storeVerificationRecord", () => {
-  it("stores the record with verify: prefix and 30-day TTL", async () => {
+  it("calls dbStoreVerification with hash and record", async () => {
     await storeVerificationRecord("abc12345", record);
-    expect(vi.mocked(cacheSet)).toHaveBeenCalledWith(
-      "verify:abc12345",
+
+    expect(vi.mocked(dbStoreVerification)).toHaveBeenCalledWith(
+      "abc12345",
       record,
-      2_592_000,
     );
   });
 
-  it("also stores a handle index entry (lowercase normalized)", async () => {
-    await storeVerificationRecord("abc12345", record);
-    expect(vi.mocked(cacheSet)).toHaveBeenCalledWith(
-      "verify-handle:testuser",
-      "abc12345",
-      2_592_000,
-    );
-  });
+  it("does not throw when Supabase write fails", async () => {
+    vi.mocked(dbStoreVerification).mockRejectedValue(new Error("Supabase down"));
 
-  it("normalizes handle to lowercase in handle index key", async () => {
-    const upperRecord = { ...record, handle: "TestUser" };
-    await storeVerificationRecord("abc12345", upperRecord);
-    expect(vi.mocked(cacheSet)).toHaveBeenCalledWith(
-      "verify-handle:testuser",
-      "abc12345",
-      2_592_000,
-    );
-  });
-
-  it("calls cacheSet twice (record + handle index)", async () => {
-    await storeVerificationRecord("abc12345", record);
-    expect(vi.mocked(cacheSet)).toHaveBeenCalledTimes(2);
-  });
-
-  it("does not throw if cacheSet fails", async () => {
-    vi.mocked(cacheSet).mockRejectedValue(new Error("Redis down"));
     await expect(
       storeVerificationRecord("abc12345", record),
     ).resolves.toBeUndefined();
   });
+
+  it("calls dbStoreVerification exactly once per invocation", async () => {
+    await storeVerificationRecord("abc12345", record);
+
+    expect(vi.mocked(dbStoreVerification)).toHaveBeenCalledTimes(1);
+  });
 });
 
 // ---------------------------------------------------------------------------
-// getVerificationRecord — reads from Supabase (Phase 4)
+// getVerificationRecord — reads from Supabase (Phase 4, unchanged)
 // ---------------------------------------------------------------------------
 
 describe("getVerificationRecord", () => {
@@ -98,48 +79,5 @@ describe("getVerificationRecord", () => {
     vi.mocked(dbGetVerification).mockRejectedValue(new Error("Supabase down"));
     const result = await getVerificationRecord("abc12345");
     expect(result).toBeNull();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// storeVerificationRecord — Supabase dual-write
-// ---------------------------------------------------------------------------
-
-describe("storeVerificationRecord — Supabase dual-write", () => {
-  it("calls dbStoreVerification with hash and record", async () => {
-    await storeVerificationRecord("abc12345", record);
-
-    expect(vi.mocked(dbStoreVerification)).toHaveBeenCalledWith(
-      "abc12345",
-      record,
-    );
-  });
-
-  it("writes to Supabase even when Redis fails", async () => {
-    vi.mocked(cacheSet).mockRejectedValue(new Error("Redis down"));
-
-    await storeVerificationRecord("abc12345", record);
-
-    expect(vi.mocked(dbStoreVerification)).toHaveBeenCalledWith(
-      "abc12345",
-      record,
-    );
-  });
-
-  it("does not throw when Supabase write throws synchronously", async () => {
-    vi.mocked(dbStoreVerification).mockImplementation(() => {
-      throw new Error("Supabase down");
-    });
-
-    await expect(
-      storeVerificationRecord("abc12345", record),
-    ).resolves.toBeUndefined();
-  });
-
-  it("still writes to Redis regardless of Supabase", async () => {
-    await storeVerificationRecord("abc12345", record);
-
-    expect(vi.mocked(cacheSet)).toHaveBeenCalledTimes(2);
-    expect(vi.mocked(dbStoreVerification)).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/lib/verification/store.ts
+++ b/apps/web/lib/verification/store.ts
@@ -1,37 +1,24 @@
-import { cacheSet } from "@/lib/cache/redis";
 import { dbStoreVerification, dbGetVerification } from "@/lib/db/verification";
 import type { VerificationRecord } from "./types";
 
-const VERIFY_TTL = 2_592_000; // 30 days in seconds
-
 /**
- * Store a verification record in Redis + Supabase (dual-write).
- * Fail-open: silently no-ops if either store is unavailable.
+ * Store a verification record in Supabase.
+ * Fail-open: silently no-ops if the store is unavailable.
  */
 export async function storeVerificationRecord(
   hash: string,
   record: VerificationRecord,
 ): Promise<void> {
   try {
-    await Promise.all([
-      cacheSet(`verify:${hash}`, record, VERIFY_TTL),
-      cacheSet(`verify-handle:${record.handle.toLowerCase()}`, hash, VERIFY_TTL),
-    ]);
+    await dbStoreVerification(hash, record);
   } catch {
-    // Fail open — Redis verification is non-critical
-  }
-
-  // Dual-write to Supabase (fire-and-forget, independent of Redis)
-  try {
-    void dbStoreVerification(hash, record);
-  } catch {
-    // Supabase errors are non-critical
+    // Fail open — verification storage is non-critical
   }
 }
 
 /**
  * Retrieve a verification record by hash.
- * Reads from Supabase (Phase 4).
+ * Reads from Supabase.
  * Returns null on miss or if DB is unavailable.
  */
 export async function getVerificationRecord(


### PR DESCRIPTION
## Summary
- **Remove Redis writes for snapshots, users, and verifications** — Supabase is now the sole store for all permanent data
- **Replace `scanKeys()` with `dbGetUsers()`** in cron warm-cache for handle discovery (authoritative Supabase user list)
- **Delete `recordSnapshot()`, `pruneSnapshots()`, `registerUser()`, `getRawRedis()`** — Redis sorted set and permanent-key operations fully removed
- Redis is now **ephemeral-only**: stats cache, rate limiting, badge counters, avatars

## Context

Phases 1–4 of the Supabase migration are complete:
- Phase 1: DAL layer (`lib/db/*.ts`)
- Phase 2: Dual-write (Redis + Supabase)
- Phase 3: Backfill (54 Redis records → Supabase)
- Phase 4: Reads switched to Supabase

This PR completes the migration by removing **Redis writes** for permanent data.

## Changes (14 files: +131 / −624)

| File | Change |
|------|--------|
| `lib/history/history.ts` | Remove `recordSnapshot`, `pruneSnapshots`, Redis helpers |
| `lib/verification/store.ts` | Remove `cacheSet` calls, Supabase-only writes |
| `lib/cache/redis.ts` | Remove `registerUser`, `getRawRedis`, `dbUpsertUser` import |
| `lib/github/client.ts` | `registerUser()` → `dbUpsertUser().catch()` |
| `api/cron/warm-cache/route.ts` | `scanKeys()` → `dbGetUsers()`, `recordSnapshot` → `dbInsertSnapshot` |
| `u/[handle]/badge.svg/route.ts` | `recordSnapshot` → `dbInsertSnapshot` |
| `api/refresh/route.ts` | `recordSnapshot` → `dbInsertSnapshot` |
| 7 test files | Updated mocks and assertions to match new data flow |

## Test plan
- [x] `pnpm run test` — 136 files, 2219 tests passing
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [x] Grep confirms no `history:*`, `user:registered:*`, or `verify:*` Redis writes remain
- [ ] Verify `/api/health` returns both Redis and Supabase "ok"
- [ ] Verify `/u/<handle>/badge.svg` renders correctly with snapshot written to Supabase
- [ ] Verify `/api/history/<handle>` returns snapshots from Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)