### PR TITLE
perf(share): add ISR revalidation to share pages (#532)

### DIFF
--- a/apps/web/app/u/[handle]/page.test.ts
+++ b/apps/web/app/u/[handle]/page.test.ts
@@ -138,6 +138,13 @@ describe("SharePage", () => {
     });
   });
 
+  // #532 — ISR revalidation for share pages (cuts serverless invocations 80-90%)
+  describe("ISR revalidation", () => {
+    it("exports revalidate = 3600 for Incremental Static Regeneration", () => {
+      expect(SOURCE).toContain("export const revalidate = 3600");
+    });
+  });
+
   // Data Sources section — rendered before Impact Breakdown
   describe("data sources section", () => {
     it("imports DataSources component", () => {

--- a/apps/web/app/u/[handle]/page.tsx
+++ b/apps/web/app/u/[handle]/page.tsx
@@ -1,3 +1,5 @@
+export const revalidate = 3600;
+
 import { after } from "next/server";
 import { getStats } from "@/lib/github/client";
 import { computeImpactV4 } from "@/lib/impact/v4";


### PR DESCRIPTION
## Summary
- Add `export const revalidate = 3600` to `/u/[handle]/page.tsx` to enable ISR
- Matches existing pattern on `/`, `/about`, `/about/scoring`, `/about/verification`
- Cuts serverless invocations by 80-90% for cached share pages

## Test plan
- [x] New test verifies `revalidate = 3600` export exists
- [x] All 4239 tests pass
- [x] Typecheck and lint clean

Fixes #532