### PR TITLE
fix(types): cast next-themes ThemeProvider for React 19 compat

### DIFF
--- a/apps/web/components/ThemeProvider.tsx
+++ b/apps/web/components/ThemeProvider.tsx
@@ -1,11 +1,20 @@
 "use client";
 
-import { ThemeProvider as NextThemesProvider } from "next-themes";
+import {
+  ThemeProvider as NextThemesProvider,
+  type ThemeProviderProps,
+} from "next-themes";
+
+// Cast needed: next-themes@0.4.6 declares ThemeProvider as a plain function
+// value, not a React.FC. React 19's stricter JSX inference drops `children`
+// from IntrinsicAttributes for const-function signatures. Safe because
+// ThemeProviderProps extends React.PropsWithChildren.
+const Provider = NextThemesProvider as React.FC<ThemeProviderProps>;
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   return (
-    <NextThemesProvider attribute="data-theme" defaultTheme="light" enableSystem={false}>
+    <Provider attribute="data-theme" defaultTheme="light" enableSystem={false}>
       {children}
-    </NextThemesProvider>
+    </Provider>
   );
 }


### PR DESCRIPTION
## Summary
- Cast `NextThemesProvider` to `React.FC<ThemeProviderProps>` to fix TypeScript compilation error
- `next-themes@0.4.6` declares ThemeProvider as a plain const function, not `React.FC` — React 19's stricter JSX inference drops `children` from `IntrinsicAttributes` for const-function signatures
- This was the sole blocker identified by the pre-launch audit (6 parallel specialists)

## Verification
- `pnpm run typecheck` — passes (was failing with TS2322)
- `pnpm run test` — 136 files, 2,219 tests pass
- `pnpm run lint` — clean
- `pnpm run build` — production build succeeds (53 routes)

## Test plan
- [x] TypeScript typecheck passes locally
- [x] Full test suite passes (2,219 tests)
- [x] Production build succeeds
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)