### PR TITLE
docs: fix stale CLAUDE.md entries (#534)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Chapa generates a **live, embeddable, animated SVG badge** that showcases a deve
 - GET `/api/verify/:hash` Badge verification endpoint
 - GET `/api/admin/users` Admin user list (session auth + admin check)
 - POST `/api/supplemental` Upload EMU supplemental stats (CLI)
-- POST `/api/studio/config` Save/load badge customization config
+- GET|PUT `/api/studio/config` Load/save badge customization config
 - POST `/api/refresh?handle=` Force refresh (rate-limited)
 - GET `/api/history/:handle` Score history, trend, and diff (public, rate-limited)
 


### PR DESCRIPTION
## Summary
- Fixed `/api/studio/config` route documentation: was `POST`, actual implementation exports `GET` + `PUT`
- Investigated "Quality Champion" vs "Guardian" archetype naming — confirmed "Quality Champion" is correct in CLAUDE.md (used in types, scoring, and all UI). "Guardian" is only a URL slug.

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] Full test suite passes (4,238 tests)

Fixes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)