### PR TITLE
fix(auth): add AbortSignal timeout to BB/CB OAuth fetches (#535)

### DIFF
--- a/apps/web/lib/auth/bitbucket.test.ts
+++ b/apps/web/lib/auth/bitbucket.test.ts
@@ -432,6 +432,84 @@ describe("isTokenExpired", () => {
 });
 
 // ---------------------------------------------------------------------------
+// AbortSignal timeout on all fetch calls
+// ---------------------------------------------------------------------------
+
+describe("Bitbucket OAuth fetch AbortSignal timeout", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exchangeBitbucketCode passes an AbortSignal to fetch", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          access_token: "tok",
+          refresh_token: "ref",
+          expires_in: 7200,
+          token_type: "bearer",
+          scopes: "account",
+        }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await exchangeBitbucketCode("code", "cid", "csecret", "http://localhost:3001/cb");
+
+    const [, opts] = mockFetch.mock.calls[0]!;
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("refreshBitbucketToken passes an AbortSignal to fetch", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          access_token: "tok",
+          refresh_token: "ref",
+          expires_in: 7200,
+          token_type: "bearer",
+          scopes: "account",
+        }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await refreshBitbucketToken("refresh_tok", "cid", "csecret");
+
+    const [, opts] = mockFetch.mock.calls[0]!;
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("fetchBitbucketUser passes an AbortSignal to fetch", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          username: "bb-user",
+          display_name: "BB User",
+          links: { avatar: { href: "https://example.com/avatar.png" } },
+        }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fetchBitbucketUser("access_tok");
+
+    const [, opts] = mockFetch.mock.calls[0]!;
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("returns null when fetch aborts due to timeout", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new DOMException("signal timed out", "AbortError")),
+    );
+
+    const result = await exchangeBitbucketCode("code", "cid", "csecret", "http://localhost:3001/cb");
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Cookie Secure flag (conditional on HTTPS)
 // ---------------------------------------------------------------------------
 

--- a/apps/web/lib/auth/bitbucket.ts
+++ b/apps/web/lib/auth/bitbucket.ts
@@ -26,6 +26,9 @@ const BB_AUTHORIZE_URL = "https://bitbucket.org/site/oauth2/authorize";
 const BB_TOKEN_URL = "https://bitbucket.org/site/oauth2/access_token";
 const BB_API_URL = "https://api.bitbucket.org/2.0";
 
+/** 10-second timeout for all external OAuth fetches */
+const FETCH_TIMEOUT_MS = 10_000;
+
 /** 5-minute buffer before token expiry — refresh proactively */
 const TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
 
@@ -125,6 +128,7 @@ export async function exchangeBitbucketCode(
         Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString("base64")}`,
       },
       body,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
 
     if (!res.ok) return null;
@@ -161,6 +165,7 @@ export async function refreshBitbucketToken(
         Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString("base64")}`,
       },
       body,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
 
     if (!res.ok) return null;
@@ -187,6 +192,7 @@ export async function fetchBitbucketUser(
       headers: {
         Authorization: `Bearer ${accessToken}`,
       },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
     if (!res.ok) return null;
     const data = await res.json();

--- a/apps/web/lib/auth/codeberg.test.ts
+++ b/apps/web/lib/auth/codeberg.test.ts
@@ -387,6 +387,78 @@ describe("clearCodebergStateCookie", () => {
 });
 
 // ---------------------------------------------------------------------------
+// AbortSignal timeout on all fetch calls
+// ---------------------------------------------------------------------------
+
+describe("Codeberg OAuth fetch AbortSignal timeout", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exchangeCodebergCode passes an AbortSignal to fetch", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          access_token: "tok",
+          token_type: "bearer",
+        }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await exchangeCodebergCode("code", "cid", "csecret", "http://localhost:3001/cb");
+
+    const [, opts] = mockFetch.mock.calls[0]!;
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("refreshCodebergToken passes an AbortSignal to fetch", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          access_token: "tok",
+          token_type: "bearer",
+        }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await refreshCodebergToken("refresh_tok", "cid", "csecret");
+
+    const [, opts] = mockFetch.mock.calls[0]!;
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("fetchCodebergUser passes an AbortSignal to fetch", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          login: "cb-user",
+          full_name: "CB User",
+          avatar_url: "https://codeberg.org/avatars/12345",
+        }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fetchCodebergUser("access_tok");
+
+    const [, opts] = mockFetch.mock.calls[0]!;
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("returns null when fetch aborts due to timeout", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new DOMException("signal timed out", "AbortError")),
+    );
+
+    const result = await exchangeCodebergCode("code", "cid", "csecret", "http://localhost:3001/cb");
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Cookie Secure flag (conditional on HTTPS)
 // ---------------------------------------------------------------------------
 

--- a/apps/web/lib/auth/codeberg.ts
+++ b/apps/web/lib/auth/codeberg.ts
@@ -25,6 +25,9 @@ const CB_AUTHORIZE_URL = "https://codeberg.org/login/oauth/authorize";
 const CB_TOKEN_URL = "https://codeberg.org/login/oauth/access_token";
 const CB_API_URL = "https://codeberg.org/api/v1";
 
+/** 10-second timeout for all external OAuth fetches */
+const FETCH_TIMEOUT_MS = 10_000;
+
 // ---------------------------------------------------------------------------
 // OAuth URL
 // ---------------------------------------------------------------------------
@@ -120,6 +123,7 @@ export async function exchangeCodebergCode(
         grant_type: "authorization_code",
         redirect_uri: redirectUri,
       }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
 
     if (!res.ok) return null;
@@ -156,6 +160,7 @@ export async function refreshCodebergToken(
         grant_type: "refresh_token",
         refresh_token: refreshToken,
       }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
 
     if (!res.ok) return null;
@@ -183,6 +188,7 @@ export async function fetchCodebergUser(
       headers: {
         Authorization: `token ${accessToken}`,
       },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
     if (!res.ok) return null;
     const data = await res.json();


### PR DESCRIPTION
## Summary
- Add `signal: AbortSignal.timeout(10_000)` to all 6 fetch calls in `lib/auth/bitbucket.ts` and `lib/auth/codeberg.ts`
- Prevents hanging when Bitbucket/Codeberg OAuth endpoints are slow or unreachable
- Follows existing pattern from `lib/github/queries.ts` (`AbortSignal.timeout(15_000)`)

## Test plan
- [x] 8 new tests verify AbortSignal is passed to every fetch call
- [x] Timeout abort errors caught by existing error handling
- [x] All 4246 tests pass
- [x] Typecheck and lint clean

Fixes #535