### PR TITLE
refactor(db): replace unsafe type casts with runtime row validation

### DIFF
--- a/apps/web/lib/db/parse-row.test.ts
+++ b/apps/web/lib/db/parse-row.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import { parseRow, parseRows } from "./parse-row";
+
+// ---------------------------------------------------------------------------
+// parseRow — single-row runtime validation
+// ---------------------------------------------------------------------------
+
+describe("parseRow", () => {
+  const requiredKeys = ["name", "age"] as const;
+
+  it("returns the typed object when all required keys are present", () => {
+    const input = { name: "Alice", age: 30, extra: true };
+    const result = parseRow(input, requiredKeys);
+    expect(result).toEqual(input);
+  });
+
+  it("returns null when input is null", () => {
+    const result = parseRow(null, requiredKeys);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when input is undefined", () => {
+    const result = parseRow(undefined, requiredKeys);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when input is not an object", () => {
+    expect(parseRow("string", requiredKeys)).toBeNull();
+    expect(parseRow(42, requiredKeys)).toBeNull();
+    expect(parseRow(true, requiredKeys)).toBeNull();
+  });
+
+  it("returns null when a required key is missing", () => {
+    const input = { name: "Alice" }; // missing "age"
+    const result = parseRow(input, requiredKeys);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when a required key is undefined", () => {
+    const input = { name: "Alice", age: undefined };
+    const result = parseRow(input, requiredKeys);
+    expect(result).toBeNull();
+  });
+
+  it("allows null values for required keys (nullable columns)", () => {
+    const input = { name: "Alice", age: null };
+    const result = parseRow(input, requiredKeys);
+    expect(result).toEqual(input);
+  });
+
+  it("preserves extra keys not in the required list", () => {
+    const input = { name: "Alice", age: 30, email: "a@b.com" };
+    const result = parseRow(input, requiredKeys);
+    expect(result).toHaveProperty("email", "a@b.com");
+  });
+
+  it("works with an empty required keys list", () => {
+    const input = { foo: "bar" };
+    const result = parseRow(input, []);
+    expect(result).toEqual(input);
+  });
+
+  it("logs a warning on invalid row when label is provided", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    parseRow(null, requiredKeys, "TestTable");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[db] TestTable"),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("does not log when no label is provided", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    parseRow(null, requiredKeys);
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseRows — array validation
+// ---------------------------------------------------------------------------
+
+describe("parseRows", () => {
+  const requiredKeys = ["id", "value"] as const;
+
+  it("returns typed array when all rows are valid", () => {
+    const input = [
+      { id: 1, value: "a" },
+      { id: 2, value: "b" },
+    ];
+    const result = parseRows(input, requiredKeys);
+    expect(result).toEqual(input);
+    expect(result).toHaveLength(2);
+  });
+
+  it("returns empty array when input is null", () => {
+    expect(parseRows(null, requiredKeys)).toEqual([]);
+  });
+
+  it("returns empty array when input is undefined", () => {
+    expect(parseRows(undefined, requiredKeys)).toEqual([]);
+  });
+
+  it("filters out invalid rows (missing required keys)", () => {
+    const input = [
+      { id: 1, value: "a" },
+      { id: 2 }, // missing "value"
+      { id: 3, value: "c" },
+    ];
+    const result = parseRows(input, requiredKeys);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ id: 1, value: "a" });
+    expect(result[1]).toEqual({ id: 3, value: "c" });
+  });
+
+  it("filters out null entries in the array", () => {
+    const input = [{ id: 1, value: "a" }, null, { id: 2, value: "b" }];
+    const result = parseRows(input, requiredKeys);
+    expect(result).toHaveLength(2);
+  });
+
+  it("returns empty array when no rows are valid", () => {
+    const input = [{ id: 1 }, { value: "b" }]; // all missing a key
+    const result = parseRows(input, requiredKeys);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array for empty input array", () => {
+    expect(parseRows([], requiredKeys)).toEqual([]);
+  });
+});
+
+// Need vi for spyOn
+import { vi } from "vitest";

--- a/apps/web/lib/db/parse-row.ts
+++ b/apps/web/lib/db/parse-row.ts
@@ -1,0 +1,65 @@
+/**
+ * Runtime row validation for Supabase query results.
+ *
+ * Replaces unsafe `as unknown as RowType` casts with a runtime check
+ * that verifies required fields exist before returning a typed object.
+ * Returns null (single) or filters out invalid entries (array) instead
+ * of blindly trusting the shape of the data from the database.
+ */
+
+/**
+ * Validate that a value is a non-null object containing all required keys.
+ * Returns the value typed as T if valid, or null otherwise.
+ *
+ * Nullable column values (null) are allowed — only missing keys and
+ * undefined values are rejected, since those indicate a schema mismatch.
+ *
+ * @param value - The raw query result (unknown shape from Supabase)
+ * @param requiredKeys - Keys that must be present and not undefined
+ * @param label - Optional label for warning logs (e.g. table name)
+ */
+export function parseRow<T extends object>(
+  value: unknown,
+  requiredKeys: readonly (keyof T & string)[],
+  label?: string,
+): T | null {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    if (label) {
+      console.warn(`[db] ${label}: expected row object, got ${value === null ? "null" : typeof value}`);
+    }
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+
+  for (const key of requiredKeys) {
+    if (!(key in record) || record[key] === undefined) {
+      if (label) {
+        console.warn(`[db] ${label}: row missing required key "${key}"`);
+      }
+      return null;
+    }
+  }
+
+  return value as T;
+}
+
+/**
+ * Validate an array of rows, filtering out any that fail validation.
+ * Returns an empty array if the input is null/undefined.
+ *
+ * @param values - The raw array from Supabase (may contain nulls)
+ * @param requiredKeys - Keys that must be present on each valid row
+ * @param label - Optional label for warning logs
+ */
+export function parseRows<T extends object>(
+  values: unknown[] | null | undefined,
+  requiredKeys: readonly (keyof T & string)[],
+  label?: string,
+): T[] {
+  if (!values) return [];
+
+  return values
+    .map((v) => parseRow<T>(v, requiredKeys, label))
+    .filter((v): v is T => v !== null);
+}

--- a/apps/web/lib/db/snapshots.ts
+++ b/apps/web/lib/db/snapshots.ts
@@ -8,6 +8,7 @@
 
 import type { MetricsSnapshot } from "@/lib/history/types";
 import { getSupabase } from "./supabase";
+import { parseRow, parseRows } from "./parse-row";
 
 // ---------------------------------------------------------------------------
 // Row ↔ Type mapping
@@ -132,6 +133,35 @@ function snapshotToRow(
   };
 }
 
+/** Keys required on every SnapshotRow — used by parseRow for runtime validation. */
+const SNAPSHOT_REQUIRED_KEYS: readonly (keyof SnapshotRow)[] = [
+  "date",
+  "captured_at",
+  "commits_total",
+  "prs_merged_count",
+  "prs_merged_weight",
+  "reviews_submitted",
+  "issues_closed",
+  "repos_contributed",
+  "active_days",
+  "lines_added",
+  "lines_deleted",
+  "total_stars",
+  "total_forks",
+  "total_watchers",
+  "top_repo_share",
+  "building",
+  "guarding",
+  "consistency",
+  "breadth",
+  "archetype",
+  "profile_type",
+  "composite_score",
+  "adjusted_composite",
+  "confidence",
+  "tier",
+] as const;
+
 // Select clause for all snapshot columns (excludes id and handle)
 const SNAPSHOT_COLUMNS = [
   "date",
@@ -225,7 +255,7 @@ export async function dbGetSnapshots(
     const { data, error } = await query;
     if (error) throw error;
 
-    return (data ?? []).map((row) => rowToSnapshot(row as unknown as SnapshotRow));
+    return parseRows<SnapshotRow>(data, SNAPSHOT_REQUIRED_KEYS, "metrics_snapshots").map(rowToSnapshot);
   } catch (error) {
     console.error("[db] dbGetSnapshots failed:", (error as Error).message);
     return [];
@@ -254,7 +284,10 @@ export async function dbGetLatestSnapshot(
     if (error) throw error;
     if (!data) return null;
 
-    return rowToSnapshot(data as unknown as SnapshotRow);
+    const row = parseRow<SnapshotRow>(data, SNAPSHOT_REQUIRED_KEYS, "metrics_snapshots");
+    if (!row) return null;
+
+    return rowToSnapshot(row);
   } catch (error) {
     console.error(
       "[db] dbGetLatestSnapshot failed:",

--- a/apps/web/lib/db/users.ts
+++ b/apps/web/lib/db/users.ts
@@ -6,6 +6,21 @@
  */
 
 import { getSupabase } from "./supabase";
+import { parseRows } from "./parse-row";
+
+// ---------------------------------------------------------------------------
+// Row type
+// ---------------------------------------------------------------------------
+
+interface UserRow {
+  handle: string;
+  registered_at: string;
+}
+
+const USER_REQUIRED_KEYS: readonly (keyof UserRow)[] = [
+  "handle",
+  "registered_at",
+] as const;
 
 /**
  * Register a user (upsert — idempotent).
@@ -54,7 +69,7 @@ export async function dbGetUsers(
 
     if (error) throw error;
 
-    return (data ?? []).map((row) => ({
+    return parseRows<UserRow>(data, USER_REQUIRED_KEYS, "users").map((row) => ({
       handle: row.handle,
       registeredAt: row.registered_at,
     }));

--- a/apps/web/lib/db/verification.test.ts
+++ b/apps/web/lib/db/verification.test.ts
@@ -246,3 +246,34 @@ describe("dbCleanExpiredVerifications", () => {
     expect(result).toBe(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Runtime row validation (parseRow integration)
+// ---------------------------------------------------------------------------
+
+describe("runtime row validation", () => {
+  it("dbGetVerification returns null for a malformed row (missing required key)", async () => {
+    // Row missing the "tier" field
+    const incompleteRow: Record<string, unknown> = {
+      hash: "abc12345",
+      handle: "testuser",
+      display_name: "Test User",
+      adjusted_composite: 52,
+      confidence: 85,
+      archetype: "Builder",
+      profile_type: "collaborative",
+      building: 70,
+      guarding: 50,
+      consistency: 60,
+      breadth: 40,
+      commits_total: 200,
+      prs_merged_count: 30,
+      reviews_submitted: 50,
+      generated_at: "2025-06-15",
+    };
+    terminalResolve = { data: incompleteRow, error: null };
+
+    const result = await dbGetVerification("abc12345");
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Added `parseRow`/`parseRows` runtime validation helpers (`apps/web/lib/db/parse-row.ts`) that check Supabase query results for required fields before casting to typed interfaces
- Replaced all 3 `as unknown as RowType` casts in `snapshots.ts` and `verification.ts` with `parseRow`/`parseRows` calls that return `null` or filter out invalid rows instead of blindly trusting the data shape
- Added `UserRow` interface and `parseRows` validation to `users.ts` for consistency (previously accessed untyped Supabase results directly)
- Added 22 new tests: 18 unit tests for `parseRow`/`parseRows` and 4 integration tests verifying graceful handling of malformed DB rows

Fixes #367

## Test plan
- [x] All 2241 tests pass (up from 2219)
- [x] TypeScript typecheck passes
- [x] ESLint passes with zero warnings
- [x] Pre-commit hooks pass (typecheck + lint + tests)
- [x] Verified no `as unknown as` casts remain in `apps/web/lib/db/`
- [x] Verified malformed rows are handled gracefully (null return / array filtering) instead of runtime errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)