### PR TITLE
fix(og-image): add timeout guard to svgToPng (#537)

### DIFF
--- a/apps/web/app/u/[handle]/og-image/route.test.ts
+++ b/apps/web/app/u/[handle]/og-image/route.test.ts
@@ -277,5 +277,37 @@ describe("GET /u/[handle]/og-image", () => {
 
       consoleSpy.mockRestore();
     });
+
+    it("returns 504 when svgToPng exceeds the timeout", async () => {
+      // Silence expected console.error from the timeout error path
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      // Simulate a svgToPng call that never resolves within the timeout
+      mockSvgToPng.mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 30_000)),
+      );
+
+      const [req, ctx] = makeRequest("testuser");
+
+      // Advance timers past the 10s timeout
+      const responsePromise = GET(req, ctx);
+      await vi.advanceTimersByTimeAsync(10_001);
+      const res = await responsePromise;
+
+      expect(res.status).toBe(504);
+      const body = await res.text();
+      expect(body).toContain("timed out");
+
+      consoleSpy.mockRestore();
+    });
+
+    it("returns PNG successfully when svgToPng completes within timeout", async () => {
+      // Ensure the timeout guard doesn't interfere with normal fast responses
+      mockSvgToPng.mockReturnValue(FAKE_PNG);
+      const [req, ctx] = makeRequest("testuser");
+      const res = await GET(req, ctx);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toBe("image/png");
+    });
   });
 });

--- a/apps/web/app/u/[handle]/og-image/route.ts
+++ b/apps/web/app/u/[handle]/og-image/route.ts
@@ -10,6 +10,14 @@ import { cacheGet, cacheSet } from "@/lib/cache/redis";
 import { toDateString } from "@/lib/utils/date";
 
 const OG_CACHE_TTL = 86400; // 24 hours
+const SVG_TO_PNG_TIMEOUT_MS = 10_000; // 10 seconds
+
+class SvgToPngTimeoutError extends Error {
+  constructor() {
+    super("svgToPng timed out");
+    this.name = "SvgToPngTimeoutError";
+  }
+}
 
 /**
  * GET /u/:handle/og-image
@@ -70,7 +78,12 @@ export async function GET(
       verificationDate: verification?.date,
     });
 
-    const png = svgToPng(svg, 1200);
+    const png = await Promise.race([
+      Promise.resolve().then(() => svgToPng(svg, 1200)),
+      new Promise<never>((_resolve, reject) =>
+        setTimeout(() => reject(new SvgToPngTimeoutError()), SVG_TO_PNG_TIMEOUT_MS),
+      ),
+    ]);
 
     // Cache the PNG as base64 for 24h (fire-and-forget — don't block response)
     cacheSet(ogCacheKey, Buffer.from(png).toString("base64"), OG_CACHE_TTL).catch(() => {});
@@ -83,6 +96,10 @@ export async function GET(
       },
     });
   } catch (e) {
+    if (e instanceof SvgToPngTimeoutError) {
+      console.error("[og-image] svgToPng timed out after 10s");
+      return new NextResponse("PNG conversion timed out", { status: 504 });
+    }
     console.error("[og-image] failed to generate badge PNG:", e);
     return new NextResponse("Failed to generate image", { status: 500 });
   }


### PR DESCRIPTION
## Summary
- Wrap `svgToPng()` in `Promise.race` with a 10-second timeout guard
- Returns 504 (Gateway Timeout) with descriptive message on timeout
- Non-timeout errors continue to return 500

## Test plan
- [x] Timeout test: mock svgToPng to never resolve, advance timers past 10s, assert 504
- [x] Normal test: mock svgToPng returning immediately, assert 200 with PNG
- [x] All 4240 tests pass
- [x] Typecheck and lint clean

Fixes #537