### PR TITLE
perf(studio): lazy-load effect components in BadgePreviewCard

### DIFF
--- a/apps/web/app/studio/BadgePreviewCard.test.tsx
+++ b/apps/web/app/studio/BadgePreviewCard.test.tsx
@@ -145,4 +145,75 @@ describe("BadgePreviewCard", () => {
       expect(SOURCE).toContain("HOLOGRAPHIC_CSS");
     });
   });
+
+  describe("lazy-loaded effects (dynamic imports)", () => {
+    it("imports next/dynamic", () => {
+      expect(SOURCE).toContain("from \"next/dynamic\"");
+    });
+
+    it("lazy-loads AuroraBackground via dynamic()", () => {
+      expect(SOURCE).toMatch(
+        /dynamic\(\s*\(\)\s*=>\s*import\(["']@\/lib\/effects\/backgrounds\/AuroraBackground["']\)/,
+      );
+    });
+
+    it("lazy-loads ParticleCanvas via dynamic()", () => {
+      // ParticleCanvas wraps useParticles and should be in its own dynamic chunk
+      expect(SOURCE).toMatch(
+        /dynamic\(\s*\(\)\s*=>\s*import\(["'].*Particle/,
+      );
+    });
+
+    it("lazy-loads GradientBorder via dynamic()", () => {
+      expect(SOURCE).toMatch(
+        /dynamic\(\s*\(\)\s*=>\s*import\(["']@\/lib\/effects\/borders\/GradientBorder["']\)/,
+      );
+    });
+
+    it("lazy-loads HolographicOverlay via dynamic()", () => {
+      expect(SOURCE).toMatch(
+        /dynamic\(\s*\(\)\s*=>\s*import\(["']@\/lib\/effects\/interactions\/HolographicOverlay["']\)/,
+      );
+    });
+
+    it("disables SSR for all dynamic effect components", () => {
+      // Count occurrences of ssr: false in dynamic() option objects
+      const ssrFalseCount = (SOURCE.match(/ssr:\s*false/g) ?? []).length;
+      expect(ssrFalseCount).toBeGreaterThanOrEqual(4);
+    });
+
+    it("provides loading fallbacks for dynamic components", () => {
+      // Count occurrences of loading: in dynamic() option objects
+      const loadingCount = (SOURCE.match(/loading:\s*\(\)/g) ?? []).length;
+      expect(loadingCount).toBeGreaterThanOrEqual(4);
+    });
+
+    it("does NOT eagerly import AuroraBackground component", () => {
+      // Static import of AuroraBackground should be gone
+      expect(SOURCE).not.toMatch(
+        /^import\s+\{[^}]*AuroraBackground[^}]*\}\s+from/m,
+      );
+    });
+
+    it("does NOT eagerly import ParticleBackground module", () => {
+      // Static import of useParticles/PARTICLE_PRESETS should be gone
+      expect(SOURCE).not.toMatch(
+        /^import\s+\{[^}]*useParticles[^}]*\}\s+from/m,
+      );
+    });
+
+    it("does NOT eagerly import GradientBorder component", () => {
+      // Static import of GradientBorder component should be gone (CSS constant may still be imported)
+      expect(SOURCE).not.toMatch(
+        /^import\s+\{[^}]*GradientBorder[^}]*\}\s+from\s+["']@\/lib\/effects\/borders\/GradientBorder["']/m,
+      );
+    });
+
+    it("does NOT eagerly import HolographicOverlay component", () => {
+      // Static import of HolographicOverlay component should be gone (CSS constant may still be imported)
+      expect(SOURCE).not.toMatch(
+        /^import\s+\{[^}]*HolographicOverlay[^}]*\}\s+from\s+["']@\/lib\/effects\/interactions\/HolographicOverlay["']/m,
+      );
+    });
+  });
 });

--- a/apps/web/lib/effects/backgrounds/ParticleCanvas.tsx
+++ b/apps/web/lib/effects/backgrounds/ParticleCanvas.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useRef } from "react";
+import { useParticles, PARTICLE_PRESETS } from "./ParticleBackground";
+
+/**
+ * Standalone ParticleCanvas component for dynamic import.
+ * Wraps the useParticles hook with a canvas element using the sparkle preset.
+ */
+export default function ParticleCanvas() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  useParticles(canvasRef, PARTICLE_PRESETS.sparkle);
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden="true"
+      className="absolute inset-0 w-full h-full"
+    />
+  );
+}

--- a/apps/web/lib/effects/borders/GradientBorder.tsx
+++ b/apps/web/lib/effects/borders/GradientBorder.tsx
@@ -9,47 +9,8 @@ export interface GradientBorderProps {
   className?: string;
 }
 
-/** CSS for rotating conic-gradient border. Inject once in the page. */
-export const GRADIENT_BORDER_CSS = `
-@property --gradient-angle {
-  syntax: "<angle>";
-  initial-value: 0deg;
-  inherits: false;
-}
-
-@keyframes rotate-gradient-border {
-  0% { --gradient-angle: 0deg; }
-  100% { --gradient-angle: 360deg; }
-}
-
-.animated-gradient-border {
-  background: conic-gradient(
-    from var(--gradient-angle),
-    #5E4FCC, #7C6AEF, #9D8FFF, #7C6AEF, #5E4FCC
-  );
-  animation: rotate-gradient-border 4s linear infinite;
-}
-
-@supports not (background: conic-gradient(from var(--gradient-angle), red, blue)) {
-  .animated-gradient-border {
-    background: linear-gradient(90deg, #5E4FCC, #7C6AEF, #9D8FFF, #7C6AEF, #5E4FCC);
-    background-size: 300% 300%;
-    animation: gradient-shift-fallback 3s ease infinite;
-  }
-  @keyframes gradient-shift-fallback {
-    0% { background-position: 0% 50%; }
-    50% { background-position: 100% 50%; }
-    100% { background-position: 0% 50%; }
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .animated-gradient-border {
-    animation: none !important;
-    background: conic-gradient(from 45deg, #5E4FCC, #7C6AEF, #9D8FFF, #7C6AEF, #5E4FCC);
-  }
-}
-`;
+// Re-export CSS constant from lightweight module (allows importing CSS without pulling in the component)
+export { GRADIENT_BORDER_CSS } from "./gradient-border-css";
 
 export function GradientBorder({
   enabled = true,

--- a/apps/web/lib/effects/borders/gradient-border-css.ts
+++ b/apps/web/lib/effects/borders/gradient-border-css.ts
@@ -1,0 +1,41 @@
+/** CSS for rotating conic-gradient border. Inject once in the page. */
+export const GRADIENT_BORDER_CSS = `
+@property --gradient-angle {
+  syntax: "<angle>";
+  initial-value: 0deg;
+  inherits: false;
+}
+
+@keyframes rotate-gradient-border {
+  0% { --gradient-angle: 0deg; }
+  100% { --gradient-angle: 360deg; }
+}
+
+.animated-gradient-border {
+  background: conic-gradient(
+    from var(--gradient-angle),
+    #5E4FCC, #7C6AEF, #9D8FFF, #7C6AEF, #5E4FCC
+  );
+  animation: rotate-gradient-border 4s linear infinite;
+}
+
+@supports not (background: conic-gradient(from var(--gradient-angle), red, blue)) {
+  .animated-gradient-border {
+    background: linear-gradient(90deg, #5E4FCC, #7C6AEF, #9D8FFF, #7C6AEF, #5E4FCC);
+    background-size: 300% 300%;
+    animation: gradient-shift-fallback 3s ease infinite;
+  }
+  @keyframes gradient-shift-fallback {
+    0% { background-position: 0% 50%; }
+    50% { background-position: 100% 50%; }
+    100% { background-position: 0% 50%; }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animated-gradient-border {
+    animation: none !important;
+    background: conic-gradient(from 45deg, #5E4FCC, #7C6AEF, #9D8FFF, #7C6AEF, #5E4FCC);
+  }
+}
+`;

--- a/apps/web/lib/effects/interactions/HolographicOverlay.tsx
+++ b/apps/web/lib/effects/interactions/HolographicOverlay.tsx
@@ -13,50 +13,8 @@ export interface HolographicOverlayProps {
   className?: string;
 }
 
-/** CSS for holographic overlay. Inject once in the page. */
-export const HOLOGRAPHIC_CSS = `
-.holo-card {
-  position: relative;
-  overflow: hidden;
-  transition: border-color 0.3s ease, box-shadow 0.3s ease;
-}
-.holo-card:hover {
-  border-color: rgba(124, 106, 239, 0.25);
-  box-shadow: 0 0 40px rgba(124, 106, 239, 0.06);
-}
-.holo-overlay {
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background-size: 200% 200%;
-  mix-blend-mode: color-dodge;
-  opacity: 0;
-  transition: opacity 0.4s ease;
-  pointer-events: none;
-  z-index: 8;
-}
-.holo-amber {
-  background: linear-gradient(var(--holo-angle, 115deg), transparent 20%, rgba(124,106,239,0.3) 36%, rgba(157,143,255,0.3) 42%, rgba(255,255,255,0.2) 48%, rgba(157,143,255,0.3) 54%, rgba(94,79,204,0.3) 60%, transparent 80%);
-  background-size: 200% 200%;
-}
-.holo-rainbow {
-  background: linear-gradient(var(--holo-angle, 115deg), transparent 20%, rgba(255,0,100,0.25) 30%, rgba(255,150,0,0.25) 38%, rgba(255,255,0,0.25) 44%, rgba(0,255,100,0.25) 50%, rgba(0,100,255,0.25) 56%, rgba(150,0,255,0.25) 64%, transparent 80%);
-  background-size: 200% 200%;
-}
-.holo-overlay.active { opacity: var(--holo-intensity, 0.45); }
-.holo-overlay.auto-animate.active { animation: holo-shift var(--holo-speed, 3s) ease infinite; }
-@keyframes holo-shift {
-  0%, 100% { background-position: 0% 50%; }
-  50% { background-position: 100% 50%; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .holo-overlay {
-    opacity: calc(var(--holo-intensity, 0.45) * 0.4) !important;
-    animation: none !important;
-    background-position: 50% 50%;
-  }
-}
-`;
+// Re-export CSS constant from lightweight module (allows importing CSS without pulling in the component)
+export { HOLOGRAPHIC_CSS } from "./holographic-css";
 
 export function HolographicOverlay({
   variant = "amber",

--- a/apps/web/lib/effects/interactions/holographic-css.ts
+++ b/apps/web/lib/effects/interactions/holographic-css.ts
@@ -1,0 +1,44 @@
+/** CSS for holographic overlay. Inject once in the page. */
+export const HOLOGRAPHIC_CSS = `
+.holo-card {
+  position: relative;
+  overflow: hidden;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+.holo-card:hover {
+  border-color: rgba(124, 106, 239, 0.25);
+  box-shadow: 0 0 40px rgba(124, 106, 239, 0.06);
+}
+.holo-overlay {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background-size: 200% 200%;
+  mix-blend-mode: color-dodge;
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  pointer-events: none;
+  z-index: 8;
+}
+.holo-amber {
+  background: linear-gradient(var(--holo-angle, 115deg), transparent 20%, rgba(124,106,239,0.3) 36%, rgba(157,143,255,0.3) 42%, rgba(255,255,255,0.2) 48%, rgba(157,143,255,0.3) 54%, rgba(94,79,204,0.3) 60%, transparent 80%);
+  background-size: 200% 200%;
+}
+.holo-rainbow {
+  background: linear-gradient(var(--holo-angle, 115deg), transparent 20%, rgba(255,0,100,0.25) 30%, rgba(255,150,0,0.25) 38%, rgba(255,255,0,0.25) 44%, rgba(0,255,100,0.25) 50%, rgba(0,100,255,0.25) 56%, rgba(150,0,255,0.25) 64%, transparent 80%);
+  background-size: 200% 200%;
+}
+.holo-overlay.active { opacity: var(--holo-intensity, 0.45); }
+.holo-overlay.auto-animate.active { animation: holo-shift var(--holo-speed, 3s) ease infinite; }
+@keyframes holo-shift {
+  0%, 100% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .holo-overlay {
+    opacity: calc(var(--holo-intensity, 0.45) * 0.4) !important;
+    animation: none !important;
+    background-position: 50% 50%;
+  }
+}
+`;


### PR DESCRIPTION
## Summary
- Replace static imports of `AuroraBackground`, `ParticleCanvas`, `GradientBorder`, and `HolographicOverlay` with `next/dynamic` imports (`ssr: false` + loading fallbacks) so only the active effect is loaded based on the badge config
- Extract CSS constants (`GRADIENT_BORDER_CSS`, `HOLOGRAPHIC_CSS`) to standalone lightweight modules to avoid pulling in component code when only CSS strings are needed
- Create standalone `ParticleCanvas` component file for clean dynamic import of the canvas-based particle system
- Keep `useTilt` (hook — must be called at top level), `glassStyle` (pure function), and `fireSingleBurst` (already lazy via internal `canvas-confetti` dynamic import) as static imports

Fixes #365

## Test plan
- [x] All 2230 tests pass (136 test files), including 11 new tests for dynamic import verification
- [x] TypeScript typecheck passes
- [x] ESLint lint passes
- [x] Pre-commit hooks pass (typecheck + lint + full test suite)
- [ ] Manual verification: Studio page renders correctly with all effect types (aurora, particles, gradient border, holographic, tilt, confetti)
- [ ] Manual verification: No visual regression when switching between effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)