### PR TITLE
chore(db): add merge_operations retention policy (#538)

### DIFF
--- a/apps/web/app/api/cron/warm-cache/route.test.ts
+++ b/apps/web/app/api/cron/warm-cache/route.test.ts
@@ -41,6 +41,10 @@ vi.mock("@/lib/db/verification", () => ({
   dbCleanExpiredVerifications: vi.fn(() => Promise.resolve(0)),
 }));
 
+vi.mock("@/lib/db/telemetry", () => ({
+  dbCleanExpiredMergeOperations: vi.fn(() => Promise.resolve(0)),
+}));
+
 vi.mock("@/lib/cache/snapshot-cache", () => ({
   updateSnapshotCache: vi.fn(() => Promise.resolve()),
 }));
@@ -74,6 +78,7 @@ import {
 } from "@/lib/db/snapshots";
 import { getStats } from "@/lib/github/client";
 import { dbCleanExpiredVerifications } from "@/lib/db/verification";
+import { dbCleanExpiredMergeOperations } from "@/lib/db/telemetry";
 import { compareSnapshots } from "@/lib/history/diff";
 import { isSignificantChange } from "@/lib/history/significant-change";
 import { notifyScoreBump } from "@/lib/email/score-bump";
@@ -681,6 +686,41 @@ describe("GET /api/cron/warm-cache", () => {
 
       expect(body.rotation.coversAll).toBe(true);
       expect(body.rotation.totalUsers).toBe(30);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Merge operations cleanup
+  // ---------------------------------------------------------------------------
+
+  describe("merge operations cleanup", () => {
+    it("calls dbCleanExpiredMergeOperations", async () => {
+      mockedDbGetUsers.mockResolvedValue([]);
+
+      await GET(makeRequest("test-cron-secret"));
+
+      expect(vi.mocked(dbCleanExpiredMergeOperations)).toHaveBeenCalled();
+    });
+
+    it("includes expiredMergeOpsDeleted in response", async () => {
+      mockedDbGetUsers.mockResolvedValue([]);
+      vi.mocked(dbCleanExpiredMergeOperations).mockResolvedValue(42);
+
+      const res = await GET(makeRequest("test-cron-secret"));
+      const body = await res.json();
+
+      expect(body.expiredMergeOpsDeleted).toBe(42);
+    });
+
+    it("does not fail if merge ops cleanup throws", async () => {
+      mockedDbGetUsers.mockResolvedValue([]);
+      vi.mocked(dbCleanExpiredMergeOperations).mockRejectedValue(
+        new Error("Supabase down"),
+      );
+
+      const res = await GET(makeRequest("test-cron-secret"));
+
+      expect(res.status).toBe(200);
     });
   });
 });

--- a/apps/web/app/api/cron/warm-cache/route.ts
+++ b/apps/web/app/api/cron/warm-cache/route.ts
@@ -13,6 +13,7 @@ import { compareSnapshots } from "@/lib/history/diff";
 import { isSignificantChange } from "@/lib/history/significant-change";
 import { notifyScoreBump } from "@/lib/email/score-bump";
 import { dbCleanExpiredVerifications } from "@/lib/db/verification";
+import { dbCleanExpiredMergeOperations } from "@/lib/db/telemetry";
 import { cacheGet, cacheSet } from "@/lib/cache/redis";
 
 /** Vercel Pro allows up to 300s for serverless functions. */
@@ -157,6 +158,14 @@ export async function GET(request: NextRequest) {
     // Non-critical — don't fail the cron response
   }
 
+  // Clean merge_operations rows older than 90 days (fire-and-forget safe)
+  let expiredMergeOpsDeleted = 0;
+  try {
+    expiredMergeOpsDeleted = await dbCleanExpiredMergeOperations();
+  } catch {
+    // Non-critical — don't fail the cron response
+  }
+
   return NextResponse.json(
     {
       warmed,
@@ -164,6 +173,7 @@ export async function GET(request: NextRequest) {
       snapshots,
       notifications,
       expiredVerificationsDeleted,
+      expiredMergeOpsDeleted,
       total: toWarm.length,
       handles: toWarm,
       rotation: {

--- a/apps/web/lib/db/telemetry.test.ts
+++ b/apps/web/lib/db/telemetry.test.ts
@@ -1,21 +1,62 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ---------------------------------------------------------------------------
-// Mock Supabase client
+// Mock Supabase client — tracks arguments for all chain methods
 // ---------------------------------------------------------------------------
 
 const mockInsert = vi.fn();
-const mockFrom = vi.fn(() => ({ insert: mockInsert }));
+const mockDelete = vi.fn();
+const mockSelect = vi.fn();
+const mockLt = vi.fn();
+const mockLimit = vi.fn();
+
+let terminalResolve: { data: unknown; error: unknown };
 
 const { mockGetSupabase } = vi.hoisted(() => ({
   mockGetSupabase: vi.fn(),
 }));
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockFrom = vi.fn((): any => {
+  const chain: Record<string, unknown> = {};
+  chain.insert = mockInsert;
+  chain.select = (...args: unknown[]) => {
+    mockSelect(...args);
+    return chain;
+  };
+  chain.lt = (...args: unknown[]) => {
+    mockLt(...args);
+    return chain;
+  };
+  chain.limit = (...args: unknown[]) => {
+    mockLimit(...args);
+    return chain;
+  };
+  chain.delete = () => {
+    mockDelete();
+    return chain;
+  };
+  // Terminal .then for delete().lt().limit().select() chain
+  chain.then = (
+    resolve: (v: unknown) => void,
+    reject: (e: unknown) => void,
+  ) => {
+    if (terminalResolve.error) reject(terminalResolve.error);
+    else resolve(terminalResolve);
+  };
+  return chain;
+});
+
 vi.mock("./supabase", () => ({
   getSupabase: mockGetSupabase,
 }));
 
-import { dbInsertTelemetry } from "./telemetry";
+import {
+  dbInsertTelemetry,
+  dbCleanExpiredMergeOperations,
+  MERGE_OPS_RETENTION_DAYS,
+  MERGE_OPS_CLEANUP_BATCH_SIZE,
+} from "./telemetry";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -42,12 +83,13 @@ const validPayload = {
 };
 
 // ---------------------------------------------------------------------------
-// Tests
+// Tests — dbInsertTelemetry
 // ---------------------------------------------------------------------------
 
 describe("dbInsertTelemetry", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    terminalResolve = { data: null, error: null };
   });
 
   it("returns false when Supabase is unavailable", async () => {
@@ -128,5 +170,117 @@ describe("dbInsertTelemetry", () => {
     expect(mockInsert).toHaveBeenCalledWith(
       expect.objectContaining({ target_handle: "juan294" }),
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — dbCleanExpiredMergeOperations
+// ---------------------------------------------------------------------------
+
+describe("dbCleanExpiredMergeOperations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    terminalResolve = { data: null, error: null };
+  });
+
+  it("exports MERGE_OPS_RETENTION_DAYS as 90", () => {
+    expect(MERGE_OPS_RETENTION_DAYS).toBe(90);
+  });
+
+  it("exports MERGE_OPS_CLEANUP_BATCH_SIZE as 1000", () => {
+    expect(MERGE_OPS_CLEANUP_BATCH_SIZE).toBe(1000);
+  });
+
+  it("returns count of deleted rows", async () => {
+    terminalResolve = { data: [{ id: 1 }, { id: 2 }, { id: 3 }], error: null };
+    mockGetSupabase.mockReturnValue({ from: mockFrom });
+
+    const result = await dbCleanExpiredMergeOperations();
+
+    expect(result).toBe(3);
+    expect(mockFrom).toHaveBeenCalledWith("merge_operations");
+    expect(mockDelete).toHaveBeenCalled();
+  });
+
+  it("filters rows older than 90 days using .lt(created_at, ...)", async () => {
+    terminalResolve = { data: [], error: null };
+    mockGetSupabase.mockReturnValue({ from: mockFrom });
+
+    await dbCleanExpiredMergeOperations();
+
+    expect(mockLt).toHaveBeenCalledWith(
+      "created_at",
+      expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+    );
+
+    // Verify the cutoff date is approximately 90 days ago
+    const cutoffArg = mockLt.mock.calls[0]![1] as string;
+    const cutoffDate = new Date(cutoffArg);
+    const expectedCutoff = new Date();
+    expectedCutoff.setDate(expectedCutoff.getDate() - 90);
+    // Allow 5 seconds of drift for test execution time
+    expect(Math.abs(cutoffDate.getTime() - expectedCutoff.getTime())).toBeLessThan(5000);
+  });
+
+  it("applies MERGE_OPS_CLEANUP_BATCH_SIZE limit", async () => {
+    terminalResolve = { data: [], error: null };
+    mockGetSupabase.mockReturnValue({ from: mockFrom });
+
+    await dbCleanExpiredMergeOperations();
+
+    expect(mockLimit).toHaveBeenCalledWith(MERGE_OPS_CLEANUP_BATCH_SIZE);
+  });
+
+  it("selects id column to get deleted count", async () => {
+    terminalResolve = { data: [], error: null };
+    mockGetSupabase.mockReturnValue({ from: mockFrom });
+
+    await dbCleanExpiredMergeOperations();
+
+    expect(mockSelect).toHaveBeenCalledWith("id");
+  });
+
+  it("returns 0 when Supabase is unavailable", async () => {
+    mockGetSupabase.mockReturnValue(null);
+
+    const result = await dbCleanExpiredMergeOperations();
+
+    expect(result).toBe(0);
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("returns 0 on Supabase error without throwing (fail-open)", async () => {
+    terminalResolve = { data: null, error: new Error("delete failed") };
+    mockGetSupabase.mockReturnValue({ from: mockFrom });
+
+    const result = await dbCleanExpiredMergeOperations();
+
+    expect(result).toBe(0);
+  });
+
+  it("returns 0 when data is null (no rows deleted)", async () => {
+    terminalResolve = { data: null, error: null };
+    mockGetSupabase.mockReturnValue({ from: mockFrom });
+
+    const result = await dbCleanExpiredMergeOperations();
+
+    expect(result).toBe(0);
+  });
+
+  it("does not delete recent rows (cutoff is 90 days, not more)", async () => {
+    terminalResolve = { data: [], error: null };
+    mockGetSupabase.mockReturnValue({ from: mockFrom });
+
+    await dbCleanExpiredMergeOperations();
+
+    // The .lt() filter ensures only rows with created_at < cutoff are deleted.
+    // Rows created within the last 90 days have created_at >= cutoff, so they
+    // won't match the filter. We verify the cutoff is exactly 90 days ago.
+    const cutoffArg = mockLt.mock.calls[0]![1] as string;
+    const cutoffDate = new Date(cutoffArg);
+    const now = new Date();
+    const diffDays = (now.getTime() - cutoffDate.getTime()) / (1000 * 60 * 60 * 24);
+    expect(diffDays).toBeGreaterThanOrEqual(89.9);
+    expect(diffDays).toBeLessThanOrEqual(90.1);
   });
 });

--- a/apps/web/lib/db/telemetry.ts
+++ b/apps/web/lib/db/telemetry.ts
@@ -1,10 +1,17 @@
 /**
  * Supabase data access — merge_operations table.
  *
- * Stores CLI merge telemetry data. Fail-open: returns false on error, never throws.
+ * Stores CLI merge telemetry data and provides retention cleanup.
+ * Fail-open: returns false/0 on error, never throws.
  */
 
 import { getSupabase } from "./supabase";
+
+/** Rows older than this many days are eligible for cleanup. */
+export const MERGE_OPS_RETENTION_DAYS = 90;
+
+/** Max rows deleted per cleanup run to avoid locking the table. */
+export const MERGE_OPS_CLEANUP_BATCH_SIZE = 1000;
 
 export interface TelemetryPayload {
   operationId: string;
@@ -63,5 +70,36 @@ export async function dbInsertTelemetry(payload: TelemetryPayload): Promise<bool
   } catch (error) {
     console.error("[db] dbInsertTelemetry failed:", (error as Error).message);
     return false;
+  }
+}
+
+/**
+ * Delete merge_operations rows older than MERGE_OPS_RETENTION_DAYS (90 days).
+ * Batched to avoid table locks. Intended to be called from cron (warm-cache).
+ * Returns the number of deleted rows, or 0 on error (fail-open).
+ */
+export async function dbCleanExpiredMergeOperations(): Promise<number> {
+  const db = getSupabase();
+  if (!db) return 0;
+
+  try {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - MERGE_OPS_RETENTION_DAYS);
+
+    const { data, error } = await db
+      .from("merge_operations")
+      .delete()
+      .lt("created_at", cutoff.toISOString())
+      .limit(MERGE_OPS_CLEANUP_BATCH_SIZE)
+      .select("id");
+
+    if (error) throw error;
+    return data?.length ?? 0;
+  } catch (error) {
+    console.error(
+      "[db] dbCleanExpiredMergeOperations failed:",
+      (error as Error).message,
+    );
+    return 0;
   }
 }


### PR DESCRIPTION
## Summary
- Add `dbCleanExpiredMergeOperations()` to delete rows older than 90 days (batch limit: 1000)
- Piggyback on existing warm-cache cron (fire-and-forget, non-blocking)
- Follows same pattern as `dbCleanExpiredVerifications()`
- Response includes `expiredMergeOpsDeleted` count

## Test plan
- [x] 10 new tests for cleanup function (retention, batch limit, fail-open, recent rows preserved)
- [x] 3 new tests for cron integration
- [x] All 4251 tests pass
- [x] Typecheck and lint clean

Fixes #538