### PR TITLE
fix(a11y): BadgeOverlay aria-describedby + toolbar touch targets

### DIFF
--- a/apps/web/components/BadgeOverlay.test.ts
+++ b/apps/web/components/BadgeOverlay.test.ts
@@ -137,6 +137,27 @@ describe("BadgeOverlay CSS variable colors (#331)", () => {
   });
 });
 
+describe("BadgeOverlay aria-describedby resolves to visible content (#363)", () => {
+  it("desktop panel container does NOT have aria-hidden='true'", () => {
+    // The panel container wrapping tooltip content is referenced by aria-describedby
+    // on hotspot regions. If the container has aria-hidden="true", the referenced
+    // content is removed from the accessibility tree, making aria-describedby
+    // resolve to nothing for screen reader users.
+    // Match the panel section between "leader line annotation panel" comment and "Hotspot regions" comment.
+    const panelSection = SRC.match(
+      /leader line annotation panel[\s\S]*?Hotspot regions/,
+    )?.[0];
+    expect(panelSection).toBeDefined();
+    expect(panelSection).not.toContain('aria-hidden="true"');
+  });
+
+  it("hotspot regions use aria-describedby pointing to panel IDs", () => {
+    // Verify the linkage exists — hotspots reference panels via aria-describedby
+    expect(SRC).toContain("aria-describedby");
+    expect(SRC).toContain("-panel");
+  });
+});
+
 describe("BadgeOverlay mobile fallback", () => {
   it("leader line SVG and panels are hidden on small screens (md breakpoint)", () => {
     // Leader line visuals should be desktop-only

--- a/apps/web/components/BadgeOverlay.tsx
+++ b/apps/web/components/BadgeOverlay.tsx
@@ -279,7 +279,7 @@ export function BadgeOverlay() {
 
       {/* ── Desktop: leader line annotation panel (hidden on mobile) ── */}
       {/* Only the active hotspot's panel renders (#323 — lazy render) */}
-      <div className="hidden md:contents" aria-hidden="true">
+      <div className="hidden md:contents">
         {activeHotspot && (() => {
           const isAbove = activeHotspot.leaderLine.panelAnchor === "above";
           return (

--- a/apps/web/components/BadgeToolbar.responsive.test.ts
+++ b/apps/web/components/BadgeToolbar.responsive.test.ts
@@ -21,4 +21,17 @@ describe("BadgeToolbar", () => {
       expect(SOURCE).toContain("right-0 sm:left-0 sm:right-auto");
     });
   });
+
+  describe("WCAG 2.5.8 touch target size (#370)", () => {
+    it("toolbar button class includes min-h-[44px] for 44px minimum touch target", () => {
+      // WCAG 2.5.8 recommends a minimum touch target size of 44×44 CSS pixels.
+      // Toolbar buttons previously used px-2 py-2 producing ~32-36px height.
+      expect(SOURCE).toContain("min-h-[44px]");
+    });
+
+    it("toolbar button class includes min-w-[44px] for 44px minimum touch target width", () => {
+      // Square touch target ensures both width and height meet WCAG minimum.
+      expect(SOURCE).toContain("min-w-[44px]");
+    });
+  });
 });

--- a/apps/web/components/BadgeToolbar.tsx
+++ b/apps/web/components/BadgeToolbar.tsx
@@ -129,7 +129,7 @@ export function BadgeToolbar({
   }, [handle]);
 
   const btnClass =
-    "inline-flex items-center gap-1.5 rounded-lg px-2 sm:px-3 py-2 text-xs font-medium text-text-secondary hover:text-text-primary hover:bg-amber/[0.06] transition-colors";
+    "inline-flex items-center justify-center gap-1.5 rounded-lg min-h-[44px] min-w-[44px] px-2 sm:px-3 py-2 text-xs font-medium text-text-secondary hover:text-text-primary hover:bg-amber/[0.06] transition-colors";
 
   return (
     <div className="flex flex-wrap items-center gap-1">


### PR DESCRIPTION
## Summary
- **BadgeOverlay (#363):** Removed `aria-hidden="true"` from the desktop leader-line panel container. Hotspot regions use `aria-describedby` pointing to panel IDs, but the panels were wrapped in a container with `aria-hidden="true"`, making the referenced content invisible to screen readers. Now the tooltip content is always available in the accessibility tree when a hotspot is focused.
- **BadgeToolbar (#370):** Added `min-h-[44px]` and `min-w-[44px]` to the shared toolbar button class to meet WCAG 2.5.8 minimum touch target size (44x44 CSS pixels). Previous padding-only sizing produced ~32-36px targets on mobile. Also added `justify-center` for consistent icon alignment within the larger touch area.

Fixes #363, Fixes #370

## Test plan
- [x] New test: BadgeOverlay panel section does NOT contain `aria-hidden="true"`
- [x] New test: BadgeOverlay hotspot regions have `aria-describedby` referencing panel IDs
- [x] New test: BadgeToolbar button class includes `min-h-[44px]`
- [x] New test: BadgeToolbar button class includes `min-w-[44px]`
- [x] All 2223 existing tests pass
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [ ] Visual check: toolbar buttons have adequate touch targets on mobile viewport
- [ ] Screen reader check: focusing a badge hotspot announces the tooltip content

🤖 Generated with [Claude Code](https://claude.com/claude-code)