### PR TITLE
fix(health): report degraded when Supabase is down

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,6 @@ CHAPA_VERIFICATION_SECRET=   # HMAC secret for badge verification hash (required
 # Feature flags
 COMING_SOON=                    # Set to "true" to redirect all traffic to /coming-soon (optional)
 NEXT_PUBLIC_STUDIO_ENABLED=     # Set to "true" to enable Creator Studio (optional, disabled by default)
-NEXT_PUBLIC_SCORING_PAGE_ENABLED=  # Set to "true" to enable the scoring methodology page (optional)
 NEXT_PUBLIC_EXPERIMENTS_ENABLED=   # Set to "true" to enable /experiments pages (optional)
 
 # Admin

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,7 +209,6 @@ GITHUB_TOKEN=              # GitHub personal access token (optional — fallback
 COMING_SOON=               # When set to any truthy value, enables coming-soon gate that blocks most routes (optional)
 CHAPA_VERIFICATION_SECRET= # HMAC secret for badge verification hash generation (required for /api/verify)
 NEXT_PUBLIC_STUDIO_ENABLED= # Set to "true" to enable Creator Studio (optional, disabled by default)
-NEXT_PUBLIC_SCORING_PAGE_ENABLED= # Set to "true" to enable /about/scoring page (optional, disabled by default)
 NEXT_PUBLIC_EXPERIMENTS_ENABLED= # Set to "true" to enable /experiments pages (optional, disabled by default)
 
 ADMIN_HANDLES=                 # Comma-separated GitHub handles allowed to access /admin (server-side only, optional)

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -8,8 +8,9 @@ export async function GET() {
     pingSupabase(),
   ]);
 
-  // Only Redis affects degraded status in Phase 1 — Supabase is optional
-  const status = redisStatus === "ok" ? "ok" : "degraded";
+  // Both Redis and Supabase are critical — either failing triggers degraded
+  const status =
+    redisStatus === "ok" && supabaseStatus === "ok" ? "ok" : "degraded";
   const httpStatus = status === "ok" ? 200 : 503;
 
   return NextResponse.json(


### PR DESCRIPTION
## Summary
- Health endpoint now reports `status: "degraded"` (503) when **either** Redis **or** Supabase is down, not just Redis. This reflects Phase 4's promotion of Supabase to primary data store. Fixes #362.
- Removed unused `NEXT_PUBLIC_SCORING_PAGE_ENABLED` env var from `CLAUDE.md` and `.env.example` (zero code references). Fixes #366.

## Changes
- `apps/web/app/api/health/route.ts` — changed status logic from Redis-only to both-critical
- `apps/web/app/api/health/route.test.ts` — rewrote tests: Redis-only fail, Supabase-only fail (x2), both fail, both OK, timestamp
- `CLAUDE.md` — removed `NEXT_PUBLIC_SCORING_PAGE_ENABLED` line
- `.env.example` — removed `NEXT_PUBLIC_SCORING_PAGE_ENABLED` line

## Test plan
- [x] Redis OK + Supabase OK → 200 ok
- [x] Redis error + Supabase OK → 503 degraded
- [x] Redis unavailable + Supabase OK → 503 degraded
- [x] Redis OK + Supabase unavailable → 503 degraded
- [x] Redis OK + Supabase error → 503 degraded
- [x] Both fail → 503 degraded
- [x] Timestamp always valid ISO 8601
- [x] Full test suite (2220 tests), typecheck, lint all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)