### PR TITLE
fix(a11y): enforce 44px touch targets and keyboard accessibility

### DIFF
--- a/apps/web/app/cli/authorize/page.tsx
+++ b/apps/web/app/cli/authorize/page.tsx
@@ -13,11 +13,16 @@ export default async function CliAuthorizePage({ searchParams }: Props) {
 
   if (!sessionId) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-bg">
-        <p className="text-terminal-red font-heading">
-          Missing session parameter. Run &quot;chapa login&quot; from your terminal.
-        </p>
-      </div>
+      <main className="flex min-h-screen items-center justify-center bg-bg px-6">
+        <div className="w-full max-w-md rounded-xl border border-stroke bg-card p-8">
+          <h1 className="font-heading text-xl font-bold text-text-primary mb-4">
+            Authorize Chapa CLI
+          </h1>
+          <p className="text-terminal-red font-heading text-sm">
+            Missing session parameter. Run &quot;chapa login&quot; from your terminal.
+          </p>
+        </div>
+      </main>
     );
   }
 

--- a/apps/web/components/AuthorTypewriter.tsx
+++ b/apps/web/components/AuthorTypewriter.tsx
@@ -157,6 +157,7 @@ export function AuthorTypewriter({ className }: AuthorTypewriterProps) {
     <div
       className={`group relative z-20 transition-opacity duration-500 ${className ?? ""}`}
       onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") e.stopPropagation(); }}
     >
       {/* Popover card — appears above the pill on hover */}
       {SOCIAL_LINKS.length > 0 && (

--- a/apps/web/components/CopyButton.tsx
+++ b/apps/web/components/CopyButton.tsx
@@ -17,7 +17,7 @@ export function CopyButton({ text }: { text: string }) {
     <button
       onClick={handleCopy}
       aria-label="Copy embed snippet"
-      className="p-2.5 rounded-lg text-text-secondary hover:text-amber transition-colors"
+      className="min-h-[44px] min-w-[44px] p-2.5 rounded-lg text-text-secondary hover:text-amber transition-colors"
     >
       <span aria-live="polite" className="sr-only">{copied ? "Copied!" : "Copy"}</span>
       {copied ? (

--- a/apps/web/components/ErrorBanner.tsx
+++ b/apps/web/components/ErrorBanner.tsx
@@ -43,7 +43,7 @@ export function ErrorBanner({ message }: ErrorBannerProps) {
       <button
         type="button"
         onClick={() => setDismissed(true)}
-        className="ml-2 flex-shrink-0 rounded-full p-1 text-amber/70 transition-colors hover:bg-amber/10 hover:text-amber"
+        className="ml-2 flex-shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center rounded-full p-1 text-amber/70 transition-colors hover:bg-amber/10 hover:text-amber"
         aria-label="Dismiss error"
       >
         <svg

--- a/apps/web/components/MobileNav.tsx
+++ b/apps/web/components/MobileNav.tsx
@@ -70,7 +70,7 @@ export function MobileNav({ links }: MobileNavProps) {
     <>
       <button
         type="button"
-        className="md:hidden flex items-center justify-center w-10 h-10 rounded-lg border border-stroke text-text-secondary transition-colors hover:text-text-primary hover:bg-amber/[0.06]"
+        className="md:hidden flex items-center justify-center w-11 h-11 rounded-lg border border-stroke text-text-secondary transition-colors hover:text-text-primary hover:bg-amber/[0.06]"
         aria-label="Toggle navigation"
         aria-controls="mobile-nav-panel"
         aria-expanded={open}

--- a/apps/web/components/ShortcutCheatSheet.tsx
+++ b/apps/web/components/ShortcutCheatSheet.tsx
@@ -100,7 +100,7 @@ export function ShortcutCheatSheet({ open, onClose }: ShortcutCheatSheetProps) {
           </h2>
           <button
             onClick={onClose}
-            className="rounded-lg p-1.5 text-text-secondary transition-colors hover:bg-amber/10 hover:text-text-primary"
+            className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg p-1.5 text-text-secondary transition-colors hover:bg-amber/10 hover:text-text-primary"
             aria-label="Close keyboard shortcuts"
           >
             <svg

--- a/apps/web/components/ThemeToggle.test.tsx
+++ b/apps/web/components/ThemeToggle.test.tsx
@@ -77,16 +77,17 @@ const THEME_TOGGLE_SOURCE = fs.readFileSync(
 );
 
 describe("ThemeToggle — mobile responsiveness (#240)", () => {
-  it("button uses h-10 w-10 for 40px touch target", () => {
-    expect(THEME_TOGGLE_SOURCE).toContain("h-10 w-10");
-    // Ensure the old smaller size is not used
+  it("button uses h-11 w-11 for 44px touch target (WCAG 2.5.8)", () => {
+    expect(THEME_TOGGLE_SOURCE).toContain("h-11 w-11");
+    // Ensure the old smaller sizes are not used
     expect(THEME_TOGGLE_SOURCE).not.toContain("h-8 w-8");
+    expect(THEME_TOGGLE_SOURCE).not.toContain("h-10 w-10");
   });
 
-  it("hydration placeholder also uses h-10 w-10", () => {
+  it("hydration placeholder also uses h-11 w-11", () => {
     // The placeholder div should match the button size to prevent layout shift
     const placeholderMatch = THEME_TOGGLE_SOURCE.match(
-      /className="h-10 w-10"[\s\S]*?aria-hidden="true"/,
+      /className="h-11 w-11"[\s\S]*?aria-hidden="true"/,
     );
     expect(placeholderMatch).not.toBeNull();
   });

--- a/apps/web/components/ThemeToggle.tsx
+++ b/apps/web/components/ThemeToggle.tsx
@@ -16,7 +16,7 @@ export function ThemeToggle() {
   const hydrated = useHydrated();
 
   if (!hydrated) {
-    return <div className="h-10 w-10" aria-hidden="true" />;
+    return <div className="h-11 w-11" aria-hidden="true" />;
   }
 
   const isDark = theme === "dark";
@@ -24,7 +24,7 @@ export function ThemeToggle() {
   return (
     <button
       onClick={() => setTheme(isDark ? "light" : "dark")}
-      className="flex h-10 w-10 items-center justify-center rounded-lg text-terminal-dim transition-colors hover:text-amber"
+      className="flex h-11 w-11 items-center justify-center rounded-lg text-terminal-dim transition-colors hover:text-amber"
       aria-label={isDark ? "Switch to light theme" : "Switch to dark theme"}
     >
       {isDark ? (


### PR DESCRIPTION
## Summary
- **CopyButton**, **ErrorBanner dismiss**, **ShortcutCheatSheet close**: add `min-h-[44px] min-w-[44px]` for WCAG 2.5.8 compliance
- **ThemeToggle** and **MobileNav hamburger**: bump `h-10`/`w-10` → `h-11`/`w-11` (44px)
- **AuthorTypewriter**: add `onKeyDown` handler for keyboard parity with `onClick`
- **CLI authorize error page**: add `<h1>` heading and consistent card layout
- Update ThemeToggle tests for new 44px size

Fixes #379, Fixes #380, Fixes #381, Fixes #382, Fixes #383, Fixes #384

## Test plan
- [x] All 2,268 tests pass
- [x] TypeScript compiles cleanly
- [x] ESLint passes
- [x] ThemeToggle test updated to assert `h-11 w-11`
- [ ] Visual check: buttons remain properly sized on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)