### PR TITLE
chore: shared package config + pnpm approve-builds (#393-#394)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
+      "core-js",
       "esbuild",
+      "protobufjs",
       "sharp",
       "unrs-resolver"
     ]

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -10,9 +10,8 @@
     "isolatedModules": true,
     "noUncheckedIndexedAccess": true,
     "declaration": true,
-    "declarationMap": true,
-    "outDir": "dist"
+    "declarationMap": true
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- Remove misleading `outDir: "dist"` from `packages/shared/tsconfig.json` — the shared package has no build step and is consumed via Next.js `transpilePackages`
- Add `core-js` and `protobufjs` to `pnpm.onlyBuiltDependencies` to suppress install warnings

## Test plan
- [x] `pnpm run test` — 2,268 tests pass
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm install` — no more "ignored build scripts" warning

Fixes #393, #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)