### PR TITLE
fix(a11y): add main-content id to experiment pages (#541)

### DIFF
--- a/apps/web/app/experiments/aurora/page.tsx
+++ b/apps/web/app/experiments/aurora/page.tsx
@@ -170,7 +170,7 @@ export default function AuroraExperimentPage() {
   const [speed, setSpeed] = useState<Speed>("medium");
 
   return (
-    <div className="relative min-h-screen bg-bg">
+    <div id="main-content" className="relative min-h-screen bg-bg">
       {/* Aurora effect — always behind everything */}
       <AuroraBackground
         intensity={intensity}

--- a/apps/web/app/experiments/confetti/page.tsx
+++ b/apps/web/app/experiments/confetti/page.tsx
@@ -106,7 +106,7 @@ export default function ConfettiExperimentPage() {
   }, [particleCount, palette, speed]);
 
   return (
-    <div className="min-h-screen bg-bg bg-grid-warm">
+    <div id="main-content" className="min-h-screen bg-bg bg-grid-warm">
       <style>{getBadgeContentCSS({}).join("\n")}</style>
       {/* Ambient glow */}
       <div

--- a/apps/web/app/experiments/gradient-border/page.tsx
+++ b/apps/web/app/experiments/gradient-border/page.tsx
@@ -171,7 +171,7 @@ export default function GradientBorderExperiment() {
         }}
       />
 
-      <main className="min-h-screen bg-bg bg-grid-warm">
+      <main id="main-content" className="min-h-screen bg-bg bg-grid-warm">
         {/* Ambient glow */}
         <div
           className="pointer-events-none fixed inset-0 overflow-hidden"

--- a/apps/web/app/experiments/heatmap-wave/page.tsx
+++ b/apps/web/app/experiments/heatmap-wave/page.tsx
@@ -31,7 +31,7 @@ export default function HeatmapWavePage() {
   }, []);
 
   return (
-    <main className="min-h-screen bg-bg bg-grid-warm">
+    <main id="main-content" className="min-h-screen bg-bg bg-grid-warm">
       {/* Ambient glow */}
       <div
         className="pointer-events-none fixed left-1/2 top-1/4 -translate-x-1/2 -translate-y-1/2 rounded-full bg-amber/[0.04] blur-[150px]"

--- a/apps/web/app/experiments/hexmap/page.tsx
+++ b/apps/web/app/experiments/hexmap/page.tsx
@@ -513,7 +513,7 @@ export default function HexmapExperimentPage() {
   }, []);
 
   return (
-    <main className="min-h-screen bg-bg bg-grid-warm">
+    <main id="main-content" className="min-h-screen bg-bg bg-grid-warm">
       <div className="relative mx-auto max-w-6xl px-6 py-20">
         {/* ── Header ─────────────────────────────────────────── */}
         <p className="mb-4 text-sm font-medium tracking-widest uppercase text-amber">

--- a/apps/web/app/experiments/holographic/page.tsx
+++ b/apps/web/app/experiments/holographic/page.tsx
@@ -330,7 +330,7 @@ export default function HolographicExperimentPage() {
         }
       `}</style>
 
-      <div className="min-h-screen bg-bg px-6 py-16">
+      <div id="main-content" className="min-h-screen bg-bg px-6 py-16">
         <div className="mx-auto max-w-5xl">
           {/* Page header */}
           <header className="mb-4">

--- a/apps/web/app/experiments/metallic-shimmer/page.tsx
+++ b/apps/web/app/experiments/metallic-shimmer/page.tsx
@@ -28,7 +28,7 @@ export default function MetallicShimmerPage() {
   const highlightColor = `rgba(246, 242, 192, ${intensity / 100})`;
 
   return (
-    <main className="min-h-screen bg-bg bg-grid-warm">
+    <main id="main-content" className="min-h-screen bg-bg bg-grid-warm">
       {/* Ambient glow */}
       <div
         className="pointer-events-none fixed left-1/2 top-1/4 -translate-x-1/2 -translate-y-1/2 rounded-full bg-amber/[0.04] blur-[150px]"

--- a/apps/web/app/experiments/number-counters/page.tsx
+++ b/apps/web/app/experiments/number-counters/page.tsx
@@ -589,7 +589,7 @@ export default function NumberCountersPage() {
   }, []);
 
   return (
-    <div className="relative min-h-screen bg-bg">
+    <div id="main-content" className="relative min-h-screen bg-bg">
       {/* Ambient glow */}
       <div className="pointer-events-none fixed inset-0 overflow-hidden">
         <div className="absolute -top-40 left-1/4 h-[500px] w-[500px] rounded-full bg-amber/[0.03] blur-[150px]" />

--- a/apps/web/app/experiments/particles/page.tsx
+++ b/apps/web/app/experiments/particles/page.tsx
@@ -649,7 +649,7 @@ const INTERACTIVE_CONFIG: ParticleConfig = {
 
 export default function ParticlesExperimentPage() {
   return (
-    <div className="min-h-screen bg-bg">
+    <div id="main-content" className="min-h-screen bg-bg">
       <style>{getBadgeContentCSS({}).join("\n")}</style>
       {/* Ambient glow */}
       <div

--- a/apps/web/app/experiments/skip-link.test.ts
+++ b/apps/web/app/experiments/skip-link.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/**
+ * The skip-to-content link in the global layout targets `#main-content`.
+ * Every experiment page must have exactly one element with `id="main-content"`
+ * on its outermost content wrapper so the skip link lands correctly.
+ */
+
+const EXPERIMENTS_DIR = path.resolve(__dirname);
+
+const experimentDirs = fs
+  .readdirSync(EXPERIMENTS_DIR, { withFileTypes: true })
+  .filter((d) => d.isDirectory() && !d.name.startsWith("_"))
+  .map((d) => d.name);
+
+describe("experiment pages skip-link target", () => {
+  it.each(experimentDirs)(
+    "%s/page.tsx contains id=\"main-content\"",
+    (dir) => {
+      const pagePath = path.join(EXPERIMENTS_DIR, dir, "page.tsx");
+      expect(
+        fs.existsSync(pagePath),
+        `${dir}/page.tsx should exist`,
+      ).toBe(true);
+
+      const source = fs.readFileSync(pagePath, "utf-8");
+      expect(
+        source,
+        `${dir}/page.tsx must include id="main-content" on its content wrapper`,
+      ).toContain('id="main-content"');
+    },
+  );
+
+  it("has at least 10 experiment pages", () => {
+    // Guard against accidentally deleting experiments and having a vacuous test
+    expect(experimentDirs.length).toBeGreaterThanOrEqual(10);
+  });
+});

--- a/apps/web/app/experiments/text-effects/page.tsx
+++ b/apps/web/app/experiments/text-effects/page.tsx
@@ -496,7 +496,7 @@ export default function TextEffectsExperimentPage() {
         }
       `}</style>
 
-      <div className="min-h-screen bg-bg bg-grid-warm">
+      <div id="main-content" className="min-h-screen bg-bg bg-grid-warm">
         {/* Ambient glow */}
         <div
           className="pointer-events-none fixed top-1/4 left-1/3 h-[500px] w-[500px] rounded-full bg-amber/[0.03] blur-[150px]"

--- a/apps/web/app/experiments/tier-visuals/page.tsx
+++ b/apps/web/app/experiments/tier-visuals/page.tsx
@@ -735,7 +735,7 @@ export default function TierVisualsExperimentPage() {
         }}
       />
 
-      <div className="min-h-screen bg-bg bg-grid-warm">
+      <div id="main-content" className="min-h-screen bg-bg bg-grid-warm">
         {/* Ambient glow */}
         <div className="pointer-events-none fixed inset-0 overflow-hidden" aria-hidden="true">
           <div className="absolute top-1/4 -left-32 h-[500px] w-[500px] rounded-full bg-amber/[0.03] blur-[150px]" />


### PR DESCRIPTION
## Summary
- Add `id="main-content"` to the outermost content wrapper on all 11 experiment pages
- Skip-to-content link now works on all experiment pages
- Added regression test verifying all experiment pages include the target

## Test plan
- [x] New test verifies all 13 experiment pages have `id="main-content"`
- [x] All 4252 tests pass
- [x] Typecheck and lint clean

Fixes #541