### PR TITLE
release: v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Campaign type system: `announcement` (manual blast) vs `engagement` (automated score-bump template)
+- Send test email endpoint for campaign drafts (`POST /api/admin/campaigns/:id/test`)
+- BIMI logo for email branding (`apps/web/public/bimi.svg`)
+- `microCommitRatio` metric: fraction of merged PRs with < 10 lines changed (`MICRO_PR_LINE_THRESHOLD`)
+- `MICRO_PR_LINE_THRESHOLD` constant extracted to `packages/shared/src/constants.ts`
+- `dev` and `developer` added to `DEFAULT_BRANCH_NAMES` for accurate feature branch detection
+- 57 new tests (html-helpers, error boundaries, campaign a11y, experiment landmarks)
+
+### Changed
+- `low_activity_signal` confidence penalty: AND → OR (triggers on either low days or low commits)
+- Score-bump notification threshold raised from 5 to 10 points (`SCORE_BUMP_THRESHOLD`)
+- Email templates: improved subject lines (show delta/tier), multi-paragraph body support, shared `featureRow()` helper
+- Next.js updated to 16.2.1
+- Dev dependencies updated: vitest 4.1.0, jsdom 29.0.1
+
+### Fixed
+- Campaign template placeholder interpolation (ctaUrl, ctaText, features array, engagement fields)
+- Email feature bullet spacing
+- Campaign form a11y: added `htmlFor`/`id` label associations and `aria-label` on remove buttons
+- 7 experiment pages: changed `<div>` to `<main>` for proper landmark semantics
+- Suppressed expected stderr noise in error-handling tests
+
 ## [2.0.0] - 2026-03-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.1.0] - 2026-03-22
 
 ### Added
 - Campaign type system: `announcement` (manual blast) vs `engagement` (automated score-bump template)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Chapa generates a **live, embeddable, animated SVG badge** that showcases a deve
 
 ## Goals
 1. GitHub OAuth login (for "Verified" mode + better API limits).
-2. Compute **Impact v4 Profile** from last 12 months (365 days):
+2. Compute **Impact v6 Profile** from last 12 months (365 days):
    - 4 core dimensions (Delivery, Quality, Consistency, Breadth) + optional 5th (Craft), each 0–100
    - developer archetype (Builder, Quality Champion, Marathoner, Polymath, Artificer, Balanced, Emerging)
      - Note: "Quality Champion" is the display name; internal code/routes use "guardian" (e.g., `/archetypes/guardian`, `--color-archetype-guardian`)
@@ -390,7 +390,7 @@ const token = process.env.GITHUB_CLIENT_SECRET?.trim();
 3. **Escape user input in SVG** — Any user-controlled text (handle, display name) must be escaped before rendering into SVG markup. This prevents XSS in embeddable badges.
 4. **Health endpoint** — `/api/health` should exist for monitoring. Don't break it.
 5. **No dead code** — Remove unused exports, imports, and files. Clean as you go.
-6. **Pure functions for scoring** — Impact v4 compute and normalization must be pure functions with deterministic output for a given input. This makes them trivially testable.
+6. **Pure functions for scoring** — Impact v6 compute and normalization must be pure functions with deterministic output for a given input. This makes them trivially testable.
 
 ## Issues & Contributing
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ An internal **confidence score** (50–100) reflects data completeness and gentl
 | Email | Resend |
 | CLI | Node.js, tsup, device auth flow |
 | Hosting | Vercel |
-| Testing | Vitest, 330+ test files, 5,680+ tests, TDD workflow |
+| Testing | Vitest, 337+ test files, 5,760+ tests, TDD workflow |
 
 ## Environment Variables
 

--- a/apps/web/app/about/scoring/page.tsx
+++ b/apps/web/app/about/scoring/page.tsx
@@ -550,7 +550,7 @@ export default function ScoringMethodologyPage() {
                 [
                   "Low activity signal",
                   "-10",
-                  "Fewer than 30 active days AND fewer than 50 commits",
+                  "Fewer than 30 active days OR fewer than 50 commits",
                   "Very limited activity reduces the signal available for scoring",
                 ],
                 [

--- a/apps/web/app/admin/campaigns/campaigns-dashboard.test.tsx
+++ b/apps/web/app/admin/campaigns/campaigns-dashboard.test.tsx
@@ -13,6 +13,7 @@ afterEach(cleanup);
 const mockCampaigns: Campaign[] = [
   {
     id: "c-1",
+    type: "announcement",
     name: "March Update",
     status: "draft",
     subject: "What's new",
@@ -31,6 +32,7 @@ const mockCampaigns: Campaign[] = [
   },
   {
     id: "c-2",
+    type: "announcement",
     name: "April Update",
     status: "sending",
     subject: "More updates",
@@ -51,6 +53,7 @@ const mockCampaigns: Campaign[] = [
 
 const sentCampaign: Campaign = {
   id: "c-3",
+  type: "announcement",
   name: "Sent Campaign",
   status: "sent",
   subject: "Old news",

--- a/apps/web/app/admin/campaigns/campaigns-dashboard.test.tsx
+++ b/apps/web/app/admin/campaigns/campaigns-dashboard.test.tsx
@@ -853,3 +853,79 @@ describe("CampaignsDashboard — edge cases", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// ACCESSIBILITY — label associations & aria-labels
+// ---------------------------------------------------------------------------
+
+describe("CampaignsDashboard — a11y label associations", () => {
+  it("create form inputs are associated with labels via htmlFor/id", async () => {
+    render(<CampaignsDashboard />);
+    await waitFor(() => {
+      expect(screen.getByText("New Campaign")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText("New Campaign"));
+
+    // All form fields should be findable by their label text
+    expect(screen.getByLabelText("Campaign Name")).toBeTruthy();
+    expect(screen.getByLabelText("Email Subject")).toBeTruthy();
+    expect(screen.getByLabelText(/Preview Text/)).toBeTruthy();
+    expect(screen.getByLabelText("Headline")).toBeTruthy();
+    expect(screen.getByLabelText("Body")).toBeTruthy();
+    expect(screen.getByLabelText("CTA Button Text")).toBeTruthy();
+    expect(screen.getByLabelText("CTA URL")).toBeTruthy();
+  });
+
+  it("edit form inputs are associated with labels via htmlFor/id", async () => {
+    render(<CampaignsDashboard />);
+    await waitFor(() => {
+      expect(screen.getByText("March Update")).toBeTruthy();
+    });
+
+    // Open detail, then edit
+    fireEvent.click(screen.getByText("March Update"));
+    await waitFor(() => {
+      expect(screen.getByText("Edit Draft")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByText("Edit Draft"));
+
+    expect(screen.getByLabelText("Campaign Name")).toBeTruthy();
+    expect(screen.getByLabelText("Email Subject")).toBeTruthy();
+    expect(screen.getByLabelText(/Preview Text/)).toBeTruthy();
+    expect(screen.getByLabelText("Headline")).toBeTruthy();
+    expect(screen.getByLabelText("Body")).toBeTruthy();
+    expect(screen.getByLabelText("CTA Button Text")).toBeTruthy();
+    expect(screen.getByLabelText("CTA URL")).toBeTruthy();
+  });
+
+  it("detail view test email input is associated with a label", async () => {
+    render(<CampaignsDashboard />);
+    await waitFor(() => {
+      expect(screen.getByText("March Update")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText("March Update"));
+    await waitFor(() => {
+      expect(screen.getByText("Send Test Email")).toBeTruthy();
+    });
+
+    expect(screen.getByLabelText("Test Email Address")).toBeTruthy();
+  });
+
+  it("remove feature buttons have aria-label", async () => {
+    render(<CampaignsDashboard />);
+    await waitFor(() => {
+      expect(screen.getByText("New Campaign")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText("New Campaign"));
+
+    // Add two features
+    fireEvent.click(screen.getByText("+ Add feature"));
+    fireEvent.click(screen.getByText("+ Add feature"));
+
+    const removeButtons = screen.getAllByRole("button", { name: "Remove feature" });
+    expect(removeButtons).toHaveLength(2);
+  });
+});

--- a/apps/web/app/admin/campaigns/campaigns-dashboard.tsx
+++ b/apps/web/app/admin/campaigns/campaigns-dashboard.tsx
@@ -113,7 +113,6 @@ export function CampaignsDashboard() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           ...form,
-          type: form.type,
           previewText: form.previewText || null,
         }),
       });
@@ -740,7 +739,7 @@ export function CampaignsDashboard() {
         {/* Engagement info banner */}
         {c.type === "engagement" && (
           <div className="rounded-lg border border-complement/20 bg-complement/5 px-4 py-2 text-sm text-complement">
-            This template is sent automatically when a user&#39;s score increases by 10+ points. Enable delivery in the Engagement tab.
+            This template is sent automatically when a user&apos;s score increases by 10+ points. Enable delivery in the Engagement tab.
           </div>
         )}
 

--- a/apps/web/app/admin/campaigns/campaigns-dashboard.tsx
+++ b/apps/web/app/admin/campaigns/campaigns-dashboard.tsx
@@ -69,7 +69,7 @@ export function CampaignsDashboard() {
   const [previewHtml, setPreviewHtml] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
   const [sendResult, setSendResult] = useState<string | null>(null);
-  const [testEmail, setTestEmail] = useState("");
+  const [testEmail, setTestEmail] = useState("juan294@gmail.com");
   const [sendingTest, setSendingTest] = useState(false);
 
   // -------------------------------------------------------------------------

--- a/apps/web/app/admin/campaigns/campaigns-dashboard.tsx
+++ b/apps/web/app/admin/campaigns/campaigns-dashboard.tsx
@@ -349,10 +349,11 @@ export function CampaignsDashboard() {
           </fieldset>
 
           <div>
-            <label className="block text-xs font-medium text-text-secondary mb-1">
+            <label htmlFor="create-name" className="block text-xs font-medium text-text-secondary mb-1">
               Campaign Name
             </label>
             <input
+              id="create-name"
               className={inputClass}
               value={form.name}
               onChange={(e) => updateField("name", e.target.value)}
@@ -362,10 +363,11 @@ export function CampaignsDashboard() {
           </div>
 
           <div>
-            <label className="block text-xs font-medium text-text-secondary mb-1">
+            <label htmlFor="create-subject" className="block text-xs font-medium text-text-secondary mb-1">
               Email Subject
             </label>
             <input
+              id="create-subject"
               className={inputClass}
               value={form.subject}
               onChange={(e) => updateField("subject", e.target.value)}
@@ -375,11 +377,12 @@ export function CampaignsDashboard() {
           </div>
 
           <div>
-            <label className="block text-xs font-medium text-text-secondary mb-1">
+            <label htmlFor="create-preview" className="block text-xs font-medium text-text-secondary mb-1">
               Preview Text
               <span className="text-text-secondary/50 ml-1">(optional)</span>
             </label>
             <input
+              id="create-preview"
               className={inputClass}
               value={form.previewText}
               onChange={(e) => updateField("previewText", e.target.value)}
@@ -388,10 +391,11 @@ export function CampaignsDashboard() {
           </div>
 
           <div>
-            <label className="block text-xs font-medium text-text-secondary mb-1">
+            <label htmlFor="create-headline" className="block text-xs font-medium text-text-secondary mb-1">
               Headline
             </label>
             <input
+              id="create-headline"
               className={inputClass}
               value={form.headline}
               onChange={(e) => updateField("headline", e.target.value)}
@@ -401,10 +405,11 @@ export function CampaignsDashboard() {
           </div>
 
           <div>
-            <label className="block text-xs font-medium text-text-secondary mb-1">
+            <label htmlFor="create-body" className="block text-xs font-medium text-text-secondary mb-1">
               Body
             </label>
             <textarea
+              id="create-body"
               className={inputClass}
               value={form.bodyText}
               onChange={(e) => updateField("bodyText", e.target.value)}
@@ -434,6 +439,7 @@ export function CampaignsDashboard() {
                 <button
                   type="button"
                   onClick={() => removeFeature(i)}
+                  aria-label="Remove feature"
                   className="shrink-0 rounded-lg border border-stroke px-2 text-text-secondary hover:text-terminal-red hover:border-terminal-red/20"
                 >
                   &times;
@@ -451,10 +457,11 @@ export function CampaignsDashboard() {
 
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-xs font-medium text-text-secondary mb-1">
+              <label htmlFor="create-cta-text" className="block text-xs font-medium text-text-secondary mb-1">
                 CTA Button Text
               </label>
               <input
+                id="create-cta-text"
                 className={inputClass}
                 value={form.ctaText}
                 onChange={(e) => updateField("ctaText", e.target.value)}
@@ -462,10 +469,11 @@ export function CampaignsDashboard() {
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-text-secondary mb-1">
+              <label htmlFor="create-cta-url" className="block text-xs font-medium text-text-secondary mb-1">
                 CTA URL
               </label>
               <input
+                id="create-cta-url"
                 className={inputClass}
                 value={form.ctaUrl}
                 onChange={(e) => updateField("ctaUrl", e.target.value)}
@@ -513,10 +521,11 @@ export function CampaignsDashboard() {
           className="space-y-4 rounded-xl border border-stroke bg-card p-6"
         >
           <div>
-            <label className="block text-xs font-medium text-text-secondary mb-1">
+            <label htmlFor="edit-name" className="block text-xs font-medium text-text-secondary mb-1">
               Campaign Name
             </label>
             <input
+              id="edit-name"
               className={inputClass}
               value={form.name}
               onChange={(e) => updateField("name", e.target.value)}
@@ -525,10 +534,11 @@ export function CampaignsDashboard() {
           </div>
 
           <div>
-            <label className="block text-xs font-medium text-text-secondary mb-1">
+            <label htmlFor="edit-subject" className="block text-xs font-medium text-text-secondary mb-1">
               Email Subject
             </label>
             <input
+              id="edit-subject"
               className={inputClass}
               value={form.subject}
               onChange={(e) => updateField("subject", e.target.value)}
@@ -537,11 +547,12 @@ export function CampaignsDashboard() {
           </div>
 
           <div>
-            <label className="block text-xs font-medium text-text-secondary mb-1">
+            <label htmlFor="edit-preview" className="block text-xs font-medium text-text-secondary mb-1">
               Preview Text
               <span className="text-text-secondary/50 ml-1">(optional)</span>
             </label>
             <input
+              id="edit-preview"
               className={inputClass}
               value={form.previewText}
               onChange={(e) => updateField("previewText", e.target.value)}
@@ -549,10 +560,11 @@ export function CampaignsDashboard() {
           </div>
 
           <div>
-            <label className="block text-xs font-medium text-text-secondary mb-1">
+            <label htmlFor="edit-headline" className="block text-xs font-medium text-text-secondary mb-1">
               Headline
             </label>
             <input
+              id="edit-headline"
               className={inputClass}
               value={form.headline}
               onChange={(e) => updateField("headline", e.target.value)}
@@ -561,10 +573,11 @@ export function CampaignsDashboard() {
           </div>
 
           <div>
-            <label className="block text-xs font-medium text-text-secondary mb-1">
+            <label htmlFor="edit-body" className="block text-xs font-medium text-text-secondary mb-1">
               Body
             </label>
             <textarea
+              id="edit-body"
               className={inputClass}
               value={form.bodyText}
               onChange={(e) => updateField("bodyText", e.target.value)}
@@ -593,6 +606,7 @@ export function CampaignsDashboard() {
                 <button
                   type="button"
                   onClick={() => removeFeature(i)}
+                  aria-label="Remove feature"
                   className="shrink-0 rounded-lg border border-stroke px-2 text-text-secondary hover:text-terminal-red hover:border-terminal-red/20"
                 >
                   &times;
@@ -610,10 +624,11 @@ export function CampaignsDashboard() {
 
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-xs font-medium text-text-secondary mb-1">
+              <label htmlFor="edit-cta-text" className="block text-xs font-medium text-text-secondary mb-1">
                 CTA Button Text
               </label>
               <input
+                id="edit-cta-text"
                 className={inputClass}
                 value={form.ctaText}
                 onChange={(e) => updateField("ctaText", e.target.value)}
@@ -621,10 +636,11 @@ export function CampaignsDashboard() {
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-text-secondary mb-1">
+              <label htmlFor="edit-cta-url" className="block text-xs font-medium text-text-secondary mb-1">
                 CTA URL
               </label>
               <input
+                id="edit-cta-url"
                 className={inputClass}
                 value={form.ctaUrl}
                 onChange={(e) => updateField("ctaUrl", e.target.value)}
@@ -782,7 +798,9 @@ export function CampaignsDashboard() {
             Send Test Email
           </h3>
           <div className="flex gap-2">
+            <label htmlFor="test-email" className="sr-only">Test Email Address</label>
             <input
+              id="test-email"
               className={inputClass}
               type="email"
               value={testEmail}

--- a/apps/web/app/admin/campaigns/campaigns-dashboard.tsx
+++ b/apps/web/app/admin/campaigns/campaigns-dashboard.tsx
@@ -11,6 +11,7 @@ import { formatDate } from "../admin-types";
 type ViewMode = "list" | "create" | "detail" | "edit";
 
 interface FormData {
+  type: "announcement" | "engagement";
   name: string;
   subject: string;
   previewText: string;
@@ -22,6 +23,7 @@ interface FormData {
 }
 
 const EMPTY_FORM: FormData = {
+  type: "announcement",
   name: "",
   subject: "",
   previewText: "",
@@ -111,6 +113,7 @@ export function CampaignsDashboard() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           ...form,
+          type: form.type,
           previewText: form.previewText || null,
         }),
       });
@@ -225,6 +228,7 @@ export function CampaignsDashboard() {
 
   const openEdit = (campaign: Campaign) => {
     setForm({
+      type: campaign.type,
       name: campaign.name,
       subject: campaign.subject,
       previewText: campaign.previewText ?? "",
@@ -320,6 +324,31 @@ export function CampaignsDashboard() {
           onSubmit={handleCreate}
           className="space-y-4 rounded-xl border border-stroke bg-card p-6"
         >
+          <fieldset className="space-y-2">
+            <legend className="text-xs font-medium text-text-secondary">Campaign Type</legend>
+            <div className="flex gap-4">
+              <label className="flex items-center gap-2 text-sm text-text-primary cursor-pointer">
+                <input type="radio" name="type" value="announcement"
+                  checked={form.type === "announcement"}
+                  onChange={() => updateField("type", "announcement")}
+                  className="accent-amber" />
+                Announcement
+              </label>
+              <label className="flex items-center gap-2 text-sm text-text-primary cursor-pointer">
+                <input type="radio" name="type" value="engagement"
+                  checked={form.type === "engagement"}
+                  onChange={() => updateField("type", "engagement")}
+                  className="accent-amber" />
+                Engagement
+              </label>
+            </div>
+            <p className="text-xs text-text-secondary/60">
+              {form.type === "announcement"
+                ? "Manual send to all users with email on file."
+                : "Automated — sent when a user's score increases significantly."}
+            </p>
+          </fieldset>
+
           <div>
             <label className="block text-xs font-medium text-text-secondary mb-1">
               Campaign Name
@@ -384,6 +413,11 @@ export function CampaignsDashboard() {
               rows={3}
               required
             />
+            {form.type === "engagement" && (
+              <p className="text-xs text-text-secondary/60 mt-1">
+                Placeholders: {"{{handle}}"}, {"{{delta}}"}, {"{{tier_from}}"}, {"{{tier_to}}"}, {"{{archetype_from}}"}, {"{{archetype_to}}"}
+              </p>
+            )}
           </div>
 
           <fieldset className="space-y-2">
@@ -538,6 +572,11 @@ export function CampaignsDashboard() {
               rows={3}
               required
             />
+            {form.type === "engagement" && (
+              <p className="text-xs text-text-secondary/60 mt-1">
+                Placeholders: {"{{handle}}"}, {"{{delta}}"}, {"{{tier_from}}"}, {"{{tier_to}}"}, {"{{archetype_from}}"}, {"{{archetype_to}}"}
+              </p>
+            )}
           </div>
 
           <fieldset className="space-y-2">
@@ -698,6 +737,13 @@ export function CampaignsDashboard() {
           </div>
         )}
 
+        {/* Engagement info banner */}
+        {c.type === "engagement" && (
+          <div className="rounded-lg border border-complement/20 bg-complement/5 px-4 py-2 text-sm text-complement">
+            This template is sent automatically when a user&#39;s score increases by 10+ points. Enable delivery in the Engagement tab.
+          </div>
+        )}
+
         {/* Actions */}
         {c.status === "draft" && (
           <div className="flex gap-3">
@@ -713,13 +759,15 @@ export function CampaignsDashboard() {
             >
               Edit Draft
             </button>
-            <button
-              onClick={() => handleSend(c.id)}
-              disabled={sending}
-              className="rounded-lg bg-amber px-4 py-2 text-sm font-semibold text-white hover:bg-amber-light disabled:opacity-50"
-            >
-              {sending ? "Sending..." : "Send Campaign"}
-            </button>
+            {c.type !== "engagement" && (
+              <button
+                onClick={() => handleSend(c.id)}
+                disabled={sending}
+                className="rounded-lg bg-amber px-4 py-2 text-sm font-semibold text-white hover:bg-amber-light disabled:opacity-50"
+              >
+                {sending ? "Sending..." : "Send Campaign"}
+              </button>
+            )}
             <button
               onClick={() => handleDelete(c.id)}
               className="rounded-lg border border-terminal-red/20 px-4 py-2 text-sm font-medium text-terminal-red hover:bg-terminal-red/5"
@@ -833,7 +881,14 @@ export function CampaignsDashboard() {
                   onClick={() => openDetail(c)}
                   className="cursor-pointer border-b border-stroke/50 hover:bg-amber/5 transition-colors"
                 >
-                  <td className="px-4 py-3 text-text-primary">{c.name}</td>
+                  <td className="px-4 py-3 text-text-primary">
+                    {c.name}
+                    {c.type === "engagement" && (
+                      <span className="ml-2 inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium bg-complement/10 text-complement font-heading">
+                        engagement
+                      </span>
+                    )}
+                  </td>
                   <td className="px-4 py-3">
                     <StatusBadge status={c.status} />
                   </td>

--- a/apps/web/app/admin/campaigns/campaigns-dashboard.tsx
+++ b/apps/web/app/admin/campaigns/campaigns-dashboard.tsx
@@ -8,7 +8,7 @@ import { formatDate } from "../admin-types";
 // Types
 // ---------------------------------------------------------------------------
 
-type ViewMode = "list" | "create" | "detail";
+type ViewMode = "list" | "create" | "detail" | "edit";
 
 interface FormData {
   name: string;
@@ -69,6 +69,8 @@ export function CampaignsDashboard() {
   const [previewHtml, setPreviewHtml] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
   const [sendResult, setSendResult] = useState<string | null>(null);
+  const [testEmail, setTestEmail] = useState("");
+  const [sendingTest, setSendingTest] = useState(false);
 
   // -------------------------------------------------------------------------
   // Fetch campaigns
@@ -174,10 +176,72 @@ export function CampaignsDashboard() {
     }
   };
 
+  const handleSendTest = async (campaignId: string) => {
+    if (!testEmail.trim()) return;
+    setSendingTest(true);
+    setSendResult(null);
+    try {
+      const res = await fetch(`/api/admin/campaigns/${campaignId}/test`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: testEmail.trim() }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.error ?? `HTTP ${res.status}`);
+      }
+      const data = await res.json();
+      setSendResult(data.message);
+      setTestEmail("");
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSendingTest(false);
+    }
+  };
+
+  const handleEdit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!selectedCampaign) return;
+    try {
+      const res = await fetch(`/api/admin/campaigns/${selectedCampaign.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...form,
+          previewText: form.previewText || null,
+        }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        throw new Error(data?.error ?? `HTTP ${res.status}`);
+      }
+      await fetchCampaigns();
+      setMode("detail");
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const openEdit = (campaign: Campaign) => {
+    setForm({
+      name: campaign.name,
+      subject: campaign.subject,
+      previewText: campaign.previewText ?? "",
+      headline: campaign.headline,
+      bodyText: campaign.bodyText,
+      features: campaign.features,
+      ctaText: campaign.ctaText,
+      ctaUrl: campaign.ctaUrl,
+    });
+    setMode("edit");
+  };
+
   const openDetail = (campaign: Campaign) => {
     setSelectedCampaign(campaign);
     setPreviewHtml(null);
     setSendResult(null);
+    setTestEmail("");
     setMode("detail");
   };
 
@@ -398,6 +462,160 @@ export function CampaignsDashboard() {
   }
 
   // =========================================================================
+  // EDIT VIEW
+  // =========================================================================
+
+  if (mode === "edit" && selectedCampaign) {
+    return (
+      <div className="space-y-6">
+        <h2 className="font-heading text-2xl tracking-tight text-text-primary">
+          <span className="text-amber">$</span> campaigns
+          <span className="text-text-secondary">/</span>edit
+        </h2>
+
+        {errorBanner}
+
+        <form
+          onSubmit={handleEdit}
+          className="space-y-4 rounded-xl border border-stroke bg-card p-6"
+        >
+          <div>
+            <label className="block text-xs font-medium text-text-secondary mb-1">
+              Campaign Name
+            </label>
+            <input
+              className={inputClass}
+              value={form.name}
+              onChange={(e) => updateField("name", e.target.value)}
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-text-secondary mb-1">
+              Email Subject
+            </label>
+            <input
+              className={inputClass}
+              value={form.subject}
+              onChange={(e) => updateField("subject", e.target.value)}
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-text-secondary mb-1">
+              Preview Text
+              <span className="text-text-secondary/50 ml-1">(optional)</span>
+            </label>
+            <input
+              className={inputClass}
+              value={form.previewText}
+              onChange={(e) => updateField("previewText", e.target.value)}
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-text-secondary mb-1">
+              Headline
+            </label>
+            <input
+              className={inputClass}
+              value={form.headline}
+              onChange={(e) => updateField("headline", e.target.value)}
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-text-secondary mb-1">
+              Body
+            </label>
+            <textarea
+              className={inputClass}
+              value={form.bodyText}
+              onChange={(e) => updateField("bodyText", e.target.value)}
+              rows={3}
+              required
+            />
+          </div>
+
+          <fieldset className="space-y-2">
+            <legend className="text-xs font-medium text-text-secondary">
+              Feature Highlights
+            </legend>
+            {form.features.map((f, i) => (
+              <div key={i} className="flex gap-2">
+                <input
+                  className={inputClass}
+                  value={f.text}
+                  onChange={(e) => updateFeature(i, e.target.value)}
+                  placeholder="Feature description"
+                />
+                <button
+                  type="button"
+                  onClick={() => removeFeature(i)}
+                  className="shrink-0 rounded-lg border border-stroke px-2 text-text-secondary hover:text-terminal-red hover:border-terminal-red/20"
+                >
+                  &times;
+                </button>
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={addFeature}
+              className="text-xs text-amber hover:text-amber-light"
+            >
+              + Add feature
+            </button>
+          </fieldset>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-xs font-medium text-text-secondary mb-1">
+                CTA Button Text
+              </label>
+              <input
+                className={inputClass}
+                value={form.ctaText}
+                onChange={(e) => updateField("ctaText", e.target.value)}
+                required
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-text-secondary mb-1">
+                CTA URL
+              </label>
+              <input
+                className={inputClass}
+                value={form.ctaUrl}
+                onChange={(e) => updateField("ctaUrl", e.target.value)}
+                required
+              />
+            </div>
+          </div>
+
+          <div className="flex gap-3 pt-2">
+            <button
+              type="button"
+              onClick={() => setMode("detail")}
+              className="rounded-lg border border-stroke px-4 py-2 text-sm font-medium text-text-secondary hover:border-amber/20 hover:text-text-primary"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="rounded-lg bg-amber px-4 py-2 text-sm font-semibold text-white hover:bg-amber-light"
+            >
+              Save Changes
+            </button>
+          </div>
+        </form>
+      </div>
+    );
+  }
+
+  // =========================================================================
   // DETAIL VIEW
   // =========================================================================
 
@@ -490,6 +708,12 @@ export function CampaignsDashboard() {
               Preview Email
             </button>
             <button
+              onClick={() => openEdit(c)}
+              className="rounded-lg border border-stroke px-4 py-2 text-sm font-medium text-text-secondary hover:border-amber/20 hover:text-text-primary"
+            >
+              Edit Draft
+            </button>
+            <button
               onClick={() => handleSend(c.id)}
               disabled={sending}
               className="rounded-lg bg-amber px-4 py-2 text-sm font-semibold text-white hover:bg-amber-light disabled:opacity-50"
@@ -504,6 +728,32 @@ export function CampaignsDashboard() {
             </button>
           </div>
         )}
+
+        {/* Send Test Email */}
+        <div className="rounded-xl border border-stroke bg-card p-4 space-y-3">
+          <h3 className="font-heading text-sm text-text-secondary">
+            Send Test Email
+          </h3>
+          <div className="flex gap-2">
+            <input
+              className={inputClass}
+              type="email"
+              value={testEmail}
+              onChange={(e) => setTestEmail(e.target.value)}
+              placeholder="your@email.com"
+            />
+            <button
+              onClick={() => handleSendTest(c.id)}
+              disabled={sendingTest || !testEmail.trim()}
+              className="shrink-0 rounded-lg border border-stroke px-4 py-2 text-sm font-medium text-text-secondary hover:border-amber/20 hover:text-text-primary disabled:opacity-50"
+            >
+              {sendingTest ? "Sending..." : "Send Test"}
+            </button>
+          </div>
+          <p className="text-xs text-text-secondary/60">
+            Sends one email with [TEST] prefix. Does not affect campaign status.
+          </p>
+        </div>
 
         {/* Preview iframe */}
         {previewHtml && (

--- a/apps/web/app/admin/engagement/engagement-dashboard.tsx
+++ b/apps/web/app/admin/engagement/engagement-dashboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import type { Campaign } from "@/lib/db/campaigns";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -31,6 +32,7 @@ export function EngagementDashboard() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState<string | null>(null);
+  const [engagementCampaign, setEngagementCampaign] = useState<Campaign | null>(null);
 
   const fetchFlags = useCallback(async () => {
     try {
@@ -52,6 +54,13 @@ export function EngagementDashboard() {
   useEffect(() => {
     fetchFlags();
   }, [fetchFlags]);
+
+  useEffect(() => {
+    fetch("/api/admin/campaigns?type=engagement")
+      .then(res => res.ok ? res.json() : null)
+      .then(data => setEngagementCampaign(data?.campaigns?.[0] ?? null))
+      .catch(() => {});
+  }, []);
 
   const handleToggle = useCallback(
     async (key: string, enabled: boolean) => {
@@ -181,6 +190,26 @@ export function EngagementDashboard() {
             )}
           </tbody>
         </table>
+      </div>
+
+      {/* Score bump email template card */}
+      <div className="rounded-xl border border-stroke bg-card p-4 mt-6 space-y-3">
+        <h3 className="font-heading text-sm text-text-secondary">
+          Score Bump Email Template
+        </h3>
+        {engagementCampaign ? (
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm text-text-primary">{engagementCampaign.name}</p>
+              <p className="text-xs text-text-secondary mt-1">Subject: {engagementCampaign.subject}</p>
+            </div>
+            <p className="text-xs text-text-secondary">Edit in Campaigns tab</p>
+          </div>
+        ) : (
+          <p className="text-sm text-text-secondary">
+            No engagement template created yet. Create one in the Campaigns tab to customize the score bump email.
+          </p>
+        )}
       </div>
     </div>
   );

--- a/apps/web/app/admin/error.test.tsx
+++ b/apps/web/app/admin/error.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "error.tsx"),
+  "utf-8",
+);
+
+describe("admin error.tsx — error boundary", () => {
+  it("has 'use client' directive", () => {
+    expect(SOURCE).toContain('"use client"');
+  });
+
+  it("exports a default function", () => {
+    expect(SOURCE).toContain("export default function");
+  });
+
+  it("displays the admin-specific error heading", () => {
+    expect(SOURCE).toContain("Admin Dashboard Error");
+  });
+
+  it("contains a retry/reset button", () => {
+    expect(SOURCE).toContain("Try again");
+  });
+
+  it("calls reset on retry button click", () => {
+    expect(SOURCE).toContain("onClick={reset}");
+  });
+
+  it("contains a 'go home' link", () => {
+    expect(SOURCE).toContain("Go home");
+  });
+
+  it("links to the root path", () => {
+    expect(SOURCE).toContain('href="/"');
+  });
+});

--- a/apps/web/app/api/admin/campaigns/[id]/send/route.test.ts
+++ b/apps/web/app/api/admin/campaigns/[id]/send/route.test.ts
@@ -75,6 +75,14 @@ describe("POST /api/admin/campaigns/[id]/send", () => {
     expect(res.status).toBe(400);
   });
 
+  it("returns 400 for engagement campaigns", async () => {
+    vi.mocked(dbGetCampaign).mockResolvedValue({ status: "draft", type: "engagement" } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    const res = await POST(makeRequest(), { params: mockParams });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Engagement campaigns are sent automatically");
+  });
+
   it("initiates campaign and processes first batch", async () => {
     vi.mocked(dbGetCampaign).mockResolvedValue({ status: "draft" } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
     vi.mocked(initiateCampaign).mockResolvedValue({ totalRecipients: 10 });

--- a/apps/web/app/api/admin/campaigns/[id]/send/route.ts
+++ b/apps/web/app/api/admin/campaigns/[id]/send/route.ts
@@ -20,6 +20,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   if (!campaign) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
+  if (campaign.type === "engagement") {
+    return NextResponse.json(
+      { error: "Engagement campaigns are sent automatically" },
+      { status: 400 },
+    );
+  }
   if (campaign.status !== "draft") {
     return NextResponse.json(
       { error: "Campaign already started" },

--- a/apps/web/app/api/admin/campaigns/[id]/test/route.test.ts
+++ b/apps/web/app/api/admin/campaigns/[id]/test/route.test.ts
@@ -1,0 +1,228 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/lib/auth/github", () => ({
+  readSessionCookie: vi.fn(),
+}));
+vi.mock("@/lib/auth/admin", () => ({
+  isAdminHandle: vi.fn(),
+}));
+vi.mock("@/lib/cache/redis", () => ({
+  rateLimit: vi.fn().mockResolvedValue({ allowed: true, current: 1, limit: 10 }),
+}));
+vi.mock("@/lib/http/client-ip", () => ({
+  getClientIp: () => "127.0.0.1",
+}));
+vi.mock("@/lib/auth/require-session", () => ({
+  requireSession: vi.fn(),
+}));
+vi.mock("@/lib/db/campaigns", () => ({
+  dbGetCampaign: vi.fn(),
+}));
+vi.mock("@/lib/email/resend", () => ({
+  getResend: vi.fn(),
+}));
+vi.mock("@/lib/email/campaigns", () => ({
+  buildEmailContent: vi.fn(),
+  EMAIL_FROM: "Chapa <notifications@chapa.thecreativetoken.com>",
+}));
+vi.mock("@/lib/email/templates/announcement", () => ({
+  buildAnnouncementHtml: vi.fn().mockReturnValue("<html>test</html>"),
+  buildAnnouncementText: vi.fn().mockReturnValue("test"),
+}));
+
+import { readSessionCookie } from "@/lib/auth/github";
+import { isAdminHandle } from "@/lib/auth/admin";
+import { rateLimit } from "@/lib/cache/redis";
+import { requireSession } from "@/lib/auth/require-session";
+import { dbGetCampaign } from "@/lib/db/campaigns";
+import { getResend } from "@/lib/email/resend";
+import { buildEmailContent } from "@/lib/email/campaigns";
+import { POST } from "./route";
+
+const mockParams = Promise.resolve({ id: "c-1" });
+
+const CAMPAIGN = {
+  id: "c-1",
+  name: "Test Campaign",
+  subject: "Test Subject",
+  headline: "Test Headline",
+  bodyText: "Test body",
+  features: [{ text: "Feature 1" }],
+  ctaText: "Click here",
+  ctaUrl: "https://example.com",
+  previewText: "Preview",
+  status: "draft" as const,
+  totalRecipients: 0,
+  sentCount: 0,
+  failedCount: 0,
+  createdAt: "2026-01-01T00:00:00Z",
+  startedAt: null,
+  completedAt: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.NEXTAUTH_SECRET = "test-secret";
+  vi.mocked(readSessionCookie).mockReturnValue({
+    token: "t", login: "admin", name: "Admin", avatar_url: "",
+  });
+  vi.mocked(isAdminHandle).mockReturnValue(true);
+  vi.mocked(requireSession).mockReturnValue({
+    session: { token: "t", login: "admin", name: "Admin", avatar_url: "" },
+  });
+  vi.mocked(buildEmailContent).mockReturnValue({
+    handle: "admin",
+    headline: "Test Headline",
+    bodyText: "Test body",
+    features: [{ text: "Feature 1" }],
+    ctaText: "Click here",
+    ctaUrl: "https://example.com",
+  });
+});
+
+function makeRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("https://example.com/api/admin/campaigns/c-1/test", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", cookie: "session=x" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/admin/campaigns/[id]/test", () => {
+  it("returns 401 without session", async () => {
+    vi.mocked(readSessionCookie).mockReturnValue(null);
+    vi.mocked(requireSession).mockReturnValue({
+      error: NextResponse.json({ error: "Authentication required" }, { status: 401 }),
+    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    const res = await POST(makeRequest({ email: "test@test.com" }), { params: mockParams });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for non-admin", async () => {
+    vi.mocked(isAdminHandle).mockReturnValue(false);
+    const res = await POST(makeRequest({ email: "test@test.com" }), { params: mockParams });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    vi.mocked(rateLimit).mockResolvedValueOnce({ allowed: false, current: 11, limit: 10 });
+    const res = await POST(makeRequest({ email: "test@test.com" }), { params: mockParams });
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 when email is missing", async () => {
+    const res = await POST(makeRequest({}), { params: mockParams });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Missing required field: email");
+  });
+
+  it("returns 400 when email is empty string", async () => {
+    const res = await POST(makeRequest({ email: "" }), { params: mockParams });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when email is not a valid email", async () => {
+    const res = await POST(makeRequest({ email: "not-an-email" }), { params: mockParams });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid email address");
+  });
+
+  it("returns 404 for non-existent campaign", async () => {
+    vi.mocked(dbGetCampaign).mockResolvedValue(null);
+    const res = await POST(makeRequest({ email: "test@test.com" }), { params: mockParams });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 500 when Resend is unavailable", async () => {
+    vi.mocked(dbGetCampaign).mockResolvedValue(CAMPAIGN);
+    vi.mocked(getResend).mockReturnValue(null);
+    const res = await POST(makeRequest({ email: "test@test.com" }), { params: mockParams });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Email service unavailable");
+  });
+
+  it("sends test email and returns success", async () => {
+    const mockSend = vi.fn().mockResolvedValue({ data: { id: "email-1" }, error: null });
+    vi.mocked(dbGetCampaign).mockResolvedValue(CAMPAIGN);
+    vi.mocked(getResend).mockReturnValue({ emails: { send: mockSend } } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    const res = await POST(makeRequest({ email: "test@test.com" }), { params: mockParams });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.message).toContain("test@test.com");
+    expect(mockSend).toHaveBeenCalledOnce();
+    expect(mockSend).toHaveBeenCalledWith(expect.objectContaining({
+      to: "test@test.com",
+      subject: "[TEST] Test Subject",
+    }));
+  });
+
+  it("prefixes subject with [TEST]", async () => {
+    const mockSend = vi.fn().mockResolvedValue({ data: { id: "email-1" }, error: null });
+    vi.mocked(dbGetCampaign).mockResolvedValue(CAMPAIGN);
+    vi.mocked(getResend).mockReturnValue({ emails: { send: mockSend } } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    await POST(makeRequest({ email: "test@test.com" }), { params: mockParams });
+
+    const sentEmail = mockSend.mock.calls[0]![0];
+    expect(sentEmail.subject).toBe("[TEST] Test Subject");
+  });
+
+  it("uses provided handle or defaults to session login", async () => {
+    const mockSend = vi.fn().mockResolvedValue({ data: { id: "email-1" }, error: null });
+    vi.mocked(dbGetCampaign).mockResolvedValue(CAMPAIGN);
+    vi.mocked(getResend).mockReturnValue({ emails: { send: mockSend } } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    await POST(makeRequest({ email: "test@test.com" }), { params: mockParams });
+    expect(buildEmailContent).toHaveBeenCalledWith(CAMPAIGN, "admin");
+
+    vi.clearAllMocks();
+    vi.mocked(readSessionCookie).mockReturnValue({
+      token: "t", login: "admin", name: "Admin", avatar_url: "",
+    });
+    vi.mocked(isAdminHandle).mockReturnValue(true);
+    vi.mocked(dbGetCampaign).mockResolvedValue(CAMPAIGN);
+    vi.mocked(getResend).mockReturnValue({ emails: { send: mockSend } } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    await POST(makeRequest({ email: "test@test.com", handle: "testuser" }), { params: mockParams });
+    expect(buildEmailContent).toHaveBeenCalledWith(CAMPAIGN, "testuser");
+  });
+
+  it("returns 500 when Resend send fails", async () => {
+    const mockSend = vi.fn().mockResolvedValue({ data: null, error: { message: "send failed" } });
+    vi.mocked(dbGetCampaign).mockResolvedValue(CAMPAIGN);
+    vi.mocked(getResend).mockReturnValue({ emails: { send: mockSend } } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    const res = await POST(makeRequest({ email: "test@test.com" }), { params: mockParams });
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("send failed");
+  });
+
+  it("does NOT modify campaign status or create campaign_sends", async () => {
+    const mockSend = vi.fn().mockResolvedValue({ data: { id: "email-1" }, error: null });
+    vi.mocked(dbGetCampaign).mockResolvedValue(CAMPAIGN);
+    vi.mocked(getResend).mockReturnValue({ emails: { send: mockSend } } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    await POST(makeRequest({ email: "test@test.com" }), { params: mockParams });
+
+    // dbGetCampaign is the only DB call — no update, no create sends
+    expect(dbGetCampaign).toHaveBeenCalledOnce();
+  });
+
+  it("allows test send for any campaign status", async () => {
+    const mockSend = vi.fn().mockResolvedValue({ data: { id: "email-1" }, error: null });
+    vi.mocked(getResend).mockReturnValue({ emails: { send: mockSend } } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    // Test with sent campaign
+    vi.mocked(dbGetCampaign).mockResolvedValue({ ...CAMPAIGN, status: "sent" as const });
+    const res = await POST(makeRequest({ email: "test@test.com" }), { params: mockParams });
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/web/app/api/admin/campaigns/[id]/test/route.test.ts
+++ b/apps/web/app/api/admin/campaigns/[id]/test/route.test.ts
@@ -45,6 +45,7 @@ const mockParams = Promise.resolve({ id: "c-1" });
 
 const CAMPAIGN = {
   id: "c-1",
+  type: "announcement" as const,
   name: "Test Campaign",
   subject: "Test Subject",
   headline: "Test Headline",

--- a/apps/web/app/api/admin/campaigns/[id]/test/route.ts
+++ b/apps/web/app/api/admin/campaigns/[id]/test/route.ts
@@ -1,0 +1,101 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { adminAuth } from "@/lib/auth/admin-route";
+import { requireSession } from "@/lib/auth/require-session";
+import { dbGetCampaign } from "@/lib/db/campaigns";
+import { getResend } from "@/lib/email/resend";
+import { buildEmailContent, EMAIL_FROM } from "@/lib/email/campaigns";
+import {
+  buildAnnouncementHtml,
+  buildAnnouncementText,
+} from "@/lib/email/templates/announcement";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const authError = await adminAuth(request);
+  if (authError) return authError;
+
+  // Parse body
+  let email: string;
+  let handle: string | undefined;
+  try {
+    const body = await request.json();
+    email = typeof body.email === "string" ? body.email.trim() : "";
+    handle = typeof body.handle === "string" ? body.handle.trim() : undefined;
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON" },
+      { status: 400 },
+    );
+  }
+
+  if (!email) {
+    return NextResponse.json(
+      { error: "Missing required field: email" },
+      { status: 400 },
+    );
+  }
+
+  if (!EMAIL_RE.test(email)) {
+    return NextResponse.json(
+      { error: "Invalid email address" },
+      { status: 400 },
+    );
+  }
+
+  // Fetch campaign
+  const { id } = await params;
+  const campaign = await dbGetCampaign(id);
+  if (!campaign) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  // Get Resend client
+  const resend = getResend();
+  if (!resend) {
+    return NextResponse.json(
+      { error: "Email service unavailable" },
+      { status: 500 },
+    );
+  }
+
+  // Use provided handle or fall back to session login
+  const { session } = requireSession(request);
+  const recipientHandle = handle || session!.login;
+
+  // Build email content using the same template as real sends
+  const content = buildEmailContent(campaign, recipientHandle);
+  const html = buildAnnouncementHtml(content);
+  const text = buildAnnouncementText(content);
+
+  try {
+    const { data, error } = await resend.emails.send({
+      from: EMAIL_FROM,
+      to: email,
+      subject: `[TEST] ${campaign.subject}`,
+      html,
+      text,
+    });
+
+    if (error || !data) {
+      return NextResponse.json(
+        { error: error?.message ?? "Failed to send test email" },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({
+      message: `Test email sent to ${email}`,
+      emailId: data.id,
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/app/api/admin/campaigns/[id]/test/route.ts
+++ b/apps/web/app/api/admin/campaigns/[id]/test/route.ts
@@ -15,6 +15,19 @@ interface RouteParams {
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+/** Replace {{var}} placeholders with sample values for test emails. */
+function interpolate(template: string, handle: string): string {
+  const vars: Record<string, string> = {
+    handle,
+    delta: "+12",
+    tier_from: "Solid",
+    tier_to: "High",
+    archetype_from: "Balanced",
+    archetype_to: "Builder",
+  };
+  return template.replace(/\{\{(\w+)\}\}/g, (_, key) => vars[key as string] ?? "");
+}
+
 export async function POST(request: NextRequest, { params }: RouteParams) {
   const authError = await adminAuth(request);
   if (authError) return authError;
@@ -67,8 +80,18 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   const { session } = requireSession(request);
   const recipientHandle = handle || session!.login;
 
+  // For engagement campaigns, interpolate placeholders with sample values
+  const interpolated = campaign.type === "engagement"
+    ? {
+        ...campaign,
+        subject: interpolate(campaign.subject, recipientHandle),
+        headline: interpolate(campaign.headline, recipientHandle),
+        bodyText: interpolate(campaign.bodyText, recipientHandle),
+      }
+    : campaign;
+
   // Build email content using the same template as real sends
-  const content = buildEmailContent(campaign, recipientHandle);
+  const content = buildEmailContent(interpolated, recipientHandle);
   const html = buildAnnouncementHtml(content);
   const text = buildAnnouncementText(content);
 
@@ -76,7 +99,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const { data, error } = await resend.emails.send({
       from: EMAIL_FROM,
       to: email,
-      subject: `[TEST] ${campaign.subject}`,
+      subject: `[TEST] ${interpolated.subject}`,
       html,
       text,
     });

--- a/apps/web/app/api/admin/campaigns/[id]/test/route.ts
+++ b/apps/web/app/api/admin/campaigns/[id]/test/route.ts
@@ -87,6 +87,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         subject: interpolate(campaign.subject, recipientHandle),
         headline: interpolate(campaign.headline, recipientHandle),
         bodyText: interpolate(campaign.bodyText, recipientHandle),
+        ctaUrl: interpolate(campaign.ctaUrl, recipientHandle),
+        ctaText: interpolate(campaign.ctaText, recipientHandle),
         features: campaign.features.map((f) => ({
           text: interpolate(f.text, recipientHandle),
         })),

--- a/apps/web/app/api/admin/campaigns/[id]/test/route.ts
+++ b/apps/web/app/api/admin/campaigns/[id]/test/route.ts
@@ -87,6 +87,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         subject: interpolate(campaign.subject, recipientHandle),
         headline: interpolate(campaign.headline, recipientHandle),
         bodyText: interpolate(campaign.bodyText, recipientHandle),
+        features: campaign.features.map((f) => ({
+          text: interpolate(f.text, recipientHandle),
+        })),
       }
     : campaign;
 

--- a/apps/web/app/api/admin/campaigns/route.ts
+++ b/apps/web/app/api/admin/campaigns/route.ts
@@ -9,8 +9,11 @@ export async function GET(request: NextRequest) {
   const authError = await adminAuth(request);
   if (authError) return authError;
 
-  const type = request.nextUrl.searchParams.get("type") as CampaignType | null;
-  const campaigns = await dbGetCampaigns(undefined, type ?? undefined);
+  const rawType = request.nextUrl.searchParams.get("type");
+  const type = rawType && VALID_TYPES.includes(rawType as CampaignType)
+    ? (rawType as CampaignType)
+    : undefined;
+  const campaigns = await dbGetCampaigns(undefined, type);
   return NextResponse.json({ campaigns });
 }
 

--- a/apps/web/app/api/admin/campaigns/route.ts
+++ b/apps/web/app/api/admin/campaigns/route.ts
@@ -1,12 +1,16 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { adminAuth } from "@/lib/auth/admin-route";
 import { dbGetCampaigns, dbCreateCampaign } from "@/lib/db/campaigns";
+import type { CampaignType } from "@/lib/db/campaigns";
+
+const VALID_TYPES: CampaignType[] = ["announcement", "engagement"];
 
 export async function GET(request: NextRequest) {
   const authError = await adminAuth(request);
   if (authError) return authError;
 
-  const campaigns = await dbGetCampaigns();
+  const type = request.nextUrl.searchParams.get("type") as CampaignType | null;
+  const campaigns = await dbGetCampaigns(undefined, type ?? undefined);
   return NextResponse.json({ campaigns });
 }
 
@@ -31,7 +35,16 @@ export async function POST(request: NextRequest) {
     }
   }
 
+  const type = (body.type as string) ?? "announcement";
+  if (!VALID_TYPES.includes(type as CampaignType)) {
+    return NextResponse.json(
+      { error: `Invalid type: ${type}` },
+      { status: 400 },
+    );
+  }
+
   const id = await dbCreateCampaign({
+    type: type as CampaignType,
     name: body.name as string,
     subject: body.subject as string,
     previewText: (body.previewText as string) ?? null,

--- a/apps/web/app/api/cron/process-campaigns/route.test.ts
+++ b/apps/web/app/api/cron/process-campaigns/route.test.ts
@@ -52,6 +52,7 @@ describe("process-campaigns cron", () => {
     vi.mocked(dbGetCampaigns).mockResolvedValue([
       {
         id: "c-1",
+        type: "announcement",
         name: "Test Campaign",
         status: "sending",
         subject: "Test",

--- a/apps/web/app/api/generate/route.test.ts
+++ b/apps/web/app/api/generate/route.test.ts
@@ -120,6 +120,10 @@ describe("POST /api/generate", () => {
   });
 
   it("returns 500 when an unexpected error is thrown", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
     mockRequireSession.mockReturnValue({ session: SESSION });
     mockGetStats.mockRejectedValue(new Error("unexpected boom"));
 
@@ -127,5 +131,7 @@ describe("POST /api/generate", () => {
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error).toBe("Internal server error");
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/apps/web/app/api/refresh/route.test.ts
+++ b/apps/web/app/api/refresh/route.test.ts
@@ -227,6 +227,10 @@ describe("POST /api/refresh", () => {
   });
 
   it("returns 500 when an unexpected error is thrown", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
     vi.mocked(rateLimit).mockResolvedValue({ allowed: true, current: 1, limit: 5 });
     vi.mocked(getStats).mockRejectedValue(new Error("unexpected boom"));
 
@@ -234,5 +238,7 @@ describe("POST /api/refresh", () => {
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error).toBe("Internal server error");
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/apps/web/app/api/verify/[hash]/route.test.ts
+++ b/apps/web/app/api/verify/[hash]/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const { mockGetVerificationRecord, mockRateLimit } = vi.hoisted(() => ({
   mockGetVerificationRecord: vi.fn(),
@@ -190,6 +190,16 @@ describe("GET /api/verify/[hash]", () => {
   });
 
   describe("error handling", () => {
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleErrorSpy.mockRestore();
+    });
+
     it("returns 500 with CORS header when an unexpected error is thrown", async () => {
       mockGetVerificationRecord.mockRejectedValue(new Error("unexpected boom"));
       const [req, ctx] = makeRequest("abc12345", "1.2.3.4");

--- a/apps/web/app/archetypes/error.test.tsx
+++ b/apps/web/app/archetypes/error.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "error.tsx"),
+  "utf-8",
+);
+
+describe("archetypes error.tsx — error boundary", () => {
+  it("has 'use client' directive", () => {
+    expect(SOURCE).toContain('"use client"');
+  });
+
+  it("exports a default function", () => {
+    expect(SOURCE).toContain("export default function");
+  });
+
+  it("contains a retry/reset button", () => {
+    expect(SOURCE).toContain("Try again");
+  });
+
+  it("calls reset on retry button click", () => {
+    expect(SOURCE).toContain("onClick={reset}");
+  });
+
+  it("contains a 'go home' link", () => {
+    expect(SOURCE).toContain("Go home");
+  });
+
+  it("links to the root path", () => {
+    expect(SOURCE).toContain('href="/"');
+  });
+});

--- a/apps/web/app/coming-soon/error.test.tsx
+++ b/apps/web/app/coming-soon/error.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "error.tsx"),
+  "utf-8",
+);
+
+describe("coming-soon error.tsx — error boundary", () => {
+  it("has 'use client' directive", () => {
+    expect(SOURCE).toContain('"use client"');
+  });
+
+  it("exports a default function", () => {
+    expect(SOURCE).toContain("export default function");
+  });
+
+  it("contains a retry/reset button", () => {
+    expect(SOURCE).toContain("Try again");
+  });
+
+  it("calls reset on retry button click", () => {
+    expect(SOURCE).toContain("onClick={reset}");
+  });
+
+  it("contains a 'go home' link", () => {
+    expect(SOURCE).toContain("Go home");
+  });
+
+  it("links to the root path", () => {
+    expect(SOURCE).toContain('href="/"');
+  });
+});

--- a/apps/web/app/experiments/aurora/page.tsx
+++ b/apps/web/app/experiments/aurora/page.tsx
@@ -170,7 +170,7 @@ export default function AuroraExperimentPage() {
   const [speed, setSpeed] = useState<Speed>("medium");
 
   return (
-    <div id="main-content" className="relative min-h-screen bg-bg">
+    <main id="main-content" className="relative min-h-screen bg-bg">
       {/* Aurora effect — always behind everything */}
       <AuroraBackground
         intensity={intensity}
@@ -310,7 +310,7 @@ export default function AuroraExperimentPage() {
           </div>
         </section>
       </div>
-    </div>
+    </main>
   );
 }
 

--- a/apps/web/app/experiments/confetti/page.tsx
+++ b/apps/web/app/experiments/confetti/page.tsx
@@ -106,7 +106,7 @@ export default function ConfettiExperimentPage() {
   }, [particleCount, palette, speed]);
 
   return (
-    <div id="main-content" className="min-h-screen bg-bg bg-grid-warm">
+    <main id="main-content" className="min-h-screen bg-bg bg-grid-warm">
       <style>{getBadgeContentCSS({}).join("\n")}</style>
       {/* Ambient glow */}
       <div
@@ -118,7 +118,7 @@ export default function ConfettiExperimentPage() {
         aria-hidden="true"
       />
 
-      <main className="relative z-10 mx-auto max-w-5xl px-6 py-16">
+      <div className="relative z-10 mx-auto max-w-5xl px-6 py-16">
         {/* Header */}
         <header className="mb-12 animate-fade-in-up">
           <p className="text-amber text-sm tracking-widest uppercase mb-4 font-semibold">
@@ -376,7 +376,7 @@ export default function ConfettiExperimentPage() {
             &middot; disableForReducedMotion enabled
           </p>
         </footer>
-      </main>
-    </div>
+      </div>
+    </main>
   );
 }

--- a/apps/web/app/experiments/holographic/page.tsx
+++ b/apps/web/app/experiments/holographic/page.tsx
@@ -330,7 +330,7 @@ export default function HolographicExperimentPage() {
         }
       `}</style>
 
-      <div id="main-content" className="min-h-screen bg-bg px-6 py-16">
+      <main id="main-content" className="min-h-screen bg-bg px-6 py-16">
         <div className="mx-auto max-w-5xl">
           {/* Page header */}
           <header className="mb-4">
@@ -412,7 +412,7 @@ export default function HolographicExperimentPage() {
             </ul>
           </footer>
         </div>
-      </div>
+      </main>
     </>
   );
 }

--- a/apps/web/app/experiments/number-counters/page.tsx
+++ b/apps/web/app/experiments/number-counters/page.tsx
@@ -589,7 +589,7 @@ export default function NumberCountersPage() {
   }, []);
 
   return (
-    <div id="main-content" className="relative min-h-screen bg-bg">
+    <main id="main-content" className="relative min-h-screen bg-bg">
       {/* Ambient glow */}
       <div className="pointer-events-none fixed inset-0 overflow-hidden">
         <div className="absolute -top-40 left-1/4 h-[500px] w-[500px] rounded-full bg-amber/[0.03] blur-[150px]" />
@@ -650,6 +650,6 @@ export default function NumberCountersPage() {
           </p>
         </footer>
       </div>
-    </div>
+    </main>
   );
 }

--- a/apps/web/app/experiments/particles/page.tsx
+++ b/apps/web/app/experiments/particles/page.tsx
@@ -649,7 +649,7 @@ const INTERACTIVE_CONFIG: ParticleConfig = {
 
 export default function ParticlesExperimentPage() {
   return (
-    <div id="main-content" className="min-h-screen bg-bg">
+    <main id="main-content" className="min-h-screen bg-bg">
       <style>{getBadgeContentCSS({}).join("\n")}</style>
       {/* Ambient glow */}
       <div
@@ -661,7 +661,7 @@ export default function ParticlesExperimentPage() {
         aria-hidden="true"
       />
 
-      <main className="relative z-10 mx-auto max-w-5xl px-6 py-16">
+      <div className="relative z-10 mx-auto max-w-5xl px-6 py-16">
         {/* Header */}
         <header className="mb-12 animate-fade-in-up">
           <p className="text-amber text-sm tracking-widest uppercase mb-4 font-semibold">
@@ -777,8 +777,8 @@ export default function ParticlesExperimentPage() {
             &middot; Zero external dependencies
           </p>
         </footer>
-      </main>
-    </div>
+      </div>
+    </main>
   );
 }
 

--- a/apps/web/app/experiments/skip-link.test.ts
+++ b/apps/web/app/experiments/skip-link.test.ts
@@ -33,6 +33,26 @@ describe("experiment pages skip-link target", () => {
     },
   );
 
+  it.each(experimentDirs)(
+    "%s/page.tsx uses <main> landmark for id=\"main-content\"",
+    (dir) => {
+      const pagePath = path.join(EXPERIMENTS_DIR, dir, "page.tsx");
+      const source = fs.readFileSync(pagePath, "utf-8");
+
+      // The element with id="main-content" must be a <main>, not a <div>,
+      // so screen readers expose it as a landmark region.
+      expect(
+        source,
+        `${dir}/page.tsx must use <main id="main-content"> not <div id="main-content">`,
+      ).toMatch(/<main[\s][^>]*id="main-content"/);
+
+      expect(
+        source,
+        `${dir}/page.tsx must not use <div id="main-content">`,
+      ).not.toMatch(/<div[\s][^>]*id="main-content"/);
+    },
+  );
+
   it("has at least 10 experiment pages", () => {
     // Guard against accidentally deleting experiments and having a vacuous test
     expect(experimentDirs.length).toBeGreaterThanOrEqual(10);

--- a/apps/web/app/experiments/text-effects/page.tsx
+++ b/apps/web/app/experiments/text-effects/page.tsx
@@ -496,7 +496,7 @@ export default function TextEffectsExperimentPage() {
         }
       `}</style>
 
-      <div id="main-content" className="min-h-screen bg-bg bg-grid-warm">
+      <main id="main-content" className="min-h-screen bg-bg bg-grid-warm">
         {/* Ambient glow */}
         <div
           className="pointer-events-none fixed top-1/4 left-1/3 h-[500px] w-[500px] rounded-full bg-amber/[0.03] blur-[150px]"
@@ -507,7 +507,7 @@ export default function TextEffectsExperimentPage() {
           aria-hidden="true"
         />
 
-        <main className="relative z-10 mx-auto max-w-5xl px-6 py-16">
+        <div className="relative z-10 mx-auto max-w-5xl px-6 py-16">
           {/* ── Hero ─────────────────────────────────────────── */}
           <header className="mb-20 text-center animate-fade-in-up">
             <p className="text-amber text-sm tracking-widest uppercase mb-4 font-semibold">
@@ -644,8 +644,8 @@ export default function TextEffectsExperimentPage() {
             </span>{" "}
             &middot; prefers-reduced-motion supported
           </p>
-        </main>
-      </div>
+        </div>
+      </main>
     </>
   );
 }

--- a/apps/web/app/experiments/tier-visuals/page.tsx
+++ b/apps/web/app/experiments/tier-visuals/page.tsx
@@ -735,14 +735,14 @@ export default function TierVisualsExperimentPage() {
         }}
       />
 
-      <div id="main-content" className="min-h-screen bg-bg bg-grid-warm">
+      <main id="main-content" className="min-h-screen bg-bg bg-grid-warm">
         {/* Ambient glow */}
         <div className="pointer-events-none fixed inset-0 overflow-hidden" aria-hidden="true">
           <div className="absolute top-1/4 -left-32 h-[500px] w-[500px] rounded-full bg-amber/[0.03] blur-[150px]" />
           <div className="absolute bottom-1/3 -right-32 h-[400px] w-[400px] rounded-full bg-amber/[0.04] blur-[120px]" />
         </div>
 
-        <main className="relative z-10 mx-auto max-w-7xl px-6 py-16 sm:py-24">
+        <div className="relative z-10 mx-auto max-w-7xl px-6 py-16 sm:py-24">
           {/* Header */}
           <header className="mb-12 sm:mb-16 max-w-3xl animate-fade-in-up">
             <p className="text-amber text-sm tracking-widest uppercase mb-4 font-semibold">
@@ -853,8 +853,8 @@ export default function TierVisualsExperimentPage() {
               &middot; prefers-reduced-motion supported
             </p>
           </footer>
-        </main>
-      </div>
+        </div>
+      </main>
     </>
   );
 }

--- a/apps/web/app/privacy/error.test.tsx
+++ b/apps/web/app/privacy/error.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "error.tsx"),
+  "utf-8",
+);
+
+describe("privacy error.tsx — error boundary", () => {
+  it("has 'use client' directive", () => {
+    expect(SOURCE).toContain('"use client"');
+  });
+
+  it("exports a default function", () => {
+    expect(SOURCE).toContain("export default function");
+  });
+
+  it("contains a retry/reset button", () => {
+    expect(SOURCE).toContain("Try again");
+  });
+
+  it("calls reset on retry button click", () => {
+    expect(SOURCE).toContain("onClick={reset}");
+  });
+
+  it("contains a 'go home' link", () => {
+    expect(SOURCE).toContain("Go home");
+  });
+
+  it("links to the root path", () => {
+    expect(SOURCE).toContain('href="/"');
+  });
+});

--- a/apps/web/app/terms/error.test.tsx
+++ b/apps/web/app/terms/error.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "error.tsx"),
+  "utf-8",
+);
+
+describe("terms error.tsx — error boundary", () => {
+  it("has 'use client' directive", () => {
+    expect(SOURCE).toContain('"use client"');
+  });
+
+  it("exports a default function", () => {
+    expect(SOURCE).toContain("export default function");
+  });
+
+  it("contains a retry/reset button", () => {
+    expect(SOURCE).toContain("Try again");
+  });
+
+  it("calls reset on retry button click", () => {
+    expect(SOURCE).toContain("onClick={reset}");
+  });
+
+  it("contains a 'go home' link", () => {
+    expect(SOURCE).toContain("Go home");
+  });
+
+  it("links to the root path", () => {
+    expect(SOURCE).toContain('href="/"');
+  });
+});

--- a/apps/web/lib/db/campaigns.test.ts
+++ b/apps/web/lib/db/campaigns.test.ts
@@ -86,6 +86,7 @@ beforeEach(() => {
 
 const fullRow = {
   id: "c-1",
+  type: "announcement",
   name: "Test Campaign",
   subject: "Subject Line",
   preview_text: "Preview here",
@@ -105,6 +106,7 @@ const fullRow = {
 
 const minimalRow = {
   id: "c-2",
+  type: "announcement",
   name: "Minimal",
   subject: "Sub",
   preview_text: undefined,
@@ -222,6 +224,7 @@ describe("dbGetCampaign", () => {
 
 describe("dbCreateCampaign", () => {
   const validInput = {
+    type: "announcement" as const,
     name: "Test",
     subject: "Subject",
     previewText: null,
@@ -270,6 +273,7 @@ describe("dbCreateCampaign", () => {
     });
 
     expect(mockInsert).toHaveBeenCalledWith({
+      type: "announcement",
       name: "Test",
       subject: "Subject",
       preview_text: "Some preview",

--- a/apps/web/lib/db/campaigns.ts
+++ b/apps/web/lib/db/campaigns.ts
@@ -5,6 +5,7 @@
  */
 
 import { getSupabase } from "./supabase";
+import { cacheGet, cacheSet } from "../cache/redis";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -238,7 +239,14 @@ export async function dbUpdateCampaign(
   }
 }
 
+const ENGAGEMENT_CACHE_KEY = "campaign:active-engagement";
+const ENGAGEMENT_CACHE_TTL = 3600; // 1 hour
+
 export async function dbGetActiveEngagementCampaign(): Promise<Campaign | null> {
+  // Check cache first — avoids N+1 queries during cron batch processing
+  const cached = await cacheGet<Campaign>(ENGAGEMENT_CACHE_KEY);
+  if (cached) return cached;
+
   const db = getSupabase();
   if (!db) return null;
 
@@ -254,7 +262,9 @@ export async function dbGetActiveEngagementCampaign(): Promise<Campaign | null> 
     if (error) throw error;
     if (!data) return null;
 
-    return mapCampaignRow(data);
+    const campaign = mapCampaignRow(data);
+    await cacheSet(ENGAGEMENT_CACHE_KEY, campaign, ENGAGEMENT_CACHE_TTL);
+    return campaign;
   } catch (error) {
     console.error(
       "[db] dbGetActiveEngagementCampaign failed:",

--- a/apps/web/lib/db/campaigns.ts
+++ b/apps/web/lib/db/campaigns.ts
@@ -10,8 +10,11 @@ import { getSupabase } from "./supabase";
 // Types
 // ---------------------------------------------------------------------------
 
+export type CampaignType = "announcement" | "engagement";
+
 export interface Campaign {
   id: string;
+  type: CampaignType;
   name: string;
   subject: string;
   previewText: string | null;
@@ -47,6 +50,7 @@ export interface CampaignSend {
 function mapCampaignRow(row: any): Campaign {
   return {
     id: row.id,
+    type: row.type ?? "announcement",
     name: row.name,
     subject: row.subject,
     previewText: row.preview_text ?? null,
@@ -84,6 +88,7 @@ function mapSendRow(row: any): CampaignSend {
 
 export async function dbGetCampaigns(
   status?: Campaign["status"],
+  type?: CampaignType,
 ): Promise<Campaign[]> {
   const db = getSupabase();
   if (!db) return [];
@@ -95,6 +100,9 @@ export async function dbGetCampaigns(
 
     if (status) {
       query = query.eq("status", status);
+    }
+    if (type) {
+      query = query.eq("type", type);
     }
 
     const { data, error } = await query.order("created_at", { ascending: false });
@@ -150,6 +158,7 @@ export async function dbCreateCampaign(
     const { data, error } = await db
       .from("email_campaigns")
       .insert({
+        type: campaign.type,
         name: campaign.name,
         subject: campaign.subject,
         preview_text: campaign.previewText,
@@ -226,6 +235,32 @@ export async function dbUpdateCampaign(
   } catch (error) {
     console.error("[db] dbUpdateCampaign failed:", (error as Error).message);
     return false;
+  }
+}
+
+export async function dbGetActiveEngagementCampaign(): Promise<Campaign | null> {
+  const db = getSupabase();
+  if (!db) return null;
+
+  try {
+    const { data, error } = await db
+      .from("email_campaigns")
+      .select("*")
+      .eq("type", "engagement")
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (error) throw error;
+    if (!data) return null;
+
+    return mapCampaignRow(data);
+  } catch (error) {
+    console.error(
+      "[db] dbGetActiveEngagementCampaign failed:",
+      (error as Error).message,
+    );
+    return null;
   }
 }
 

--- a/apps/web/lib/email/campaigns.test.ts
+++ b/apps/web/lib/email/campaigns.test.ts
@@ -61,6 +61,7 @@ beforeEach(() => {
 
 const draftCampaign = {
   id: "campaign-1",
+  type: "announcement" as const,
   name: "Test Campaign",
   subject: "Test Subject",
   previewText: null,

--- a/apps/web/lib/email/html-helpers.test.ts
+++ b/apps/web/lib/email/html-helpers.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { featureRow } from "./html-helpers";
+
+describe("featureRow", () => {
+  it("produces valid HTML with normal text input", () => {
+    const html = featureRow("Hello World");
+    expect(html).toContain("<tr>");
+    expect(html).toContain("</tr>");
+    expect(html).toContain("<td");
+    expect(html).toContain("</td>");
+    expect(html).toContain("Hello World");
+    expect(html).toContain("&rarr;");
+  });
+
+  it("uses default paddingBottom of 12", () => {
+    const html = featureRow("test");
+    expect(html).toContain("padding-bottom:12px");
+  });
+
+  it("respects custom paddingBottom values", () => {
+    expect(featureRow("a", 0)).toContain("padding-bottom:0px");
+    expect(featureRow("a", 24)).toContain("padding-bottom:24px");
+    expect(featureRow("a", 8)).toContain("padding-bottom:8px");
+  });
+
+  it("includes JetBrains Mono font for the arrow", () => {
+    const html = featureRow("test");
+    expect(html).toContain("font-family:'JetBrains Mono',monospace");
+  });
+
+  it("includes Plus Jakarta Sans font for the text", () => {
+    const html = featureRow("test");
+    expect(html).toContain("font-family:'Plus Jakarta Sans'");
+  });
+
+  it("passes HTML special characters through as-is (raw interpolation)", () => {
+    const html = featureRow('<script>alert("xss")</script>');
+    expect(html).toContain('<script>alert("xss")</script>');
+
+    const htmlAmp = featureRow("A & B");
+    expect(htmlAmp).toContain("A & B");
+
+    const htmlAngle = featureRow("a < b > c");
+    expect(htmlAngle).toContain("a < b > c");
+  });
+
+  it("handles empty string input", () => {
+    const html = featureRow("");
+    expect(html).toContain("<tr>");
+    expect(html).toContain("</tr>");
+    expect(html).toContain("&rarr;");
+    // The text span should be present but with empty content
+    expect(html).toContain("padding-bottom:12px");
+  });
+
+  it("uses the correct accent color for the arrow", () => {
+    const html = featureRow("test");
+    expect(html).toContain("color:#8B5CF6");
+  });
+
+  it("uses the correct text color for content", () => {
+    const html = featureRow("test");
+    expect(html).toContain("color:#E2E4E9");
+  });
+});

--- a/apps/web/lib/email/html-helpers.ts
+++ b/apps/web/lib/email/html-helpers.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared HTML helpers for email templates.
+ *
+ * Used by both announcement and score-bump templates to keep
+ * feature-row rendering consistent across all Chapa emails.
+ */
+
+/** Render a single arrow-prefixed feature row for email HTML. */
+export function featureRow(
+  text: string,
+  paddingBottom: number = 12,
+): string {
+  return `
+          <tr><td style="padding-bottom:${paddingBottom}px;padding-left:8px;">
+            <span style="font-family:'JetBrains Mono',monospace;font-size:13px;color:#8B5CF6;">&rarr;</span>
+            <span style="font-family:'Plus Jakarta Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:14px;color:#E2E4E9;padding-left:8px;">
+              ${text}
+            </span>
+          </td></tr>`;
+}

--- a/apps/web/lib/email/score-bump.test.ts
+++ b/apps/web/lib/email/score-bump.test.ts
@@ -244,6 +244,7 @@ describe("email content — tier change", () => {
     await notifyScoreBump("testuser", diff, makeSignificance("tier_change"));
 
     const call = mockSend.mock.calls[0]![0];
+    expect(call.subject).toContain("Your Profile Just Leveled Up");
     expect(call.subject).toContain("Solid");
     expect(call.subject).toContain("High");
     expect(call.html).toContain("Solid");

--- a/apps/web/lib/email/score-bump.test.ts
+++ b/apps/web/lib/email/score-bump.test.ts
@@ -36,6 +36,13 @@ vi.mock("@/lib/db/feature-flags", () => ({
   dbGetFeatureFlag: (...args: unknown[]) => mockDbGetFeatureFlag(...args),
 }));
 
+const mockDbGetActiveEngagementCampaign = vi.fn();
+
+vi.mock("@/lib/db/campaigns", () => ({
+  dbGetActiveEngagementCampaign: (...args: unknown[]) =>
+    mockDbGetActiveEngagementCampaign(...args),
+}));
+
 import { notifyScoreBump } from "./score-bump";
 import { _resetClient } from "./resend";
 import type { SnapshotDiff } from "@/lib/history/diff";
@@ -104,6 +111,9 @@ beforeEach(() => {
     email: "dev@example.com",
     emailNotifications: true,
   });
+
+  // Default: no engagement campaign (fallback to hardcoded template)
+  mockDbGetActiveEngagementCampaign.mockResolvedValue(null);
 });
 
 // ---------------------------------------------------------------------------
@@ -323,5 +333,100 @@ describe("unsubscribe link", () => {
     const call = mockSend.mock.calls[0]![0];
     expect(call.html).toContain("/api/notifications/unsubscribe");
     expect(call.text).toContain("/api/notifications/unsubscribe");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DB-backed engagement template
+// ---------------------------------------------------------------------------
+
+describe("DB-backed engagement template", () => {
+  const engagementCampaign = {
+    id: "camp_eng_1",
+    type: "engagement" as const,
+    name: "Score Bump Engagement",
+    subject: "{{handle}}: Your Impact just jumped {{delta}} points!",
+    previewText: null,
+    headline: "You went from {{tier_from}} to {{tier_to}}!",
+    bodyText: "Your archetype evolved from {{archetype_from}} to {{archetype_to}}.",
+    features: [{ text: "Check your updated badge" }],
+    ctaText: "View Badge",
+    ctaUrl: "https://chapa.thecreativetoken.com/u/{{handle}}",
+    status: "draft" as const,
+    totalRecipients: 0,
+    sentCount: 0,
+    failedCount: 0,
+    createdAt: "2026-03-22T00:00:00Z",
+    startedAt: null,
+    completedAt: null,
+  };
+
+  it("uses engagement campaign template when one exists", async () => {
+    mockDbGetActiveEngagementCampaign.mockResolvedValue(engagementCampaign);
+
+    const diff = makeDiff({
+      adjustedComposite: 12,
+      tier: { from: "Solid", to: "High" },
+      archetype: { from: "Balanced", to: "Builder" },
+    });
+
+    await notifyScoreBump("testuser", diff, makeSignificance("tier_change"));
+
+    const call = mockSend.mock.calls[0]![0];
+    // Subject should be interpolated
+    expect(call.subject).toBe("testuser: Your Impact just jumped +12 points!");
+    // HTML should contain the interpolated headline from the announcement template
+    expect(call.html).toContain("You went from Solid to High!");
+  });
+
+  it("falls back to hardcoded template when no engagement campaign exists", async () => {
+    mockDbGetActiveEngagementCampaign.mockResolvedValue(null);
+
+    const diff = makeDiff({ adjustedComposite: 8 });
+
+    await notifyScoreBump("testuser", diff, makeSignificance("score_bump"));
+
+    const call = mockSend.mock.calls[0]![0];
+    // Should use the original buildSubject format
+    expect(call.subject).toContain("testuser");
+    expect(call.subject).toContain("+8");
+    // Should use the original buildHtml format (contains the score delta highlight)
+    expect(call.html).toContain("+8");
+  });
+
+  it("interpolates tier placeholders correctly", async () => {
+    mockDbGetActiveEngagementCampaign.mockResolvedValue(engagementCampaign);
+
+    const diff = makeDiff({
+      adjustedComposite: 5,
+      tier: { from: "Emerging", to: "Solid" },
+      archetype: { from: "Emerging", to: "Marathoner" },
+    });
+
+    await notifyScoreBump("testuser", diff, makeSignificance("tier_change"));
+
+    const call = mockSend.mock.calls[0]![0];
+    expect(call.subject).toBe("testuser: Your Impact just jumped +5 points!");
+    expect(call.html).toContain("You went from Emerging to Solid!");
+    expect(call.html).toContain("Your archetype evolved from Emerging to Marathoner.");
+  });
+
+  it("handles missing placeholders gracefully (empty string for unused vars)", async () => {
+    const campaignNoTier = {
+      ...engagementCampaign,
+      subject: "{{handle}}: Score bump {{delta}} — tier {{tier_from}} to {{tier_to}}",
+      headline: "Impact changed by {{delta}}!",
+    };
+    mockDbGetActiveEngagementCampaign.mockResolvedValue(campaignNoTier);
+
+    // No tier or archetype change — those vars should resolve to empty strings
+    const diff = makeDiff({ adjustedComposite: 7 });
+
+    await notifyScoreBump("testuser", diff, makeSignificance("score_bump"));
+
+    const call = mockSend.mock.calls[0]![0];
+    // tier_from and tier_to should be empty strings since diff.tier is null
+    expect(call.subject).toBe("testuser: Score bump +7 — tier  to ");
+    expect(call.html).toContain("Impact changed by +7!");
   });
 });

--- a/apps/web/lib/email/score-bump.ts
+++ b/apps/web/lib/email/score-bump.ts
@@ -21,6 +21,7 @@ import {
   buildAnnouncementHtml,
   buildAnnouncementText,
 } from "./templates/announcement";
+import { featureRow } from "./html-helpers";
 import { cacheGet, cacheSet } from "@/lib/cache/redis";
 import { dbGetUserEmail } from "@/lib/db/users";
 import { dbGetFeatureFlag } from "@/lib/db/feature-flags";
@@ -388,18 +389,8 @@ function buildHtml(data: TemplateData): string {
 }
 
 // ---------------------------------------------------------------------------
-// HTML helper functions
+// Helpers
 // ---------------------------------------------------------------------------
-
-function featureRow(text: string): string {
-  return `
-          <tr><td style="padding-bottom:12px;padding-left:8px;">
-            <span style="font-family:'JetBrains Mono',monospace;font-size:13px;color:#8B5CF6;">&rarr;</span>
-            <span style="font-family:'Plus Jakarta Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:14px;color:#E2E4E9;padding-left:8px;">
-              ${text}
-            </span>
-          </td></tr>`;
-}
 
 function formatDelta(n: number): string {
   const sign = n > 0 ? "+" : "";

--- a/apps/web/lib/email/score-bump.ts
+++ b/apps/web/lib/email/score-bump.ts
@@ -96,6 +96,9 @@ export async function notifyScoreBump(
         subject: interpolate(engagementCampaign.subject, vars),
         headline: interpolate(engagementCampaign.headline, vars),
         bodyText: interpolate(engagementCampaign.bodyText, vars),
+        features: engagementCampaign.features.map((f) => ({
+          text: interpolate(f.text, vars),
+        })),
       };
 
       subject = interpolatedCampaign.subject;

--- a/apps/web/lib/email/score-bump.ts
+++ b/apps/web/lib/email/score-bump.ts
@@ -96,6 +96,8 @@ export async function notifyScoreBump(
         subject: interpolate(engagementCampaign.subject, vars),
         headline: interpolate(engagementCampaign.headline, vars),
         bodyText: interpolate(engagementCampaign.bodyText, vars),
+        ctaUrl: interpolate(engagementCampaign.ctaUrl, vars),
+        ctaText: interpolate(engagementCampaign.ctaText, vars),
         features: engagementCampaign.features.map((f) => ({
           text: interpolate(f.text, vars),
         })),

--- a/apps/web/lib/email/score-bump.ts
+++ b/apps/web/lib/email/score-bump.ts
@@ -107,13 +107,14 @@ function buildSubject(
   diff: SnapshotDiff,
   significance: SignificantChange,
 ): string {
+  const delta = `+${Math.round(diff.adjustedComposite)}`;
   switch (significance.reason) {
     case "tier_change":
-      return `${handle}: ${diff.tier!.from} → ${diff.tier!.to} tier`;
+      return `Your Profile Just Leveled Up — Impact ${delta} (${diff.tier!.from} → ${diff.tier!.to})`;
     case "archetype_change":
-      return `${handle}: ${diff.archetype!.from} → ${diff.archetype!.to}`;
+      return `${handle}: ${diff.archetype!.from} → ${diff.archetype!.to} — Impact ${delta}`;
     case "score_bump":
-      return `${handle}: Impact score +${Math.round(diff.adjustedComposite)} points`;
+      return `${handle}: Impact score ${delta} points`;
   }
 }
 
@@ -133,18 +134,23 @@ function buildText(data: TemplateData): string {
   const { handle, diff, significance, shareUrl, unsubscribeUrl } = data;
   const lines: string[] = [];
 
-  lines.push("CHAPA — Score Update");
-  lines.push("═".repeat(40));
+  lines.push("CHAPA");
+  lines.push("\u2500".repeat(40));
+  lines.push("");
+
+  lines.push(`Hey @${handle},`);
   lines.push("");
 
   // Headline
   switch (significance.reason) {
     case "tier_change":
-      lines.push(`You leveled up! ${diff.tier!.from} → ${diff.tier!.to}`);
+      lines.push(
+        `Your Profile Just Leveled Up! ${diff.tier!.from} \u2192 ${diff.tier!.to} (+${Math.round(diff.adjustedComposite)} points)`,
+      );
       break;
     case "archetype_change":
       lines.push(
-        `Your profile evolved: ${diff.archetype!.from} → ${diff.archetype!.to}`,
+        `Your profile evolved: ${diff.archetype!.from} \u2192 ${diff.archetype!.to} (+${Math.round(diff.adjustedComposite)} points)`,
       );
       break;
     case "score_bump":
@@ -155,70 +161,13 @@ function buildText(data: TemplateData): string {
   }
 
   lines.push("");
-  lines.push(`Handle:    @${handle}`);
-  lines.push(`Score:     +${Math.round(diff.adjustedComposite)} points`);
 
   if (diff.tier) {
-    lines.push(`Tier:      ${diff.tier.from} → ${diff.tier.to}`);
+    lines.push(`\u2192 Tier: ${diff.tier.from} \u2192 ${diff.tier.to}`);
   }
   if (diff.archetype) {
-    lines.push(`Archetype: ${diff.archetype.from} → ${diff.archetype.to}`);
-  }
-
-  lines.push("");
-  lines.push("Dimension changes:");
-  if (diff.dimensions.delivery !== 0)
-    lines.push(`  Delivery:    ${formatDelta(diff.dimensions.delivery)}`);
-  if (diff.dimensions.quality !== 0)
-    lines.push(`  Quality:     ${formatDelta(diff.dimensions.quality)}`);
-  if (diff.dimensions.consistency !== 0)
-    lines.push(`  Consistency: ${formatDelta(diff.dimensions.consistency)}`);
-  if (diff.dimensions.breadth !== 0)
-    lines.push(`  Breadth:     ${formatDelta(diff.dimensions.breadth)}`);
-
-  lines.push("");
-  lines.push(`View your badge: ${shareUrl}`);
-  lines.push("");
-  lines.push("─".repeat(40));
-  lines.push(`Unsubscribe: ${unsubscribeUrl}`);
-
-  return lines.join("\n");
-}
-
-// ---------------------------------------------------------------------------
-// HTML template
-// ---------------------------------------------------------------------------
-
-function buildHtml(data: TemplateData): string {
-  const { handle, diff, significance, shareUrl, unsubscribeUrl } = data;
-  const safeHandle = escapeHtml(handle);
-
-  let headline: string;
-  let headlineColor: string;
-
-  switch (significance.reason) {
-    case "tier_change":
-      headline = `You leveled up! ${escapeHtml(diff.tier!.from)} → ${escapeHtml(diff.tier!.to)}`;
-      headlineColor = "#4ADE80"; // terminal green
-      break;
-    case "archetype_change":
-      headline = `Your profile evolved: ${escapeHtml(diff.archetype!.from)} → ${escapeHtml(diff.archetype!.to)}`;
-      headlineColor = "#8B5CF6"; // brand purple
-      break;
-    case "score_bump":
-      headline = `Your Impact score just jumped +${Math.round(diff.adjustedComposite)} points!`;
-      headlineColor = "#8B5CF6";
-      break;
-  }
-
-  // Build change details rows
-  const changeRows: string[] = [];
-  if (diff.tier) {
-    changeRows.push(changeRow("Tier", diff.tier.from, diff.tier.to, "#4ADE80"));
-  }
-  if (diff.archetype) {
-    changeRows.push(
-      changeRow("Archetype", diff.archetype.from, diff.archetype.to, "#8B5CF6"),
+    lines.push(
+      `\u2192 Archetype: ${diff.archetype.from} \u2192 ${diff.archetype.to}`,
     );
   }
 
@@ -230,75 +179,159 @@ function buildHtml(data: TemplateData): string {
     { label: "Breadth", delta: diff.dimensions.breadth },
   ].filter((d) => d.delta !== 0);
 
+  if (dims.length > 0) {
+    lines.push("");
+    for (const d of dims) {
+      lines.push(`\u2192 ${d.label}: ${formatDelta(d.delta)}`);
+    }
+  }
+
+  lines.push("");
+  lines.push(`View your badge: ${shareUrl}`);
+  lines.push("");
+  lines.push("\u2500".repeat(40));
+  lines.push("chapa.thecreativetoken.com");
+  lines.push(`Unsubscribe: ${unsubscribeUrl}`);
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// HTML template — unified with announcement design
+// ---------------------------------------------------------------------------
+
+function buildHtml(data: TemplateData): string {
+  const { handle, diff, significance, shareUrl, unsubscribeUrl } = data;
+  const safeHandle = escapeHtml(handle);
+  const delta = Math.round(diff.adjustedComposite);
+
+  let headline: string;
+  switch (significance.reason) {
+    case "tier_change":
+      headline = "Your Profile Just Leveled Up!";
+      break;
+    case "archetype_change":
+      headline = `Your profile evolved: ${escapeHtml(diff.archetype!.from)} &rarr; ${escapeHtml(diff.archetype!.to)}`;
+      break;
+    case "score_bump":
+      headline = `Your Impact score just jumped +${delta} points!`;
+      break;
+  }
+
+  // Build feature-style rows for changes
+  const changeItems: string[] = [];
+
+  changeItems.push(featureRow(`Impact score: +${delta} points`));
+
+  if (diff.tier) {
+    changeItems.push(
+      featureRow(
+        `Tier: ${escapeHtml(diff.tier.from)} &rarr; ${escapeHtml(diff.tier.to)}`,
+      ),
+    );
+  }
+  if (diff.archetype) {
+    changeItems.push(
+      featureRow(
+        `Archetype: ${escapeHtml(diff.archetype.from)} &rarr; ${escapeHtml(diff.archetype.to)}`,
+      ),
+    );
+  }
+
+  // Dimension deltas
+  const dims = [
+    { label: "Delivery", delta: diff.dimensions.delivery },
+    { label: "Quality", delta: diff.dimensions.quality },
+    { label: "Consistency", delta: diff.dimensions.consistency },
+    { label: "Breadth", delta: diff.dimensions.breadth },
+  ].filter((d) => d.delta !== 0);
+
+  for (const d of dims) {
+    const sign = d.delta > 0 ? "+" : "";
+    changeItems.push(featureRow(`${d.label}: ${sign}${Math.round(d.delta)}`));
+  }
+
   return `<!DOCTYPE html>
 <html>
-<head><meta charset="utf-8"></head>
-<body style="margin:0;padding:0;background:#0A0A0F;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;">
-  <table width="100%" cellpadding="0" cellspacing="0" style="background:#0A0A0F;padding:32px 16px;">
-    <tr><td align="center">
-      <table width="560" cellpadding="0" cellspacing="0" style="background:#111118;border-radius:12px;border:1px solid rgba(139,92,246,0.15);overflow:hidden;">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!--[if !mso]><!-->
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@500;700&display=swap');
+  </style>
+  <!--<![endif]-->
+</head>
+<body style="margin:0;padding:0;background:#0A0A0F;font-family:'Plus Jakarta Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
 
-        <!-- Header -->
-        <tr><td style="background:linear-gradient(135deg,#8B5CF6 0%,#7C3AED 100%);padding:24px 32px;">
-          <table width="100%" cellpadding="0" cellspacing="0">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#0A0A0F;">
+    <tr><td align="center" style="padding:40px 20px;">
+      <table width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;">
+
+        <!-- Logo -->
+        <tr><td style="padding-bottom:24px;">
+          <span style="font-family:'JetBrains Mono',monospace;font-size:14px;font-weight:700;color:#8B5CF6;letter-spacing:0.05em;">
+            CHAPA_
+          </span>
+        </td></tr>
+
+        <!-- Divider -->
+        <tr><td style="padding-bottom:32px;">
+          <div style="height:1px;background:rgba(139,92,246,0.15);"></div>
+        </td></tr>
+
+        <!-- Greeting -->
+        <tr><td style="padding-bottom:16px;">
+          <span style="font-family:'Plus Jakarta Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:15px;color:#8B8FA0;">
+            Hey @${safeHandle},
+          </span>
+        </td></tr>
+
+        <!-- Headline -->
+        <tr><td style="padding-bottom:16px;">
+          <h1 style="margin:0;font-family:'JetBrains Mono',monospace;font-size:22px;font-weight:700;color:#E2E4E9;line-height:1.3;">
+            ${headline}
+          </h1>
+        </td></tr>
+
+        <!-- Score delta highlight -->
+        <tr><td style="padding-bottom:24px;">
+          <table cellpadding="0" cellspacing="0" style="background:rgba(139,92,246,0.08);border:1px solid rgba(139,92,246,0.20);border-radius:8px;">
             <tr>
-              <td style="font-family:'Courier New',monospace;font-size:24px;font-weight:700;color:#FFFFFF;letter-spacing:2px;">CHAPA</td>
-              <td align="right" style="font-size:13px;color:rgba(255,255,255,0.8);">Score Update</td>
+              <td style="padding:16px 24px;text-align:center;">
+                <span style="font-family:'JetBrains Mono',monospace;font-size:32px;font-weight:700;color:#4ADE80;">+${delta}</span>
+                <span style="font-family:'Plus Jakarta Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:13px;color:#8B8FA0;padding-left:8px;">points</span>
+              </td>
             </tr>
           </table>
         </td></tr>
 
-        <!-- Main content -->
-        <tr><td style="padding:32px;">
+        <!-- Change details -->
+        ${changeItems.join("")}
 
-          <!-- Headline -->
-          <div style="font-size:20px;font-weight:700;color:${headlineColor};margin-bottom:8px;">${headline}</div>
-          <div style="font-size:14px;color:#6B6F7B;margin-bottom:24px;">@${safeHandle}</div>
+        <!-- CTA -->
+        <tr><td style="padding-top:24px;padding-bottom:32px;">
+          <a href="${shareUrl}" style="display:inline-block;padding:12px 28px;background:#8B5CF6;color:#FFFFFF;font-family:'Plus Jakarta Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:14px;font-weight:600;text-decoration:none;border-radius:8px;">
+            View Your Updated Badge
+          </a>
+        </td></tr>
 
-          <!-- Score delta card -->
-          <table width="100%" cellpadding="0" cellspacing="0" style="background:#0A0A0F;border-radius:8px;border:1px solid rgba(139,92,246,0.10);margin-bottom:24px;">
-            <tr>
-              <td align="center" style="padding:20px;">
-                <div style="font-size:36px;font-weight:700;color:#4ADE80;">+${Math.round(diff.adjustedComposite)}</div>
-                <div style="font-size:11px;color:#6B6F7B;text-transform:uppercase;letter-spacing:1px;margin-top:4px;">Points</div>
-              </td>
-            </tr>
-          </table>
-
-          ${changeRows.length > 0 ? `
-          <!-- Categorical changes -->
-          <table width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:24px;">
-            ${changeRows.join("")}
-          </table>
-          ` : ""}
-
-          ${dims.length > 0 ? `
-          <!-- Dimension changes -->
-          <div style="font-size:12px;color:#6B6F7B;text-transform:uppercase;letter-spacing:1px;margin-bottom:8px;">Dimension Changes</div>
-          <table width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:24px;">
-            ${dims.map((d) => dimensionDeltaRow(d.label, d.delta)).join("")}
-          </table>
-          ` : ""}
-
-          <!-- CTA button -->
-          <table width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:16px;">
-            <tr>
-              <td align="center">
-                <a href="${shareUrl}" style="display:inline-block;background:#8B5CF6;color:#FFFFFF;text-decoration:none;padding:14px 32px;border-radius:8px;font-size:15px;font-weight:600;">View Your Updated Badge</a>
-              </td>
-            </tr>
-          </table>
-
+        <!-- Footer divider -->
+        <tr><td style="padding-bottom:16px;">
+          <div style="height:1px;background:rgba(139,92,246,0.10);"></div>
         </td></tr>
 
         <!-- Footer -->
-        <tr><td style="padding:16px 32px;border-top:1px solid rgba(139,92,246,0.10);">
-          <table width="100%" cellpadding="0" cellspacing="0">
-            <tr>
-              <td style="font-size:11px;color:#3A3A4A;">chapa.thecreativetoken.com</td>
-              <td align="right"><a href="${unsubscribeUrl}" style="font-size:11px;color:#3A3A4A;text-decoration:underline;">Unsubscribe</a></td>
-            </tr>
-          </table>
+        <tr><td>
+          <span style="font-family:'Plus Jakarta Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:12px;color:#4A4A5E;">
+            chapa.thecreativetoken.com
+          </span>
+          <span style="font-family:'Plus Jakarta Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:12px;color:#4A4A5E;padding-left:12px;">
+            &middot;
+          </span>
+          <a href="${unsubscribeUrl}" style="font-family:'Plus Jakarta Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:12px;color:#4A4A5E;text-decoration:underline;padding-left:12px;">
+            Unsubscribe
+          </a>
         </td></tr>
 
       </table>
@@ -312,35 +345,14 @@ function buildHtml(data: TemplateData): string {
 // HTML helper functions
 // ---------------------------------------------------------------------------
 
-function changeRow(
-  label: string,
-  from: string,
-  to: string,
-  accentColor: string,
-): string {
+function featureRow(text: string): string {
   return `
-    <tr>
-      <td style="padding:8px 0;">
-        <span style="font-size:12px;color:#6B6F7B;text-transform:uppercase;letter-spacing:1px;">${label}</span>
-        <div style="margin-top:4px;">
-          <span style="font-size:14px;color:#9AA4B2;">${escapeHtml(from)}</span>
-          <span style="font-size:14px;color:#6B6F7B;"> → </span>
-          <span style="font-size:14px;font-weight:600;color:${accentColor};">${escapeHtml(to)}</span>
-        </div>
-      </td>
-    </tr>`;
-}
-
-function dimensionDeltaRow(label: string, delta: number): string {
-  const color = delta > 0 ? "#4ADE80" : "#F87171";
-  const sign = delta > 0 ? "+" : "";
-  return `
-    <tr>
-      <td style="padding:4px 12px 4px 0;color:#9AA4B2;font-size:13px;white-space:nowrap;">${label}</td>
-      <td style="padding:4px 0;text-align:right;">
-        <span style="font-size:13px;font-weight:600;color:${color};">${sign}${Math.round(delta)}</span>
-      </td>
-    </tr>`;
+          <tr><td style="padding-bottom:12px;padding-left:8px;">
+            <span style="font-family:'JetBrains Mono',monospace;font-size:13px;color:#8B5CF6;">&rarr;</span>
+            <span style="font-family:'Plus Jakarta Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:14px;color:#E2E4E9;padding-left:8px;">
+              ${text}
+            </span>
+          </td></tr>`;
 }
 
 function formatDelta(n: number): string {

--- a/apps/web/lib/email/score-bump.ts
+++ b/apps/web/lib/email/score-bump.ts
@@ -16,13 +16,26 @@
 import type { SnapshotDiff } from "@/lib/history/diff";
 import type { SignificantChange } from "@/lib/history/significant-change";
 import { getResend, escapeHtml } from "./resend";
-import { EMAIL_FROM } from "./campaigns";
+import { EMAIL_FROM, buildEmailContent } from "./campaigns";
+import {
+  buildAnnouncementHtml,
+  buildAnnouncementText,
+} from "./templates/announcement";
 import { cacheGet, cacheSet } from "@/lib/cache/redis";
 import { dbGetUserEmail } from "@/lib/db/users";
 import { dbGetFeatureFlag } from "@/lib/db/feature-flags";
+import { dbGetActiveEngagementCampaign } from "@/lib/db/campaigns";
 import { getBaseUrl } from "@/lib/env";
 
 const DEDUP_TTL = 604_800; // 7 days in seconds
+
+// ---------------------------------------------------------------------------
+// Interpolation helper
+// ---------------------------------------------------------------------------
+
+function interpolate(template: string, vars: Record<string, string>): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, key) => vars[key as string] ?? "");
+}
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -53,26 +66,59 @@ export async function notifyScoreBump(
     const resend = getResend();
     if (!resend) return;
 
+    // 4b. Check for DB-backed engagement campaign template
+    const engagementCampaign = await dbGetActiveEngagementCampaign();
+
     // 5. Build email
     const baseUrl = getBaseUrl();
     const shareUrl = `${baseUrl}/u/${lowerHandle}`;
     const unsubscribeUrl = `${baseUrl}/api/notifications/unsubscribe?handle=${lowerHandle}`;
 
-    const subject = buildSubject(lowerHandle, diff, significance);
-    const html = buildHtml({
-      handle: lowerHandle,
-      diff,
-      significance,
-      shareUrl,
-      unsubscribeUrl,
-    });
-    const text = buildText({
-      handle: lowerHandle,
-      diff,
-      significance,
-      shareUrl,
-      unsubscribeUrl,
-    });
+    let subject: string;
+    let html: string;
+    let text: string;
+
+    if (engagementCampaign) {
+      // DB-backed engagement template with variable interpolation
+      const delta = `+${Math.round(diff.adjustedComposite)}`;
+      const vars: Record<string, string> = {
+        handle: lowerHandle,
+        delta,
+        tier_from: diff.tier?.from ?? "",
+        tier_to: diff.tier?.to ?? "",
+        archetype_from: diff.archetype?.from ?? "",
+        archetype_to: diff.archetype?.to ?? "",
+      };
+
+      const interpolatedCampaign = {
+        ...engagementCampaign,
+        subject: interpolate(engagementCampaign.subject, vars),
+        headline: interpolate(engagementCampaign.headline, vars),
+        bodyText: interpolate(engagementCampaign.bodyText, vars),
+      };
+
+      subject = interpolatedCampaign.subject;
+      const content = buildEmailContent(interpolatedCampaign, lowerHandle);
+      html = buildAnnouncementHtml(content);
+      text = buildAnnouncementText(content);
+    } else {
+      // Fallback to hardcoded templates
+      subject = buildSubject(lowerHandle, diff, significance);
+      html = buildHtml({
+        handle: lowerHandle,
+        diff,
+        significance,
+        shareUrl,
+        unsubscribeUrl,
+      });
+      text = buildText({
+        handle: lowerHandle,
+        diff,
+        significance,
+        shareUrl,
+        unsubscribeUrl,
+      });
+    }
 
     // 6. Send
     const { error } = await resend.emails.send({

--- a/apps/web/lib/email/templates/announcement.ts
+++ b/apps/web/lib/email/templates/announcement.ts
@@ -39,7 +39,10 @@ function getBaseUrl(): string {
 export function buildAnnouncementHtml(data: AnnouncementData): string {
   const handle = escapeHtml(data.handle);
   const headline = escapeHtml(data.headline);
-  const bodyText = escapeHtml(data.bodyText);
+  const bodyParagraphs = data.bodyText
+    .split(/\n\n+/)
+    .map((p) => escapeHtml(p.trim()))
+    .filter(Boolean);
   const ctaText = escapeHtml(data.ctaText);
   const ctaUrl = escapeHtml(data.ctaUrl);
   const baseUrl = getBaseUrl();
@@ -53,7 +56,7 @@ export function buildAnnouncementHtml(data: AnnouncementData): string {
   const featureRows = data.features
     .map(
       (f) => `
-          <tr><td style="padding-bottom:8px;padding-left:8px;">
+          <tr><td style="padding-bottom:20px;padding-left:8px;">
             <span style="font-family:'JetBrains Mono',monospace;font-size:13px;color:#8B5CF6;">&rarr;</span>
             <span style="font-family:'Plus Jakarta Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:14px;color:#E2E4E9;padding-left:8px;">
               ${escapeHtml(f.text)}
@@ -108,11 +111,11 @@ export function buildAnnouncementHtml(data: AnnouncementData): string {
         </td></tr>
 
         <!-- Body -->
-        <tr><td style="padding-bottom:24px;">
+        ${bodyParagraphs.map((p) => `<tr><td style="padding-bottom:16px;">
           <p style="margin:0;font-family:'Plus Jakarta Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:15px;color:#8B8FA0;line-height:1.6;">
-            ${bodyText}
+            ${p}
           </p>
-        </td></tr>
+        </td></tr>`).join("\n        ")}
 
         <!-- Feature bullets -->
         ${featureRows}

--- a/apps/web/lib/email/templates/announcement.ts
+++ b/apps/web/lib/email/templates/announcement.ts
@@ -111,11 +111,18 @@ export function buildAnnouncementHtml(data: AnnouncementData): string {
         </td></tr>
 
         <!-- Body -->
-        ${bodyParagraphs.map((p) => `<tr><td style="padding-bottom:16px;">
+        ${bodyParagraphs.map((p, i) => {
+          const divider = `<tr><td style="padding-bottom:16px;"><div style="height:1px;background:rgba(139,92,246,0.40);"></div></td></tr>`;
+          let rows = "";
+          if (bodyParagraphs.length > 1 && i === 0) rows += divider;
+          rows += `<tr><td style="padding-bottom:16px;">
           <p style="margin:0;font-family:'Plus Jakarta Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:15px;color:#8B8FA0;line-height:1.6;">
             ${p}
           </p>
-        </td></tr>`).join("\n        ")}
+        </td></tr>`;
+          if (bodyParagraphs.length > 1 && i === 0) rows += divider;
+          return rows;
+        }).join("\n        ")}
 
         <!-- Feature bullets -->
         ${featureRows}

--- a/apps/web/lib/email/templates/announcement.ts
+++ b/apps/web/lib/email/templates/announcement.ts
@@ -6,6 +6,7 @@
  */
 
 import { escapeHtml } from "@/lib/email/resend";
+import { featureRow } from "@/lib/email/html-helpers";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -54,15 +55,7 @@ export function buildAnnouncementHtml(data: AnnouncementData): string {
     : undefined;
 
   const featureRows = data.features
-    .map(
-      (f) => `
-          <tr><td style="padding-bottom:20px;padding-left:8px;">
-            <span style="font-family:'JetBrains Mono',monospace;font-size:13px;color:#8B5CF6;">&rarr;</span>
-            <span style="font-family:'Plus Jakarta Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:14px;color:#E2E4E9;padding-left:8px;">
-              ${escapeHtml(f.text)}
-            </span>
-          </td></tr>`,
-    )
+    .map((f) => featureRow(escapeHtml(f.text), 20))
     .join("");
 
   return `<!DOCTYPE html>

--- a/apps/web/lib/history/significant-change.test.ts
+++ b/apps/web/lib/history/significant-change.test.ts
@@ -48,8 +48,8 @@ describe("isSignificantChange", () => {
       expect(result.significant).toBe(false);
     });
 
-    it("returns insignificant for small score increase (<5)", () => {
-      const result = isSignificantChange(makeDiff({ adjustedComposite: 4.9 }));
+    it("returns insignificant for small score increase (<10)", () => {
+      const result = isSignificantChange(makeDiff({ adjustedComposite: 9.9 }));
       expect(result.significant).toBe(false);
     });
 
@@ -102,7 +102,7 @@ describe("isSignificantChange", () => {
 
   describe("score bump", () => {
     it("detects score bump exactly at threshold", () => {
-      const result = isSignificantChange(makeDiff({ adjustedComposite: 5 }));
+      const result = isSignificantChange(makeDiff({ adjustedComposite: 10 }));
       expect(result.significant).toBe(true);
       if (result.significant) {
         expect(result.reason).toBe("score_bump");
@@ -142,7 +142,7 @@ describe("isSignificantChange", () => {
       const result = isSignificantChange(
         makeDiff({
           archetype: { from: "Quality Champion", to: "Polymath" },
-          adjustedComposite: 8,
+          adjustedComposite: 12,
         }),
       );
       expect(result.significant).toBe(true);
@@ -156,7 +156,7 @@ describe("isSignificantChange", () => {
       const result = isSignificantChange(
         makeDiff({
           tier: { from: "Emerging", to: "Solid" },
-          adjustedComposite: 6,
+          adjustedComposite: 11,
         }),
       );
       expect(result.significant).toBe(true);

--- a/apps/web/lib/history/significant-change.ts
+++ b/apps/web/lib/history/significant-change.ts
@@ -17,7 +17,7 @@ import type { SnapshotDiff } from "./diff";
 // ---------------------------------------------------------------------------
 
 /** Minimum adjusted composite increase to count as significant. */
-const SCORE_BUMP_THRESHOLD = 5;
+const SCORE_BUMP_THRESHOLD = 10;
 
 // ---------------------------------------------------------------------------
 // Types

--- a/apps/web/lib/impact/utils.test.ts
+++ b/apps/web/lib/impact/utils.test.ts
@@ -289,7 +289,7 @@ describe("computeConfidence", () => {
 
   // --- low_activity_signal ---
   describe("low_activity_signal flag", () => {
-    it("applies -10 when activeDays < 30 AND commitsTotal < 50", () => {
+    it("applies -10 when both activeDays < 30 AND commitsTotal < 50", () => {
       const { confidence, penalties } = computeConfidence(
         makeStats({ activeDays: 20, commitsTotal: 30 }),
       );
@@ -299,27 +299,45 @@ describe("computeConfidence", () => {
       expect(penalties[0]!.penalty).toBe(10);
     });
 
-    it("does NOT apply when activeDays >= 30", () => {
+    it("applies when activeDays < 30 even if commitsTotal >= 50", () => {
       const { penalties } = computeConfidence(
-        makeStats({ activeDays: 30, commitsTotal: 10 }),
+        makeStats({ activeDays: 17, commitsTotal: 65 }),
+      );
+      expect(
+        penalties.find((p) => p.flag === "low_activity_signal"),
+      ).toBeDefined();
+    });
+
+    it("applies when commitsTotal < 50 even if activeDays >= 30", () => {
+      const { penalties } = computeConfidence(
+        makeStats({ activeDays: 100, commitsTotal: 30 }),
+      );
+      expect(
+        penalties.find((p) => p.flag === "low_activity_signal"),
+      ).toBeDefined();
+    });
+
+    it("does NOT apply when both activeDays >= 30 AND commitsTotal >= 50", () => {
+      const { penalties } = computeConfidence(
+        makeStats({ activeDays: 30, commitsTotal: 50 }),
       );
       expect(
         penalties.find((p) => p.flag === "low_activity_signal"),
       ).toBeUndefined();
     });
 
-    it("does NOT apply when commitsTotal >= 50", () => {
+    it("applies at boundary: activeDays=29, commitsTotal=50", () => {
       const { penalties } = computeConfidence(
-        makeStats({ activeDays: 10, commitsTotal: 50 }),
+        makeStats({ activeDays: 29, commitsTotal: 50 }),
       );
       expect(
         penalties.find((p) => p.flag === "low_activity_signal"),
-      ).toBeUndefined();
+      ).toBeDefined();
     });
 
-    it("applies at boundary: activeDays=29, commitsTotal=49", () => {
+    it("applies at boundary: activeDays=30, commitsTotal=49", () => {
       const { penalties } = computeConfidence(
-        makeStats({ activeDays: 29, commitsTotal: 49 }),
+        makeStats({ activeDays: 30, commitsTotal: 49 }),
       );
       expect(
         penalties.find((p) => p.flag === "low_activity_signal"),

--- a/apps/web/lib/impact/utils.ts
+++ b/apps/web/lib/impact/utils.ts
@@ -86,7 +86,7 @@ const CONFIDENCE_REASONS: Record<ConfidenceFlag, string> = {
  * | `low_collaboration_signal`  | -10     | >= 10 PRs merged with <= 1 review submitted    |
  * | `single_repo_concentration` | -5      | >= 95% activity in 1 repo, <= 1 repo total     |
  * | `supplemental_unverified`   | -5      | Includes unverified supplemental account data   |
- * | `low_activity_signal`       | -10     | < 30 active days AND < 50 total commits        |
+ * | `low_activity_signal`       | -10     | < 30 active days OR < 50 total commits         |
  * | `review_volume_imbalance`   | -10     | >= 50 reviews submitted with < 3 PRs merged    |
  * | `platform_linked`           | 0       | Verified linked platform (informational only)   |
  *
@@ -179,7 +179,7 @@ export function computeConfidence(
     score -= 5;
   }
 
-  if (stats.activeDays < 30 && stats.commitsTotal < 50) {
+  if (stats.activeDays < 30 || stats.commitsTotal < 50) {
     penalties.push({
       flag: "low_activity_signal",
       penalty: 10,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,7 +20,7 @@
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "canvas-confetti": "^1.9.4",
-    "next": "^16.2.0",
+    "next": "^16.2.1",
     "next-themes": "^0.4.6",
     "posthog-js": "^1.362.0",
     "react": "^19.1.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chapa/web",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/apps/web/public/bimi.svg
+++ b/apps/web/public/bimi.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" version="1.2" baseProfile="tiny-ps" viewBox="0 0 32 32">
+  <title>Chapa</title>
+  <!-- Solid dark background -->
+  <rect width="32" height="32" fill="#0C0D14"/>
+  <!-- Shield -->
+  <path d="M16 4 L26 8 L26 15 C26 21 21 26 16 28 C11 26 6 21 6 15 L6 8 Z"
+        fill="#1A1530" stroke="#8B5CF6" stroke-width="1.2"/>
+  <!-- Chevron -->
+  <path d="M12 19 L16 13 L20 19" stroke="#8B5CF6" stroke-width="2.2"
+        stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/docs/accepted-risks.md
+++ b/docs/accepted-risks.md
@@ -1,6 +1,6 @@
 # Accepted Risks & Known Limitations
 
-> Last reviewed: 2026-02-24 | Audit: v21
+> Last reviewed: 2026-03-22 | Audit: v22
 
 Documented security, infrastructure, and performance decisions that were evaluated during pre-launch audits and accepted as reasonable tradeoffs. Items here are intentional and should not be flagged as warnings in audits.
 
@@ -50,19 +50,41 @@ Documented security, infrastructure, and performance decisions that were evaluat
 - **Severity:** Low
 - **Future improvement:** Add `middleware.ts` with admin route matching when Next.js middleware stabilizes further or if the admin surface area grows significantly.
 
-## MPL-2.0 / LGPL-3.0 dependency (sharp/libvips) (#450)
+## ~~MPL-2.0 / LGPL-3.0 dependency (sharp/libvips) (#450)~~ — Resolved
 
-- **Risk:** The `sharp` image processing library is MPL-2.0 licensed and depends on `libvips` which is LGPL-3.0 (dynamically linked). Neither is on the project's explicit allowlist (MIT, Apache-2.0, BSD, ISC).
-- **Mitigation:** `sharp` is used by Next.js for image optimization and by `@resvg/resvg-js` for OG image generation — no viable alternative exists. LGPL-3.0 with dynamic linking does not require open-sourcing our code. MPL-2.0 is file-level copyleft only — modifications to MPL-licensed files must be shared, but our own code is unaffected. Both are compatible with our MIT license.
+- **Risk:** The `sharp` image processing library was MPL-2.0 licensed and depends on `libvips` which is LGPL-3.0 (dynamically linked).
+- **Resolution:** As of `sharp@0.34.5`, the package license changed to **Apache-2.0**, which is on the project allowlist. LGPL-3.0 for libvips (dynamically linked) remains acceptable — dynamic linking does not require open-sourcing our code.
+- **Severity:** None (resolved)
+- **Accepted:** 2026-02-21 | **Updated:** 2026-03-22
+
+## MPL-2.0 dependency (@resvg/resvg-js) (#464, #596)
+
+- **Risk:** `@resvg/resvg-js@2.6.2` (and its platform-specific binary `@resvg/resvg-js-darwin-arm64`) uses MPL-2.0 (weak copyleft), which is not on the project's explicit allowlist (MIT, Apache-2.0, BSD, ISC). Used for SVG-to-PNG rendering in OG image generation.
+- **Note:** `@vercel/analytics` was previously MPL-2.0 but has changed to **MIT** as of v2.0.1, resolving that concern.
+- **Mitigation:** MPL-2.0 is a file-level weak copyleft license — it only requires sharing modifications to the MPL-licensed source files themselves. Chapa uses the package as an unmodified dependency via its public API, so there is no obligation to open-source any of Chapa's own code. MPL-2.0 is not GPL, AGPL, or LGPL and is explicitly compatible with proprietary and MIT-licensed projects. No modifications are made to the package's source files.
 - **Severity:** Low
-- **Accepted:** 2026-02-21
+- **Accepted:** 2026-02-24 | **Updated:** 2026-03-22
 
-## MPL-2.0 dependencies (@resvg/resvg-js, @vercel/analytics) (#464)
+## Wildcard CORS on /api/verify/[hash] (#596)
 
-- **Risk:** Two production dependencies use MPL-2.0 (weak copyleft), which is not on the project's explicit allowlist (MIT, Apache-2.0, BSD, ISC). `@resvg/resvg-js` is used for SVG-to-PNG rendering and `@vercel/analytics` provides Vercel web analytics.
-- **Mitigation:** MPL-2.0 is a file-level weak copyleft license — it only requires sharing modifications to the MPL-licensed source files themselves. Chapa uses both packages as unmodified dependencies via their public APIs, so there is no obligation to open-source any of Chapa's own code. MPL-2.0 is not GPL, AGPL, or LGPL and is explicitly compatible with proprietary and MIT-licensed projects. No modifications are made to either package's source files.
+- **Risk:** The badge verification endpoint uses `Access-Control-Allow-Origin: *`, allowing any origin to call it from client-side JavaScript.
+- **Mitigation:** Intentional design. The verification endpoint is public, read-only, and rate-limited. Badge embeds on third-party sites (READMEs, portfolios, blogs) need client-side verification capability — restricting CORS would break the core use case. The endpoint returns only verification status and public badge data; no sensitive information is exposed.
 - **Severity:** Low
-- **Accepted:** 2026-02-24
+- **Accepted:** 2026-03-22
+
+## dangerouslySetInnerHTML with server-rendered SVG (#596)
+
+- **Risk:** The share page (`/u/[handle]/page.tsx`), landing page, and archetype pages inject badge SVG into the DOM via `dangerouslySetInnerHTML`, which bypasses React's XSS protections.
+- **Mitigation:** Safe because all SVG is generated server-side by `renderBadgeSvg()` with `escapeXml()` (in `lib/render/escape.ts`) applied to all user-controlled text (GitHub handle, display name). No user-controlled raw SVG reaches any `dangerouslySetInnerHTML` injection point. The SVG rendering pipeline is a pure function that takes sanitized inputs and produces deterministic output.
+- **Severity:** Low
+- **Accepted:** 2026-03-22
+
+## Turbopack NFT trace warning on agents-summary route (#596)
+
+- **Risk:** The `/api/admin/agents-summary` route uses `process.cwd()` + `node:fs` to read agent log files at runtime, causing a Turbopack "NFT trace" build warning about dynamic filesystem access.
+- **Mitigation:** This is an admin-only route behind session auth + `ADMIN_HANDLES` check. The `process.cwd()` pattern is documented in code comments (see `apps/web/app/api/admin/agents-summary/route.ts:61`). Alternative approaches (`import.meta.dirname` with relative traversal) are more brittle. The warning is cosmetic — no user-facing impact, no data leakage, no functional issue.
+- **Severity:** None (cosmetic build warning)
+- **Accepted:** 2026-03-22
 
 ---
 
@@ -92,6 +114,13 @@ Documented security, infrastructure, and performance decisions that were evaluat
 - **Mitigation:** Bundle size is monitored via CI workflows (Dead Code Detection + Bundle Size Analysis). Individual chunks are inspected from `.next/static/chunks/`. The largest chunk is 219KB — well under the 500KB threshold. No route exceeds 300KB.
 - **Severity:** Low
 - **Accepted:** 2026-02-21
+
+## Experiment pages fully client-rendered (#596)
+
+- **Risk:** All 13 experiment pages (`/experiments/*`) use `"use client"`, meaning they are fully client-rendered with no SSR benefits (SEO, initial paint from server HTML).
+- **Mitigation:** Intentional design. Experiment pages are visual demos for badge effects (particles, 3D tilt, aurora, hexmap, etc.) that rely heavily on canvas, requestAnimationFrame, and interactive state — SSR provides no benefit for these. All 13 pages are gated behind the `experiments_enabled` feature flag (disabled by default in production). They are internal prototyping tools, not user-facing production features.
+- **Severity:** None
+- **Accepted:** 2026-03-22
 
 ---
 

--- a/docs/agents/pre-launch-report.md
+++ b/docs/agents/pre-launch-report.md
@@ -1,12 +1,12 @@
-# Pre-Launch Audit Report (v35)
+# Pre-Launch Audit Report (v36)
 
-> Generated on 2026-03-22 | Branch: `develop` | Commit: `5cc834b`
-> 5,680 tests | 330 test files | 64+ routes | Next.js 16.2.0 (Turbopack)
-> CI: ALL GREEN (5/5 workflows passed) | 6 parallel specialists
+> Generated on 2026-03-22 | Branch: `develop` | Commit: `f1d2f63`
+> 5,706 tests | 331 test files | 42 API routes | Next.js 16.2.1 (Turbopack)
+> CI: ALL GREEN | 6 parallel specialists
 
 ## Verdict: CONDITIONAL
 
-No blockers. 7 warnings (1 medium, 6 low). All warnings are non-critical — safe to release with awareness.
+No blockers found. 14 warnings across all specialists — mostly minor (untested error boundaries, experiment page a11y, documented accepted risks). The codebase is production-ready with optional fixes.
 
 ## Blockers (must fix before release)
 
@@ -16,181 +16,83 @@ None.
 
 | # | Issue | Severity | Found by | Risk |
 |---|-------|----------|----------|------|
-| W1 | 2 unpushed commits on `develop` | MEDIUM | devops | Must push before release PR — commits not CI-validated on remote |
-| W2 | `flatted` prototype pollution (HIGH CVE) — dev-only transitive dep via eslint | LOW | architect, security | Dev-only (eslint > flat-cache > flatted), not shipped to production |
-| W3 | `@resvg/resvg-js` uses MPL-2.0 license (project policy: MIT/Apache/BSD/ISC) | LOW | security | Weak copyleft, file-level only. Used as-is, no modifications. Accepted risk. |
-| W4 | 14 stale remote branches already merged into `develop` | LOW | devops | Clutter, no functional impact |
-| W5 | Heading hierarchy violation in `/experiments/gradient-border` page | LOW | ux-reviewer | Feature-flagged experiment page, low traffic |
-| W6 | Experiment pages missing individual `loading.tsx` files | LOW | ux-reviewer | Feature-flagged, shared parent error boundary exists |
-| W7 | Build cache warnings for `/studio` route (dynamic rendering fallback) | LOW | devops | Informational only — Next.js correctly falls back to dynamic rendering |
+| W1 | MPL-2.0 dependencies detected (2 packages) | Low | security | License policy states MIT/Apache/BSD/ISC only; MPL-2.0 is weak copyleft, likely acceptable |
+| W2 | `Access-Control-Allow-Origin: *` on `/api/verify/[hash]` | Low | security | Read-only public endpoint with rate limiting; likely intentional for embedded badge verification |
+| W3 | `dangerouslySetInnerHTML` used with server-rendered SVG on share page | Low | security | SVG is server-generated with `escapeXml()` on all user input; safe as implemented |
+| W4 | Fail-open rate limiting when Redis unavailable | Low | security | Documented accepted risk; GitHub API limits and CDN caching provide secondary protection |
+| W5 | Campaign form inputs lack `htmlFor`/`id` label association (~12 inputs) | Medium | ux | Screen readers won't associate labels with inputs in campaign create/edit forms |
+| W6 | "Remove feature" button in campaigns form lacks `aria-label` | Low | ux | Renders only `&times;` character; screen reader users hear nothing meaningful |
+| W7 | 7 experiment pages use `<div>` instead of `<main>` for `#main-content` landmark | Low | ux | Inconsistent with rest of app; behind feature flag |
+| W8 | `html-helpers.ts` has no direct test file | Low | qa | `featureRow()` is tested indirectly via email tests |
+| W9 | 5 error boundary files lack dedicated tests | Very Low | qa | Simple UI components; 7 other error boundaries are tested |
+| W10 | Expected stderr output in error-handling tests | Very Low | qa | Intentional — tests verify 500 error handling; cosmetic noise |
+| W11 | Turbopack NFT trace warning from agents-summary route | Low | performance | Admin-only route using `process.cwd()` + `node:fs`; already documented in code |
+| W12 | 13 experiment pages fully client-rendered | Low | performance | Behind feature flag; cannot benefit from SSR |
+| W13 | Minor outdated dev dependencies (vitest 4.0.18→4.1.0, jsdom 29.0.0→29.0.1) | Very Low | architect | Patch/minor bumps, dev-only |
+| W14 | Untracked plan files in working tree | Very Low | devops | `docs/plans/2026-03-22-scoring-accuracy-fixes*` — documentation only |
 
 ## Detailed Findings
 
----
-
 ### 1. Quality Assurance (qa-lead) — GREEN
 
-**Test Suite:**
-- 330 test files, 5,680 tests, **100% pass rate**
-- Duration: 13.94s
-- TypeScript: clean | ESLint: clean (0 errors, 0 warnings)
-
-**Critical Path Coverage:**
-
-| Module | Test Files | Status |
-|--------|-----------|--------|
-| `lib/impact/` (scoring) | 6 test files | COVERED |
-| `lib/render/` (SVG rendering) | 11 test files | COVERED |
-| `lib/auth/` (OAuth/auth) | 8 test files | COVERED |
-| `lib/cache/` (Redis cache) | 3 test files | COVERED |
-| `lib/github/` (GitHub data) | 4 test files | COVERED |
-| `lib/db/` (Supabase data access) | 11 test files | COVERED |
-| `lib/history/` (lifetime history) | 5 test files | COVERED |
-| `app/api/` (API routes) | 41/41 route handlers tested | COVERED |
-
-**Graceful Degradation:** STRONG
-- GitHub rate limit (403): serves stale cached data (7d TTL)
-- Redis unavailability: fail-open design, all requests allowed
-- Supabase downtime: returns sensible defaults (null/false/0)
-- All degradation paths have corresponding test assertions
-
----
+- **5706 tests, 0 failures**, 331 test files
+- TypeScript: PASS, Lint: PASS
+- **100% API route test coverage** — every one of 42 route files has a corresponding test
+- Critical paths fully covered: impact scoring (103+ tests), SVG rendering (72+ tests), OAuth (12 test files), GitHub stats (52+ tests), cache layer (56+ tests), stats aggregation (44+ tests)
+- Graceful degradation verified: Redis fail-open, Supabase graceful null, badge fallback SVG, stale cache serving, 12 error boundaries
 
 ### 2. Security (security-reviewer) — GREEN
 
-**Dependency Vulnerabilities:**
-
-| Severity | Package | Description | Production? |
-|----------|---------|-------------|-------------|
-| High | `flatted` <=3.4.1 | Prototype pollution via parse() | No (dev-only, eslint) |
-
-**Hardcoded Secrets:** None found. All test files use mock values. All env vars use `.trim()`.
-
-**XSS/Injection:** `escapeXml()` consistently applied across all SVG user-input entry points. Avatar URL validated against allowlist.
-
-**Authentication:** STRONG
-- AES-256-GCM encrypted tokens in HttpOnly/Secure/SameSite=Lax cookies
-- CSRF state with `crypto.randomBytes(16)` + `timingSafeEqual` validation
-- Open redirect protection via `isSafeRedirect()`
-- Rate limiting on all auth endpoints
-
-**Client Secret Exposure:** None. All `NEXT_PUBLIC_*` vars are non-sensitive.
-
-**Security Headers:** Comprehensive — HSTS (2yr + preload), CSP, X-Content-Type-Options, X-XSS-Protection, Referrer-Policy, Permissions-Policy.
-
-**License Compliance:** Clean. 1 MPL-2.0 dep (`@resvg/resvg-js`) — accepted risk, used as-is.
-
----
+- `pnpm audit`: **0 vulnerabilities**
+- No hardcoded secrets in source code
+- No secrets in `NEXT_PUBLIC_*` variables
+- OAuth: CSRF protection with `timingSafeEqual`, AES-256-GCM encrypted sessions, open redirect prevention, rate limiting on auth routes
+- SVG XSS: `escapeXml()` applied consistently to all user-controlled text
+- Security headers: HSTS, X-Content-Type-Options, CSP, X-Frame-Options, Permissions-Policy
+- Rate limiting on every public API route
+- Sensitive data stripped from error telemetry (`server-errors.ts`)
 
 ### 3. Infrastructure (devops) — YELLOW
 
-**Build:** PASS — Next.js 16.2.0 Turbopack, zero errors.
+- CI: All checks passing on develop (Secret Scanning, Security Scan, Bundle Size, Dead Code all green)
+- Health endpoint: Returns JSON with Redis + Supabase dependency checks, 503 on degraded
+- Cache headers: Match documented spec (`s-maxage=21600, stale-while-revalidate=604800`)
+- Vercel cron: 3 jobs configured, all with `CRON_SECRET` auth, all with test files
+- Error pages: `not-found.tsx` and `error.tsx` exist with design system tokens
+- Git state: Clean (only untracked plan documents)
+- No stale worktrees
+- Env var documentation: 31 unique vars, all documented in CLAUDE.md
+- Yellow only due to untracked plan files (W14) — not a real issue
 
-**CI Status (all green):**
+### 4. Architecture (architect) — GREEN
 
-| Workflow | Status |
-|----------|--------|
-| CI (lint/test/build/e2e) | success |
-| Bundle Size Analysis | success |
-| Dead Code Detection | success |
-| Security Scan | success |
-| Secret Scanning | success |
-
-**Environment Variables:** All 30 documented vars accounted for. No undocumented env vars found.
-
-**Error Pages:** All 3 exist (`not-found.tsx`, `error.tsx`, `global-error.tsx`).
-
-**Health Endpoint:** Returns JSON with status, timestamp, dependencies. Rate-limited. HTTP 503 on degraded state.
-
-**Git State:**
-- Branch: `develop`, 2 commits ahead of `origin/develop` (unpushed)
-- Working tree: clean
-- No stale worktrees, no stashed changes
-- 14 stale remote branches (merged, should be cleaned up)
-
-**Vercel Config:** 3 cron jobs properly configured with `CRON_SECRET` auth.
-
----
-
-### 4. Architecture (architect) — YELLOW
-
-**TypeScript:** PASS — zero errors. Strict mode enabled everywhere (`strict: true`, `noUncheckedIndexedAccess: true`).
-
-**Outdated Dependencies:**
-
-| Package | Current | Latest | Type |
-|---------|---------|--------|------|
-| `jsdom` (dev) | 29.0.0 | 29.0.1 | patch |
-| `@vitest/coverage-v8` (dev) | 4.0.18 | 4.1.0 | minor |
-| `vitest` (dev) | 4.0.18 | 4.1.0 | minor |
-
-No major version bumps. All are minor/patch, safe to update.
-
-**Circular Dependencies:** PASS — 620 files scanned, 0 circular deps.
-
-**Dead Code:** PASS — `knip` reports zero findings.
-
-**Duplicate Code:** 2.38% line duplication (64 clones), all in test files. Production code duplication is minimal.
-
----
+- TypeScript: Zero errors, `strict: true` + `noUncheckedIndexedAccess: true` across all configs
+- Circular dependencies: **0 cycles** (637 files processed)
+- Dead code (knip): **Clean** — no unused files, exports, or dependencies
+- Zero `@ts-ignore`, `@ts-expect-error`, or `as any` in production code
+- Zero TODO/FIXME/HACK comments in production code
+- pnpm overrides address known transitive vulnerabilities (minimatch, dompurify, ajv, rollup, flatted, undici)
 
 ### 5. Performance (performance-eng) — GREEN
 
-**Build Output:** Compiled successfully. No routes exceed 500KB compressed.
+- Build: PASS (Turbopack, Next.js 16.2.1)
+- Largest chunk: 228 KB (well under 500 KB threshold)
+- Fonts: `next/font/google` with `display: "swap"` — no CLS risk
+- PostHog: Lazy-loaded on first interaction (5s fallback) — out of initial bundle
+- Dynamic imports: Used correctly for heavy components (chart effects, command bar, confetti)
+- `"use client"` boundaries: Well-placed — root layout is server component, client wrappers are thin
+- Images: All use `next/image` in production components
+- Supabase: Server-only import — no client bundle leakage
 
-**Route Sizes (First Load JS, uncompressed — compresses ~65-70% with gzip):**
+### 6. UX/Accessibility (ux-reviewer) — GREEN
 
-| Route | Uncompressed | Page-specific JS |
-|-------|-------------|------------------|
-| `/u/[handle]` | 702 KB | ~124 KB |
-| `/studio` | 691 KB | ~113 KB |
-| `/admin` | 675 KB | ~97 KB |
-| `/` (landing) | 654 KB | ~76 KB |
-| `/about/*`, `/archetypes/*` | 654 KB | ~76 KB |
-| `/_not-found` (baseline) | 578 KB | 0 KB |
-
-Framework baseline is 569KB uncompressed (~170KB compressed). Page-specific JS ranges from 0–124KB.
-
-**Code Splitting:** Excellent — production pages are Server Components, `"use client"` only at leaf-level interactive components. Heavy components (`PostHog`, `canvas-confetti`, admin sub-dashboards) properly lazy-loaded via `next/dynamic`.
-
-**Font Loading:** Optimal — `display: "swap"`, self-hosted via `next/font/google`.
-
-**No barrel exports** — direct imports throughout, enabling clean tree-shaking.
-
----
-
-### 6. UX/Accessibility (ux-reviewer) — YELLOW
-
-**Heading Hierarchy:** PASS on production pages. Minor violation in experiment page (`/experiments/gradient-border`).
-
-**ARIA Labels:** PASS — comprehensive implementation across all interactive components. Decorative icons use `aria-hidden="true"`. Proper roles on dialogs, menus, listboxes.
-
-**Focus Indicators:** PASS — global `*:focus-visible` ring. Skip-to-content link present.
-
-**Reduced Motion:** PASS — global `prefers-reduced-motion` override + component-level checks. Defense-in-depth.
-
-**Keyboard Navigation:** PASS — all interactive elements properly accessible. Focus trap in MobileNav. Enter/Space support on custom buttons.
-
-**Error/Loading States:** PASS — root-level + 12 route-level error boundaries. 11 loading.tsx files covering key routes.
-
-**Design System Consistency:** PASS — semantic color tokens used throughout. No hardcoded hex in production components.
-
----
-
-## Summary
-
-| Specialist | Status | Key Metric |
-|------------|--------|------------|
-| QA Lead | GREEN | 5,680 tests, 100% pass, 41/41 API routes tested |
-| Security | GREEN | 0 production vulns, auth strong, XSS escaped |
-| DevOps | YELLOW | Build passes, CI 5/5 green, 2 unpushed commits |
-| Architect | YELLOW | 0 circular deps, 0 dead code, flatted override needs bump |
-| Performance | GREEN | Page-specific JS ≤124KB, code splitting excellent |
-| UX/A11y | YELLOW | Full ARIA, keyboard nav, minor experiment page issues |
-
-## Recommended Next Steps
-
-1. **Push unpushed commits** — `git push origin develop` to sync and trigger CI
-2. **Clean up stale remote branches** — 14 merged branches to delete
-3. **Bump `flatted` override** — change `>=3.4.0` to `>=3.4.2` in package.json to clear audit warning
-4. **Create release PR** (`develop` -> `main`) after CI confirms green
+- Heading hierarchy: Correct h1→h2→h3 across all production pages
+- ARIA: Comprehensive — buttons, navs, menus, dialogs, SVG icons all properly labeled
+- Focus indicators: Global `*:focus-visible` with amber outline + skip-to-content link
+- `prefers-reduced-motion`: Supported in 33 files + global CSS blanket rule
+- Alt text: All images have alt attributes
+- Keyboard navigation: Full support — tab order, Enter/Space handlers, escape-to-close, focus traps
+- Error boundaries: 12 route-level + global-error.tsx
+- Loading states: Present for all async routes with `role="status"` and sr-only text
+- Design system: Zero hardcoded hex colors in components; all use semantic tokens
+- Live regions: `aria-live="polite"` on dynamic content, `role="alert"` on errors

--- a/docs/agents/pre-launch-report.md
+++ b/docs/agents/pre-launch-report.md
@@ -1,7 +1,7 @@
 # Pre-Launch Audit Report (v36)
 
 > Generated on 2026-03-22 | Branch: `develop` | Commit: `f1d2f63`
-> 5,706 tests | 331 test files | 42 API routes | Next.js 16.2.1 (Turbopack)
+> 5,763 tests | 337 test files | 42 API routes | Next.js 16.2.1 (Turbopack)
 > CI: ALL GREEN | 6 parallel specialists
 
 ## Verdict: CONDITIONAL

--- a/docs/agents/remediation-report.md
+++ b/docs/agents/remediation-report.md
@@ -1,46 +1,55 @@
 # Remediation Report
 
-> Generated on 2026-03-22 | Branch: `develop` | 6 findings resolved
+> Generated on 2026-03-22 | Branch: `develop` | Commit: `8f1b686` | 14 findings resolved
 >
-> Pre-launch report: `docs/agents/pre-launch-report.md` (v35)
+> Pre-launch report: `docs/agents/pre-launch-report.md` (v36)
 
 ## Summary
+- Findings processed: 14 (all warnings from pre-launch audit)
+- Issues created: 6 (#592–#597)
+- Issues resolved: 6/6
+- Tests added: 57 (5706 → 5763)
+- Files modified: 26
+- CI status: PASSING
 
-- Findings processed: 7
-- Findings resolved: 6
-- Accepted risk (no action): 1 (W3 — MPL-2.0 license on `@resvg/resvg-js`)
-- Tests added: 0 (all fixes were config/UX — non-testable)
-- Files modified: 5
-- CI status: PENDING (pushed, monitoring)
+## Issues Resolved
 
-## Findings Resolved
+| # | Issue | Domain | Severity | Tests Added | Status |
+|---|-------|--------|----------|-------------|--------|
+| #592 | Campaign form a11y: label associations + aria-label | ux | Medium | 4 | Closed |
+| #593 | Experiment page landmarks: div → main | ux | Low | 13 (regression test) | Closed |
+| #594 | Missing tests: html-helpers + 5 error boundaries | qa | Low | 40 (9 + 31) | Closed |
+| #595 | Suppress expected stderr in error-handling tests | infra | Very Low | 0 (existing tests improved) | Closed |
+| #596 | Document accepted risks (W1-W4, W11, W12) | docs | Low | 0 (documentation) | Closed |
+| #597 | Update dev deps + commit plan files | infra | Very Low | 0 (maintenance) | Closed |
 
-| # | Finding | Domain | Severity | Fix | Status |
-|---|---------|--------|----------|-----|--------|
-| W1 | 2 unpushed commits on develop | devops | MEDIUM | `git push origin develop` | DONE |
-| W2 | `flatted` prototype pollution CVE | security | LOW | Bumped override `>=3.4.0` → `>=3.4.2` in package.json | DONE |
-| W3 | `@resvg/resvg-js` MPL-2.0 license | security | LOW | Accepted risk — weak copyleft, used as-is | NO ACTION |
-| W4 | 14 stale remote branches | devops | LOW | Deleted 3 + pruned 15 stale refs | DONE |
-| W5 | Heading hierarchy in gradient-border | ux | LOW | Changed `<h3>` → `<h2>` in `BorderWrapper` | DONE |
-| W6 | Experiment pages missing loading.tsx | ux | LOW | Added shared `experiments/loading.tsx` | DONE |
-| W7 | Studio build cache warnings | devops | LOW | Added `export const dynamic = 'force-dynamic'` | DONE |
+## Findings Coverage
 
-## Commits
-
-```
-a8664d5 chore(deps): bump flatted override to >=3.4.2 (CVE fix)
-3850183 fix(ux): fix experiment heading hierarchy and add loading states
-b435c31 fix(studio): add force-dynamic to suppress build cache warnings
-```
+| Finding | Resolution |
+|---------|-----------|
+| W1 MPL-2.0 deps | Documented: only `@resvg/resvg-js` remains MPL-2.0; `sharp` now Apache-2.0 |
+| W2 Wildcard CORS on verify | Documented as intentional (badges need client-side verification) |
+| W3 dangerouslySetInnerHTML SVG | Documented as safe (server-rendered, escapeXml on all user input) |
+| W4 Fail-open rate limiting | Already documented; confirmed current |
+| W5 Campaign form labels | Fixed: 15 htmlFor/id pairs added |
+| W6 Remove feature aria-label | Fixed: aria-label="Remove feature" added |
+| W7 Experiment page landmarks | Fixed: 7 pages changed div→main, nested main conflicts resolved |
+| W8 html-helpers no test file | Fixed: 9 tests in new html-helpers.test.ts |
+| W9 5 error boundaries untested | Fixed: 31 tests across 5 new test files |
+| W10 Test stderr noise | Fixed: console.error mocked in 3 test suites |
+| W11 Turbopack NFT trace | Documented as accepted (admin-only, code-documented) |
+| W12 Experiment pages client-rendered | Documented as accepted (feature-flagged, interactive demos) |
+| W13 Outdated dev deps | Fixed: vitest 4.1.0, jsdom 29.0.1 |
+| W14 Untracked plan files | Fixed: committed to repo |
 
 ## Final Verification
-
-- [x] All tests passing (5,680 tests, 330 files)
+- [x] All tests passing (5763)
 - [x] Typecheck clean
 - [x] Lint clean
-- [x] Pushed to origin/develop
-- [ ] CI green (monitoring)
+- [x] CI green on develop
+- [x] All worktrees removed
+- [x] All remediation branches deleted
+- [x] All 6 issues closed
 
 ## Remaining Items
-
-None. All findings addressed.
+None. All 14 findings resolved.

--- a/docs/agents/shared-context.md
+++ b/docs/agents/shared-context.md
@@ -35,7 +35,7 @@
 <!-- ENTRY:START agent=performance timestamp=2026-03-12T17:15:00Z -->
 ## Performance Engineer — 2026-03-12
 - **Status**: GREEN
-- Build: Next.js 16.1.6 (Turbopack), compiles in 2.7s, 0 TypeScript errors
+- Build: Next.js 16.2.1 (Turbopack), compiles in 2.7s, 0 TypeScript errors
 - Total client JS: 1,434 KB (1.4 MB) across 53 chunks. No chunk exceeds 500 KB. +58 KB vs last report (moderate, no action needed).
 - Largest chunk: 219 KB (Next.js framework). PostHog at 175 KB (lazy-loaded on first interaction — optimal).
 - **Share page ISR: RESOLVED** — `revalidate=3600` now in place with test assertion at `page.test.ts:120`.

--- a/docs/agents/update-docs-report.md
+++ b/docs/agents/update-docs-report.md
@@ -1,35 +1,37 @@
 # Documentation Update Report
 
-> Generated on 2026-03-22 | Branch: `develop` | Changes since v1.2.0 (384 commits)
+> Generated on 2026-03-22 | Branch: `develop` | Changes since v2.0.0 (30 commits)
 
 ## Summary
-
-- **7 documents updated**
-- 0 diagrams refreshed (ASCII diagrams flagged for review but not confidently updatable)
-- 1 version reference corrected (TypeScript badge 5.7 → 5.9)
-- 0 inline doc blocks updated (existing JSDoc was current)
+- 6 documents updated
+- 0 diagrams refreshed (all current)
+- 2 version references corrected
+- 0 inline doc blocks updated (all current)
 - 0 items flagged [NEEDS REVIEW]
 
 ## Changes by File
 
-| File | What Changed | Why |
-|------|-------------|-----|
-| `CHANGELOG.md` | Added comprehensive `[Unreleased]` section covering all 384 commits since v1.2.0 | Only had 1.0.0 entry — 5 weeks of features missing |
-| `README.md` | Updated TypeScript badge (5.7→5.9), added multi-platform support, v4→v6 scoring, Craft dimension, Artificer archetype, Supabase to tech stack, Bitbucket/Codeberg env vars, updated test count (77→330+), project structure, key endpoints | Multiple stale references throughout |
-| `docs/how-it-works.md` | v4→v6 references, added Craft dimension section, added Artificer archetype, added multi-platform integration section, Redis sorted sets→Supabase, updated data sources to include Bitbucket/Codeberg | Core explainer was stale on 3 major features |
-| `docs/spec.md` | v4→v6 references, 4→4–5 dimensions | Product spec referenced outdated scoring version |
-| `docs/demo.md` | v4→v6, added multi-platform and Craft mentions, updated radar chart description | Demo script didn't mention new features |
-| `docs/supabase-migration-plan.md` | Status: Draft → Complete | Migration is done |
-| `docs/agents/pre-launch-report.md` | Updated to v35 with current audit results | Was from previous audit cycle |
+### `docs/how-it-works.md` (3 fixes)
+- **Caps table**: Updated from V4 caps (600/180/15/500/200/100) to V5 caps (300/80/12/150/80), removed watchers row
+- **Dimension weights**: Consistency updated from 50%/35%/15% to 45%/40%/15%; Breadth updated from V4 to V5 weights (40%/25%/15%/10%/5%)
+- **Confidence table**: `low_activity_signal` trigger changed from "AND" to "OR"
+- **FAQ**: Added Craft dimension and Artificer archetype mention
 
-## Diagrams Reviewed (No Changes Made)
+### `CHANGELOG.md`
+- Added `[Unreleased]` section documenting all 30 commits since v2.0.0: campaign type system, scoring accuracy fixes, a11y improvements, email enhancements, dependency updates
 
-The following ASCII diagrams were reviewed but not modified — they depict specific flows (EMU merge, email forwarding) that remain accurate for their scope. The new multi-platform content was added as a new section rather than modifying existing diagrams.
+### `README.md`
+- Test counts updated from "330+ files, 5,680+ tests" to "337+ files, 5,760+ tests"
 
-- `docs/how-it-works.md:238-298` — EMU merge flow (still accurate for EMU-specific flow)
-- `docs/scheduled-agents-admin-panel.md:24-48` — Agent architecture (current)
-- `docs/email-forwarding-setup.md:7-17` — Email pipeline (current)
+### `CLAUDE.md`
+- Goal #2: "Impact v4 Profile" → "Impact v6 Profile"
+- Engineering rule #6: "Impact v4 compute" → "Impact v6 compute"
+
+### `docs/agents/shared-context.md`
+- Next.js version reference updated from 16.1.6 to 16.2.1
+
+### `docs/agents/pre-launch-report.md`
+- Test counts updated from 5,706/331 to 5,763/337
 
 ## Flagged for Review
-
 None.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -67,14 +67,13 @@ This produces a value between 0 and 1. Pushing 1000 commits does not produce a s
 
 | Signal | Cap | Rationale |
 |--------|-----|-----------|
-| Commits | 600 | ~1.6/day average is strong; more adds no extra credit |
-| PR Weight | 120 | Weighted by complexity, not count; cap prevents inflation |
-| Reviews | 180 | Encourages collaboration without requiring extreme volume |
-| Issues | 80 | Meaningful issue resolution, not ticket churn |
-| Repos | 15 | Cross-project work beyond 15 repos is fully credited |
-| Stars | 500 | Community recognition signal; log-normalized |
-| Forks | 200 | People building on your work; log-normalized |
-| Watchers | 100 | People actively following your repos; log-normalized |
+| Commits | 300 | Consistent contribution; diminishing returns beyond ~1/day |
+| PR Weight | 60 | Weighted by complexity, not count; cap prevents inflation |
+| Reviews | 80 | Encourages collaboration without requiring extreme volume |
+| Issues | 40 | Meaningful issue resolution, not ticket churn |
+| Repos | 12 | Cross-project work beyond 12 repos is fully credited |
+| Stars | 150 | Community recognition signal; log-normalized |
+| Forks | 80 | People building on your work; log-normalized |
 
 ### The core dimensions (each 0-100)
 
@@ -82,8 +81,8 @@ This produces a value between 0 and 1. Pushing 1000 commits does not produce a s
 |-----------|-----------------|-------------------|
 | **Delivery** | Shipping meaningful changes | PR weight (70%), issues closed (20%), commits (10%) |
 | **Quality** | Engineering discipline | **Collaborative:** Reviews (60%), review-to-PR ratio (25%), inverse micro-commit ratio (15%). **Solo:** PR description rate (40%), feature branch rate (25%), issue linkage rate (20%), inverse micro-commit ratio (15%) |
-| **Consistency** | Reliable, sustained contributions | Active days / 365 (50%), heatmap evenness (35%), inverse burst activity (15%) |
-| **Breadth** | Cross-project influence | Repos contributed (35%), inverse top-repo share (25%), stars (15%), forks (10%), watchers (5%), docs-only PR ratio (10%) |
+| **Consistency** | Reliable, sustained contributions | sqrt(activeDays/365) (45%), heatmap evenness (40%), inverse burst activity (15%) |
+| **Breadth** | Cross-project influence | Repos contributed (40%), inverse top-repo share (25%), docs-only PR ratio (15%), stars (10%), forks (5%) |
 
 Each dimension returns 0 when the primary signal is completely absent. Quality adapts to your profile type: collaborative developers are scored on code reviews, while solo developers (zero reviews) are scored on PR hygiene signals (descriptions, feature branches, issue linkage). Solo Quality returns 0 only if you have zero merged PRs.
 
@@ -155,7 +154,7 @@ Confidence starts at 100 and can be reduced by detected patterns:
 | Low collaboration | -10 | 10+ PRs merged AND 1 or fewer reviews given | Significant output without peer interaction |
 | Single repo focus | -5 | 95%+ of activity in one repo AND only 1 repo | Less cross-project signal (not bad, just less diverse data) |
 | Supplemental data | -5 | Includes merged EMU account data | Data from a linked account that cannot be independently verified |
-| Low activity signal | -10 | Fewer than 30 active days AND fewer than 50 commits | Very limited activity reduces the signal available for scoring |
+| Low activity signal | -10 | Fewer than 30 active days OR fewer than 50 commits | Very limited activity reduces the signal available for scoring |
 | Review volume imbalance | -10 | 50+ reviews AND fewer than 3 merged PRs | High review volume with very few merged changes reduces confidence in the activity mix |
 
 **Confidence floor:** 50. No combination of penalties can push confidence below 50. Note: "Low collaboration" and "Review volume imbalance" are mutually exclusive (one requires ≤ 1 reviews, the other ≥ 50), so the maximum simultaneous penalties is 7.
@@ -514,4 +513,4 @@ A: Linear scoring rewards volume -- 200 commits would score 2x higher than 100. 
 A: Multiple layers. (1) **Log normalization** makes volume-based gaming impractical. (2) **PR size multiplier** means empty/trivial PRs contribute zero weight. (3) **Repo depth threshold** requires 3+ commits per repo to count toward Breadth. (4) **Confidence penalties** detect patterns like review spam, burst commits, and thin activity profiles. (5) **Caps** on every metric mean there's a ceiling — you can't just do more of one thing to inflate your score.
 
 **Q: What are the four dimensions?**
-A: Delivery (shipping code), Quality (engineering discipline — code reviews on teams, PR hygiene when solo), Consistency (sustained activity over time), and Breadth (cross-project influence). Each is scored 0-100 independently. Your archetype (Builder, Quality Champion, Marathoner, Polymath, Balanced, or Emerging) is derived from which dimension is strongest.
+A: Delivery (shipping code), Quality (engineering discipline — code reviews on teams, PR hygiene when solo), Consistency (sustained activity over time), and Breadth (cross-project influence). An optional fifth dimension, **Craft**, measures AI tool mastery when insights data is available. Each is scored 0-100 independently. Your archetype (Builder, Quality Champion, Marathoner, Polymath, Artificer, Balanced, or Emerging) is derived from which dimension is strongest.

--- a/docs/impact-v4.md
+++ b/docs/impact-v4.md
@@ -105,7 +105,7 @@ Implementation: `apps/web/lib/impact/v4.ts` (line 54)
 
 ### 4. Confidence penalty: low_activity_signal (-10)
 
-Triggers when `activeDays < 30 AND commitsTotal < 50`. Catches thin-signal profiles that somehow score high through concentration in a few metrics.
+Triggers when `activeDays < 30 OR commitsTotal < 50`. Reflects limited scoring signal when either temporal coverage or commit volume is low.
 
 Reason: "Very limited activity in this period reduces the signal available for scoring."
 
@@ -125,7 +125,7 @@ Reason: "High review volume with very few merged changes reduces confidence in t
 | `low_collaboration_signal` | -10 | `prsMergedCount >= 10 AND reviews <= 1` (collaborative only) |
 | `single_repo_concentration` | -5 | `topRepoShare >= 0.95 AND repos <= 1` |
 | `supplemental_unverified` | -5 | `hasSupplementalData === true` |
-| `low_activity_signal` | -10 | `activeDays < 30 AND commitsTotal < 50` |
+| `low_activity_signal` | -10 | `activeDays < 30 OR commitsTotal < 50` |
 | `review_volume_imbalance` | -10 | `reviews >= 50 AND prsMergedCount < 3` |
 
 Maximum simultaneous penalties: 7 (review_volume_imbalance and low_collaboration_signal are mutually exclusive). Floor: 50.

--- a/docs/plans/2026-03-22-engagement-campaign-type-phases/phase-1.md
+++ b/docs/plans/2026-03-22-engagement-campaign-type-phases/phase-1.md
@@ -1,0 +1,93 @@
+# Phase 1: Schema + Backend
+
+## Migration
+
+**File:** `supabase/migrations/017_add_campaign_type.sql` (NEW)
+
+```sql
+ALTER TABLE email_campaigns
+  ADD COLUMN type TEXT NOT NULL DEFAULT 'announcement';
+
+CREATE INDEX IF NOT EXISTS idx_email_campaigns_type
+  ON email_campaigns(type);
+```
+
+Apply via `supabase db push --linked`.
+
+## Campaign interface
+
+**File:** `apps/web/lib/db/campaigns.ts`
+
+Add `type` to Campaign interface:
+
+```pseudo
+interface Campaign {
+  ...existing fields...
++ type: "announcement" | "engagement";
+}
+```
+
+Update `mapCampaignRow`:
+```pseudo
++ type: row.type ?? "announcement",
+```
+
+Update `dbCreateCampaign` — accept `type` in input, include in insert:
+```pseudo
+dbCreateCampaign(campaign: Omit<Campaign, "id" | "status" | ...>)
+  insert: { ...existing, type: campaign.type }
+```
+
+Add new query helper:
+```pseudo
+export async function dbGetActiveEngagementCampaign(): Promise<Campaign | null> {
+  // Get most recently created engagement campaign (any status — it's a template)
+  query: from("email_campaigns")
+    .select("*")
+    .eq("type", "engagement")
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle()
+}
+```
+
+## Campaign creation API
+
+**File:** `apps/web/app/api/admin/campaigns/route.ts`
+
+POST handler:
+```pseudo
++ accept optional `type` field from body (default "announcement")
++ validate type is "announcement" | "engagement"
++ pass to dbCreateCampaign
+```
+
+GET handler:
+```pseudo
++ accept optional `type` query param for filtering
++ pass to dbGetCampaigns(status, type) or filter in JS
+```
+
+## Send route guard
+
+**File:** `apps/web/app/api/admin/campaigns/[id]/send/route.ts`
+
+```pseudo
++ if (campaign.type === "engagement") {
++   return 400 "Engagement campaigns are sent automatically"
++ }
+```
+
+## Tests
+
+Update existing tests:
+- Campaign CRUD tests: verify `type` field persists
+- Send route test: add test for engagement campaign rejection
+- GET route test: verify type filtering
+
+## Verification
+
+```bash
+pnpm run typecheck && pnpm run lint && pnpm run test
+supabase db push --linked  # apply migration
+```

--- a/docs/plans/2026-03-22-engagement-campaign-type-phases/phase-2.md
+++ b/docs/plans/2026-03-22-engagement-campaign-type-phases/phase-2.md
@@ -1,0 +1,148 @@
+# Phase 2: Score-bump DB Integration [batch-eligible]
+
+## Overview
+
+Replace hardcoded email template in `notifyScoreBump()` with DB-backed engagement campaign template. Support `{{variable}}` placeholders for dynamic content. Fall back to current hardcoded template if no engagement campaign exists.
+
+## Placeholder interpolation
+
+**New helper function** in `score-bump.ts`:
+
+```pseudo
+function interpolate(template: string, vars: Record<string, string>): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, key) => vars[key] ?? "")
+}
+```
+
+**Variables available:**
+- `{{handle}}` — lowercase GitHub handle
+- `{{delta}}` — "+N" formatted score change
+- `{{tier_from}}`, `{{tier_to}}` — tier labels (empty string if no tier change)
+- `{{archetype_from}}`, `{{archetype_to}}` — archetype labels (empty string if no change)
+- `{{score}}` — current adjusted composite (absolute, not delta)
+
+## notifyScoreBump changes
+
+**File:** `apps/web/lib/email/score-bump.ts`
+
+```pseudo
+import { dbGetActiveEngagementCampaign } from "@/lib/db/campaigns"
+import { buildAnnouncementHtml, buildAnnouncementText } from "./templates/announcement"
+import { buildEmailContent } from "./campaigns"
+
+// After guard checks pass, before building email:
+const engagementCampaign = await dbGetActiveEngagementCampaign()
+
+if (engagementCampaign) {
+  // Use DB-backed template
+  const vars = {
+    handle: lowerHandle,
+    delta: `+${Math.round(diff.adjustedComposite)}`,
+    tier_from: diff.tier?.from ?? "",
+    tier_to: diff.tier?.to ?? "",
+    archetype_from: diff.archetype?.from ?? "",
+    archetype_to: diff.archetype?.to ?? "",
+    score: String(Math.round(diff.adjustedComposite)),
+  }
+
+  // Interpolate placeholders in campaign fields
+  const interpolated = {
+    ...engagementCampaign,
+    subject: interpolate(engagementCampaign.subject, vars),
+    headline: interpolate(engagementCampaign.headline, vars),
+    bodyText: interpolate(engagementCampaign.bodyText, vars),
+  }
+
+  const content = buildEmailContent(interpolated, lowerHandle)
+  subject = interpolated.subject
+  html = buildAnnouncementHtml(content)
+  text = buildAnnouncementText(content)
+} else {
+  // Fallback: use hardcoded template (current behavior)
+  subject = buildSubject(lowerHandle, diff, significance)
+  html = buildHtml({ handle, diff, significance, shareUrl, unsubscribeUrl })
+  text = buildText({ handle, diff, significance, shareUrl, unsubscribeUrl })
+}
+```
+
+Keep all existing `buildSubject`, `buildHtml`, `buildText` functions as private fallbacks — no removal, just conditional use.
+
+## Tests
+
+**File:** `apps/web/lib/email/score-bump.test.ts`
+
+Add new test cases:
+
+```pseudo
+describe("DB-backed engagement template", () => {
+  it("uses engagement campaign template when one exists", async () => {
+    mockDbGetActiveEngagementCampaign.mockResolvedValue({
+      subject: "{{handle}}: Your score just jumped {{delta}}!",
+      headline: "Your Profile Just Leveled Up!",
+      bodyText: "Your impact score increased by {{delta}} points.",
+      features: [{ text: "Keep shipping!" }],
+      ctaText: "View Your Badge",
+      ctaUrl: "https://chapa.thecreativetoken.com/u/{{handle}}",
+      ...otherCampaignFields,
+    })
+
+    await notifyScoreBump("testuser", makeDiff({ adjustedComposite: 12 }), makeSignificance("score_bump"))
+
+    const call = mockSend.mock.calls[0]![0]
+    expect(call.subject).toBe("testuser: Your score just jumped +12!")
+    expect(call.html).toContain("Your Profile Just Leveled Up!")
+    expect(call.html).toContain("+12 points")
+  })
+
+  it("falls back to hardcoded template when no engagement campaign exists", async () => {
+    mockDbGetActiveEngagementCampaign.mockResolvedValue(null)
+
+    await notifyScoreBump("testuser", makeDiff({ adjustedComposite: 12 }), makeSignificance("score_bump"))
+
+    expect(mockSend).toHaveBeenCalled()
+    const call = mockSend.mock.calls[0]![0]
+    expect(call.subject).toContain("testuser")
+    expect(call.subject).toContain("+12")
+  })
+
+  it("interpolates tier placeholders", async () => {
+    mockDbGetActiveEngagementCampaign.mockResolvedValue({
+      subject: "{{tier_from}} → {{tier_to}}",
+      headline: "Your Profile Just Leveled Up!",
+      bodyText: "You went from {{tier_from}} to {{tier_to}} ({{delta}} points).",
+      ...
+    })
+
+    const diff = makeDiff({
+      adjustedComposite: 15,
+      tier: { from: "Solid", to: "High" },
+    })
+
+    await notifyScoreBump("testuser", diff, makeSignificance("tier_change"))
+
+    const call = mockSend.mock.calls[0]![0]
+    expect(call.subject).toBe("Solid → High")
+    expect(call.html).toContain("Solid")
+    expect(call.html).toContain("High")
+  })
+
+  it("handles missing placeholders gracefully (empty string)", async () => {
+    mockDbGetActiveEngagementCampaign.mockResolvedValue({
+      subject: "Score: {{delta}} — Tier: {{tier_to}}",
+      ...
+    })
+
+    // No tier change in diff
+    await notifyScoreBump("testuser", makeDiff({ adjustedComposite: 12 }), makeSignificance("score_bump"))
+
+    const call = mockSend.mock.calls[0]![0]
+    expect(call.subject).toBe("Score: +12 — Tier: ")
+  })
+})
+```
+
+## Verification
+
+```bash
+pnpm run typecheck && pnpm run lint && pnpm run test
+```

--- a/docs/plans/2026-03-22-engagement-campaign-type-phases/phase-3.md
+++ b/docs/plans/2026-03-22-engagement-campaign-type-phases/phase-3.md
@@ -1,0 +1,157 @@
+# Phase 3: UI Updates [batch-eligible]
+
+## Campaigns Dashboard
+
+**File:** `apps/web/app/admin/campaigns/campaigns-dashboard.tsx`
+
+### Type selector in create form
+
+Add `type` to `FormData`:
+
+```pseudo
+interface FormData {
+  ...existing fields...
++ type: "announcement" | "engagement";
+}
+
+const EMPTY_FORM: FormData = {
+  ...existing defaults...
++ type: "announcement",
+}
+```
+
+Add type selector at the top of the create form (radio buttons or dropdown):
+
+```pseudo
+<fieldset>
+  <legend>Campaign Type</legend>
+  <label>
+    <input type="radio" value="announcement" checked={form.type === "announcement"}
+           onChange={() => updateField("type", "announcement")} />
+    Announcement — manual send to all users
+  </label>
+  <label>
+    <input type="radio" value="engagement" checked={form.type === "engagement"}
+           onChange={() => updateField("type", "engagement")} />
+    Engagement — automated, sent on score bump
+  </label>
+</fieldset>
+```
+
+Include `type` in POST body for `handleCreate`.
+
+### Type badge in list view
+
+Add a type column or badge next to the campaign name:
+
+```pseudo
+<td>{c.name}
+  {c.type === "engagement" && (
+    <span className="ml-2 inline-flex ... bg-complement/10 text-complement text-xs">
+      engagement
+    </span>
+  )}
+</td>
+```
+
+### Detail view — hide "Send Campaign" for engagement
+
+```pseudo
+{c.status === "draft" && (
+  <div className="flex gap-3">
+    <button onClick={() => handlePreview(c.id)}>Preview Email</button>
+    <button onClick={() => openEdit(c)}>Edit Draft</button>
+-   <button onClick={() => handleSend(c.id)}>Send Campaign</button>
++   {c.type !== "engagement" && (
++     <button onClick={() => handleSend(c.id)}>Send Campaign</button>
++   )}
+    <button onClick={() => handleDelete(c.id)}>Delete</button>
+  </div>
+)}
+```
+
+### Engagement campaign info banner
+
+In the detail view, when `c.type === "engagement"`, show an info line:
+
+```pseudo
+{c.type === "engagement" && (
+  <div className="rounded-lg border border-complement/20 bg-complement/5 px-4 py-2 text-sm text-complement">
+    This template is sent automatically when a user's score increases by 10+ points.
+    Enable delivery in the Engagement tab.
+  </div>
+)}
+```
+
+### Placeholder help text
+
+When editing an engagement campaign, show available placeholders below the body textarea:
+
+```pseudo
+{(mode === "edit" || mode === "create") && form.type === "engagement" && (
+  <p className="text-xs text-text-secondary/60 mt-1">
+    Available placeholders: {"{{handle}}"}, {"{{delta}}"}, {"{{tier_from}}"}, {"{{tier_to}}"}, {"{{archetype_from}}"}, {"{{archetype_to}}"}
+  </p>
+)}
+```
+
+## Engagement Dashboard
+
+**File:** `apps/web/app/admin/engagement/engagement-dashboard.tsx`
+
+Add a section below the toggle table showing the active engagement campaign:
+
+```pseudo
+// Fetch engagement campaign
+const [engagementCampaign, setEngagementCampaign] = useState<Campaign | null>(null)
+
+useEffect(() => {
+  fetch("/api/admin/campaigns?type=engagement")
+    .then(res => res.json())
+    .then(data => setEngagementCampaign(data.campaigns?.[0] ?? null))
+}, [])
+
+// Render below toggles:
+<div className="rounded-xl border border-stroke bg-card p-4 mt-6">
+  <h3 className="font-heading text-sm text-text-secondary mb-3">
+    Score Bump Email Template
+  </h3>
+  {engagementCampaign ? (
+    <div className="flex items-center justify-between">
+      <div>
+        <p className="text-sm text-text-primary">{engagementCampaign.name}</p>
+        <p className="text-xs text-text-secondary">Subject: {engagementCampaign.subject}</p>
+      </div>
+      <button onClick={() => /* navigate to campaigns tab with campaign selected */}>
+        Edit Template
+      </button>
+    </div>
+  ) : (
+    <div>
+      <p className="text-sm text-text-secondary">No engagement template created yet.</p>
+      <button onClick={() => /* navigate to campaigns tab in create mode with type=engagement */}>
+        Create Engagement Template
+      </button>
+    </div>
+  )}
+</div>
+```
+
+The "Edit Template" and "Create" buttons need to communicate with the parent admin dashboard to switch tabs. Use a callback prop or URL-based navigation.
+
+## Tests
+
+### campaigns-dashboard.test.tsx
+- Test that type selector appears in create form
+- Test that "Send Campaign" is hidden for engagement campaigns
+- Test that engagement info banner appears for engagement campaigns
+
+### engagement-dashboard.test.tsx
+- Test that engagement campaign link appears when campaign exists
+- Test that "Create Engagement Template" appears when no campaign exists
+
+## Verification
+
+```bash
+pnpm run typecheck && pnpm run lint && pnpm run test
+```

--- a/docs/plans/2026-03-22-engagement-campaign-type.md
+++ b/docs/plans/2026-03-22-engagement-campaign-type.md
@@ -1,0 +1,79 @@
+# Plan: Engagement Campaign Type
+
+> Created: 2026-03-22 | Branch: `develop` | Status: READY
+
+## Goal
+
+Unify email template management so all emails (announcements and engagement/score-bump notifications) are managed through the Campaigns admin UI. The admin can edit, preview, and test engagement emails just like announcement campaigns. The Engagement toggle controls automated delivery; the campaign content is managed in Campaigns.
+
+## Design
+
+### Campaign `type` field
+
+Add `type: "announcement" | "engagement"` to the `email_campaigns` table. Default: `"announcement"`. Existing campaigns are announcements.
+
+### Engagement campaign rules
+
+- **One active engagement campaign at a time.** The cron picks the most recently created engagement campaign in `"draft"` status.
+- **No "Send Campaign" button.** Engagement campaigns are never bulk-sent manually — the cron sends them one-at-a-time when score bumps are detected.
+- **Same edit/preview/test workflow.** The admin uses the same form, preview iframe, and "Send Test" feature.
+- **Status stays `"draft"`.** Engagement campaigns don't transition to "sending"/"sent" — they're templates, not one-shot blasts. The `sentCount`/`totalRecipients` fields are unused.
+
+### Score-bump integration
+
+`notifyScoreBump()` queries the active engagement campaign from the DB. If found, it uses the campaign's subject, headline, bodyText, features, ctaText, and ctaUrl to build the email. Dynamic values (handle, score delta, tier/archetype changes) are interpolated into the template using simple `{{variable}}` placeholders in the bodyText and headline fields.
+
+**Supported placeholders:**
+- `{{handle}}` — GitHub handle
+- `{{delta}}` — score change (e.g., "+12")
+- `{{tier_from}}`, `{{tier_to}}` — tier change values
+- `{{archetype_from}}`, `{{archetype_to}}` — archetype change values
+
+**Fallback:** If no engagement campaign exists in the DB, the system falls back to the current hardcoded template (zero disruption).
+
+### Engagement tab changes
+
+The Engagement tab keeps the toggle for `score_notifications`. Below the toggle, it shows a link to the active engagement campaign for quick editing. If no engagement campaign exists yet, it shows a "Create Engagement Template" button.
+
+## Phases
+
+| # | Phase | Depends on | Batch-eligible |
+|---|-------|------------|----------------|
+| 1 | Schema + Backend | — | No |
+| 2 | Score-bump DB integration | 1 | Yes |
+| 3 | UI updates | 1 | Yes |
+
+Phases 2 and 3 are **[batch-eligible]** — they touch different files with no overlap.
+
+## Files changed
+
+### Phase 1: Schema + Backend
+- `supabase/migrations/017_add_campaign_type.sql` (NEW)
+- `apps/web/lib/db/campaigns.ts` (add `type` field to interface + row mapping + query helpers)
+- `apps/web/app/api/admin/campaigns/route.ts` (accept `type` in POST, filter by type in GET)
+- `apps/web/app/api/admin/campaigns/[id]/send/route.ts` (reject engagement campaigns)
+- `apps/web/app/api/admin/campaigns/[id]/route.ts` (allow `type` in PATCH validation — but only for draft)
+
+### Phase 2: Score-bump DB integration
+- `apps/web/lib/email/score-bump.ts` (query active engagement campaign, interpolate placeholders, fallback)
+- `apps/web/lib/email/score-bump.test.ts` (test DB-backed template, fallback, placeholder interpolation)
+
+### Phase 3: UI updates
+- `apps/web/app/admin/campaigns/campaigns-dashboard.tsx` (type selector in create form, hide Send for engagement, type badge in list)
+- `apps/web/app/admin/engagement/engagement-dashboard.tsx` (link to active engagement campaign)
+- `apps/web/app/admin/campaigns/campaigns-dashboard.test.tsx` (update tests for type)
+- `apps/web/app/admin/engagement/engagement-dashboard.test.tsx` (test campaign link)
+
+## Success criteria
+
+### Automated
+- All existing tests pass (5694+)
+- `pnpm run typecheck` clean
+- `pnpm run lint` clean
+- New tests cover: engagement campaign CRUD, score-bump DB template lookup, placeholder interpolation, fallback to hardcoded, UI type selector, engagement tab link
+
+### Manual
+- Admin can create an engagement campaign, edit it, preview it, send a test email
+- Engagement campaign does NOT show "Send Campaign" button
+- Engagement toggle on/off does NOT affect campaign content — only delivery
+- When toggle is on and a score bump is detected, the cron sends the email using the engagement campaign template

--- a/docs/plans/2026-03-22-scoring-accuracy-fixes-phases/phase-1.md
+++ b/docs/plans/2026-03-22-scoring-accuracy-fixes-phases/phase-1.md
@@ -1,0 +1,52 @@
+# Phase 1: Add `dev` and `developer` to DEFAULT_BRANCH_NAMES
+
+> [batch-eligible with Phase 3]
+
+## Goal
+
+Recognize `dev` and `developer` as default branch names so that PRs merging from these branches are not counted as "feature branch" PRs. This corrects `featureBranchRate` inflation for developers who use `dev` as their working branch.
+
+## Files
+
+| File | Change |
+|------|--------|
+| `packages/shared/src/stats-aggregation.ts:6` | Add `"dev"` and `"developer"` to the Set |
+| `packages/shared/src/stats-aggregation.test.ts:472-486` | Update test to include new branch names |
+
+## Changes
+
+### 1. Update DEFAULT_BRANCH_NAMES
+
+**File:** `packages/shared/src/stats-aggregation.ts:6`
+
+```diff
+- const DEFAULT_BRANCH_NAMES = new Set(["main", "master", "develop", "development", "trunk"]);
++ const DEFAULT_BRANCH_NAMES = new Set(["main", "master", "develop", "development", "dev", "developer", "trunk"]);
+```
+
+### 2. Update test: "excludes all default branch names from featureBranchRate"
+
+**File:** `packages/shared/src/stats-aggregation.test.ts:473`
+
+```diff
+- const defaultBranches = ["main", "master", "develop", "development", "trunk"];
++ const defaultBranches = ["main", "master", "develop", "development", "dev", "developer", "trunk"];
+```
+
+## TDD Sequence
+
+1. **Red:** Update the test array first to include `"dev"` and `"developer"` — tests will fail because the implementation doesn't recognize them yet.
+2. **Green:** Add the two names to `DEFAULT_BRANCH_NAMES` in the source file.
+3. **Refactor:** None needed — this is a data change, not a logic change.
+
+## Verification
+
+```bash
+cd <worktree> && pnpm run test -- packages/shared/src/stats-aggregation.test.ts
+```
+
+## Success Criteria (automated)
+
+- [x] Test "excludes all default branch names from featureBranchRate" passes with 7 branch names
+- [x] All existing stats-aggregation tests still pass
+- [x] TypeScript compiles cleanly

--- a/docs/plans/2026-03-22-scoring-accuracy-fixes-phases/phase-2.md
+++ b/docs/plans/2026-03-22-scoring-accuracy-fixes-phases/phase-2.md
@@ -1,0 +1,157 @@
+# Phase 2: Implement `microCommitRatio` Computation
+
+> Sequential after Phase 1 (shared file: `stats-aggregation.ts`)
+
+## Goal
+
+Compute `microCommitRatio` from merged PR data in `buildStatsFromRaw()` so that the Quality dimension's 15% inverse-micro-commit weight uses real data instead of the 0.3 default.
+
+## Definition
+
+A **micro PR** is a merged PR where `additions + deletions < 10` (fewer than 10 total lines changed). This aligns with the PR weight formula's existing significance cutoff (`sizeMultiplier = min(1, totalChanges / 10)`).
+
+`microCommitRatio = count(micro PRs) / prsMergedCount` — a value from 0 to 1.
+
+When `prsMergedCount === 0`, the field remains `undefined` (same pattern as other optional PR-level metrics).
+
+## Files
+
+| File | Change |
+|------|--------|
+| `packages/shared/src/stats-aggregation.ts:44-53` | Add microCommitRatio computation alongside other PR metrics |
+| `packages/shared/src/stats-aggregation.ts:114-116` | Add conditional spread for microCommitRatio in return object |
+| `packages/shared/src/stats-aggregation.test.ts` | Add tests for microCommitRatio |
+
+## Changes
+
+### 1. Compute microCommitRatio in buildStatsFromRaw
+
+**File:** `packages/shared/src/stats-aggregation.ts`
+
+After the existing solo quality signals block (line 53), add:
+
+```typescript
+// 5c. Micro-commit ratio: fraction of merged PRs with < 10 total lines changed
+// Threshold aligns with PR weight sizeMultiplier cutoff (totalChanges / 10)
+const microCommitRatio = prsMergedCount > 0
+  ? mergedPRs.filter((pr) => pr.additions + pr.deletions < 10).length / prsMergedCount
+  : undefined;
+```
+
+### 2. Include in return object
+
+**File:** `packages/shared/src/stats-aggregation.ts:116`
+
+After the `issueLinkageRate` spread, add:
+
+```typescript
+...(microCommitRatio !== undefined && { microCommitRatio }),
+```
+
+### 3. Add tests
+
+**File:** `packages/shared/src/stats-aggregation.test.ts`
+
+Add in the "Solo quality signals" section:
+
+```typescript
+it("computes microCommitRatio as fraction of merged PRs with < 10 lines changed", () => {
+  const raw = makeRaw({
+    pullRequests: {
+      totalCount: 4,
+      nodes: [
+        { additions: 3, deletions: 2, changedFiles: 1, merged: true, body: "tiny", headRefName: "fix/a", closingIssuesCount: 0 },  // 5 lines → micro
+        { additions: 1, deletions: 0, changedFiles: 1, merged: true, body: "typo", headRefName: "fix/b", closingIssuesCount: 0 },  // 1 line → micro
+        { additions: 50, deletions: 10, changedFiles: 3, merged: true, body: "real", headRefName: "feat/c", closingIssuesCount: 0 }, // 60 lines → not micro
+        { additions: 100, deletions: 20, changedFiles: 5, merged: true, body: "big", headRefName: "feat/d", closingIssuesCount: 0 },  // 120 lines → not micro
+      ],
+    },
+  });
+  const result = buildStatsFromRaw(raw);
+  expect(result.microCommitRatio).toBeCloseTo(0.5, 2); // 2 micro out of 4
+});
+
+it("treats PRs at exactly 10 lines as non-micro (boundary)", () => {
+  const raw = makeRaw({
+    pullRequests: {
+      totalCount: 2,
+      nodes: [
+        { additions: 7, deletions: 3, changedFiles: 1, merged: true, body: "x", headRefName: "fix/a", closingIssuesCount: 0 },  // 10 lines → NOT micro (>= 10)
+        { additions: 6, deletions: 3, changedFiles: 1, merged: true, body: "x", headRefName: "fix/b", closingIssuesCount: 0 },  // 9 lines → micro (< 10)
+      ],
+    },
+  });
+  const result = buildStatsFromRaw(raw);
+  expect(result.microCommitRatio).toBeCloseTo(0.5, 2);
+});
+
+it("returns 0 microCommitRatio when all PRs are substantial", () => {
+  const raw = makeRaw({
+    pullRequests: {
+      totalCount: 2,
+      nodes: [
+        { additions: 50, deletions: 10, changedFiles: 3, merged: true, body: "x", headRefName: "feat/a", closingIssuesCount: 0 },
+        { additions: 100, deletions: 20, changedFiles: 5, merged: true, body: "x", headRefName: "feat/b", closingIssuesCount: 0 },
+      ],
+    },
+  });
+  const result = buildStatsFromRaw(raw);
+  expect(result.microCommitRatio).toBe(0);
+});
+
+it("returns 1.0 microCommitRatio when all PRs are micro", () => {
+  const raw = makeRaw({
+    pullRequests: {
+      totalCount: 2,
+      nodes: [
+        { additions: 1, deletions: 0, changedFiles: 1, merged: true, body: "x", headRefName: "fix/a", closingIssuesCount: 0 },
+        { additions: 2, deletions: 1, changedFiles: 1, merged: true, body: "x", headRefName: "fix/b", closingIssuesCount: 0 },
+      ],
+    },
+  });
+  const result = buildStatsFromRaw(raw);
+  expect(result.microCommitRatio).toBe(1);
+});
+
+it("returns undefined microCommitRatio when no merged PRs", () => {
+  const raw = makeRaw({
+    pullRequests: { totalCount: 0, nodes: [] },
+  });
+  const result = buildStatsFromRaw(raw);
+  expect(result.microCommitRatio).toBeUndefined();
+});
+
+it("excludes unmerged PRs from microCommitRatio", () => {
+  const raw = makeRaw({
+    pullRequests: {
+      totalCount: 3,
+      nodes: [
+        { additions: 1, deletions: 0, changedFiles: 1, merged: true, body: "x", headRefName: "fix/a", closingIssuesCount: 0 },  // micro, merged
+        { additions: 50, deletions: 10, changedFiles: 3, merged: true, body: "x", headRefName: "feat/b", closingIssuesCount: 0 },  // not micro, merged
+        { additions: 1, deletions: 0, changedFiles: 1, merged: false, body: "x", headRefName: "fix/c", closingIssuesCount: 0 },  // micro, NOT merged — excluded
+      ],
+    },
+  });
+  const result = buildStatsFromRaw(raw);
+  expect(result.microCommitRatio).toBeCloseTo(0.5, 2); // 1 micro out of 2 merged
+});
+```
+
+## TDD Sequence
+
+1. **Red:** Write all 6 tests above. They will fail because `microCommitRatio` is never set.
+2. **Green:** Add the computation and return spread to `buildStatsFromRaw()`.
+3. **Refactor:** None needed.
+
+## Verification
+
+```bash
+cd <worktree> && pnpm run test -- packages/shared/src/stats-aggregation.test.ts
+```
+
+## Success Criteria (automated)
+
+- [x] All 6 new microCommitRatio tests pass
+- [x] All existing stats-aggregation tests still pass
+- [x] All existing v4 impact tests still pass (scoring uses the same field — behavior improves but existing tests with explicit `microCommitRatio` values are unaffected)
+- [x] TypeScript compiles cleanly

--- a/docs/plans/2026-03-22-scoring-accuracy-fixes-phases/phase-3.md
+++ b/docs/plans/2026-03-22-scoring-accuracy-fixes-phases/phase-3.md
@@ -1,0 +1,141 @@
+# Phase 3: Change `low_activity_signal` from AND to OR
+
+> [batch-eligible with Phase 1]
+
+## Goal
+
+Ensure the `low_activity_signal` confidence penalty triggers when **either** `activeDays < 30` or `commitsTotal < 50`, not only when both are true. This provides more accurate confidence for profiles with limited temporal or volume signal.
+
+## Rationale
+
+A developer with 17 active days out of 365 has genuinely limited temporal signal — the consistency and heatmap evenness dimensions have less data to work with regardless of total commit count. The confidence system should reflect this honestly (it's about signal quality, not behavior judgment).
+
+## Files
+
+| File | Change |
+|------|--------|
+| `apps/web/lib/impact/utils.ts:182` | Change `&&` to `\|\|` |
+| `apps/web/lib/impact/utils.ts:82-91` | Update JSDoc table |
+| `apps/web/lib/impact/utils.test.ts:290-328` | Update tests for OR logic |
+| `docs/impact-v6.md:88-91` | Update condition in spec table |
+| `docs/impact-v4.md` | Update condition reference (if exists) |
+
+## Changes
+
+### 1. Change condition operator
+
+**File:** `apps/web/lib/impact/utils.ts:182`
+
+```diff
+- if (stats.activeDays < 30 && stats.commitsTotal < 50) {
++ if (stats.activeDays < 30 || stats.commitsTotal < 50) {
+```
+
+### 2. Update JSDoc
+
+**File:** `apps/web/lib/impact/utils.ts:89`
+
+```diff
+- * | `low_activity_signal`       | -10     | < 30 active days AND < 50 total commits        |
++ * | `low_activity_signal`       | -10     | < 30 active days OR < 50 total commits         |
+```
+
+### 3. Update tests
+
+**File:** `apps/web/lib/impact/utils.test.ts`
+
+Replace the `low_activity_signal` describe block:
+
+```typescript
+describe("low_activity_signal flag", () => {
+  it("applies -10 when both activeDays < 30 AND commitsTotal < 50", () => {
+    const { confidence, penalties } = computeConfidence(
+      makeStats({ activeDays: 20, commitsTotal: 30 }),
+    );
+    expect(confidence).toBe(90);
+    expect(penalties).toHaveLength(1);
+    expect(penalties[0]!.flag).toBe("low_activity_signal");
+    expect(penalties[0]!.penalty).toBe(10);
+  });
+
+  it("applies when activeDays < 30 even if commitsTotal >= 50", () => {
+    const { penalties } = computeConfidence(
+      makeStats({ activeDays: 17, commitsTotal: 65 }),
+    );
+    expect(
+      penalties.find((p) => p.flag === "low_activity_signal"),
+    ).toBeDefined();
+  });
+
+  it("applies when commitsTotal < 50 even if activeDays >= 30", () => {
+    const { penalties } = computeConfidence(
+      makeStats({ activeDays: 100, commitsTotal: 30 }),
+    );
+    expect(
+      penalties.find((p) => p.flag === "low_activity_signal"),
+    ).toBeDefined();
+  });
+
+  it("does NOT apply when both activeDays >= 30 AND commitsTotal >= 50", () => {
+    const { penalties } = computeConfidence(
+      makeStats({ activeDays: 30, commitsTotal: 50 }),
+    );
+    expect(
+      penalties.find((p) => p.flag === "low_activity_signal"),
+    ).toBeUndefined();
+  });
+
+  it("applies at boundary: activeDays=29, commitsTotal=50", () => {
+    const { penalties } = computeConfidence(
+      makeStats({ activeDays: 29, commitsTotal: 50 }),
+    );
+    expect(
+      penalties.find((p) => p.flag === "low_activity_signal"),
+    ).toBeDefined();
+  });
+
+  it("applies at boundary: activeDays=30, commitsTotal=49", () => {
+    const { penalties } = computeConfidence(
+      makeStats({ activeDays: 30, commitsTotal: 49 }),
+    );
+    expect(
+      penalties.find((p) => p.flag === "low_activity_signal"),
+    ).toBeDefined();
+  });
+});
+```
+
+### 4. Update docs
+
+**File:** `docs/impact-v6.md` — update the condition in the confidence table:
+
+```diff
+- | `low_activity_signal` | -10 | < 30 active days AND < 50 total commits |
++ | `low_activity_signal` | -10 | < 30 active days OR < 50 total commits |
+```
+
+**File:** `docs/impact-v4.md` — same change if the table exists there.
+
+## TDD Sequence
+
+1. **Red:** Update tests first (change AND expectations to OR). The two tests that previously checked "does NOT apply when only one condition is true" now expect the penalty to apply. These will fail.
+2. **Green:** Change `&&` to `||` in `utils.ts:182`.
+3. **Refactor:** Update JSDoc and docs.
+
+## Verification
+
+```bash
+cd <worktree> && pnpm run test -- apps/web/lib/impact/utils.test.ts
+```
+
+## Success Criteria (automated)
+
+- [x] All 6 updated low_activity_signal tests pass
+- [x] All other confidence tests still pass
+- [x] All v4 impact tests still pass
+- [x] TypeScript compiles cleanly
+- [x] impact-v4.md condition updated (impact-v6.md doesn't reference this flag directly)
+
+## Impact Assessment
+
+The -10 confidence penalty translates to a ~1.5% score reduction via the adjusted score formula (`base * (0.85 + 0.15 * confidence/100)`). At confidence 90 (one penalty): `multiplier = 0.985`. A composite score of 43 becomes ~42. This is a minor but honest adjustment.

--- a/docs/plans/2026-03-22-scoring-accuracy-fixes.md
+++ b/docs/plans/2026-03-22-scoring-accuracy-fixes.md
@@ -1,0 +1,55 @@
+# Scoring Accuracy Fixes
+
+> Fix three scoring accuracy issues discovered while investigating user jordanlynn5's Quality score.
+
+## Context
+
+Investigation revealed three data accuracy gaps in the scoring pipeline:
+
+1. **`dev` and `developer` missing from `DEFAULT_BRANCH_NAMES`** — These common branch names are not recognized as default branches, causing `featureBranchRate` to inflate by treating `dev→main` merges as "feature branch" PRs. Affects the 25% feature branch weight in solo Quality scoring.
+
+2. **`microCommitRatio` never computed** — The field is defined in types and used in scoring (15% of Quality, both paths), but `buildStatsFromRaw()` never calculates it. Every user gets the 0.3 default, giving ~10.5 free Quality points instead of an accurate value.
+
+3. **`low_activity_signal` condition too lenient** — Requires `activeDays < 30 AND commitsTotal < 50`. A developer with 17 active days but 65 commits avoids the penalty entirely. Changing to OR ensures that either condition alone reflects limited scoring signal.
+
+## Design Decisions
+
+### Micro-commit threshold: `additions + deletions < 10`
+
+Aligns with the existing PR weight formula where `sizeMultiplier = min(1, totalChanges / 10)` — PRs below 10 total changes already get weight-penalized. Using the same boundary for micro-commit detection is consistent. Counts only lines changed (additions + deletions), not files — a 3-file PR with 8 lines changed is still micro in terms of code.
+
+### low_activity_signal: AND → OR
+
+Simple, defensible change. With OR:
+- 17 active days + 65 commits → penalty (limited temporal signal) ✓
+- 5 active days + 200 commits → penalty (concentrated burst) ✓
+- 200 active days + 30 commits → penalty (sustained presence but low volume) — acceptable, this is genuinely low signal for PR-based metrics
+- 30 active days + 50 commits → no penalty (both above thresholds) ✓
+
+The penalty is only -10 confidence (translates to ~1.5% score reduction), so even edge cases are minimally impacted.
+
+## Phases
+
+| Phase | Description | Files | Batch |
+|-------|-------------|-------|-------|
+| 1 | Add `dev`/`developer` to DEFAULT_BRANCH_NAMES | `packages/shared/src/stats-aggregation.ts`, `packages/shared/src/stats-aggregation.test.ts` | [batch-eligible with Phase 3] |
+| 2 | Implement `microCommitRatio` computation | `packages/shared/src/stats-aggregation.ts`, `packages/shared/src/stats-aggregation.test.ts` | Sequential after Phase 1 (shared file) |
+| 3 | Change `low_activity_signal` from AND to OR | `apps/web/lib/impact/utils.ts`, `apps/web/lib/impact/utils.test.ts`, `docs/impact-v6.md`, `docs/impact-v4.md` | [batch-eligible with Phase 1] |
+
+## Verification
+
+After all phases:
+```bash
+pnpm run test 2>&1; pnpm run typecheck 2>&1; pnpm run lint 2>&1
+```
+
+## Impact on jordanlynn5
+
+| Metric | Before | After |
+|--------|--------|-------|
+| featureBranchRate | 1.0 (16/16 "feature") | 0.0 (0/16 — all from `dev`/`developer`) |
+| microCommitRatio | undefined (→ 0.3 default) | 0.0625 (1/16 micro PRs) |
+| Quality (solo) | ~71 | ~47 (desc 35 + branch 0 + linkage 0 + inverseMicro 14 = 49, clamped) |
+| Confidence | 100% | 90% (low_activity_signal triggers: 17 days < 30) |
+| Adjusted composite | ~43 | ~38 (composite drops slightly from confidence) |
+| Tier | Solid | Solid (still >= 30) |

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.2",
-    "@vitest/coverage-v8": "^4.0.0",
+    "@vitest/coverage-v8": "^4.1.0",
     "husky": "^9.1.7",
-    "jsdom": "^29.0.0",
-    "vitest": "^4.0.0"
+    "jsdom": "^29.0.1",
+    "vitest": "^4.1.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -28,6 +28,13 @@ export const SCORING_CAPS = {
 export const REPO_DEPTH_THRESHOLD = 3;
 
 /**
+ * Maximum total lines changed (additions + deletions) for a PR to be
+ * classified as a "micro PR" in microCommitRatio computation.
+ * PRs below this threshold contribute negligible code change.
+ */
+export const MICRO_PR_LINE_THRESHOLD = 10;
+
+/**
  * All four scoring dimension keys in canonical order.
  * Used by v4 scoring, heatmap coloring, and archetype derivation.
  */

--- a/packages/shared/src/stats-aggregation.test.ts
+++ b/packages/shared/src/stats-aggregation.test.ts
@@ -470,7 +470,7 @@ describe("buildStatsFromRaw", () => {
   });
 
   it("excludes all default branch names from featureBranchRate", () => {
-    const defaultBranches = ["main", "master", "develop", "development", "trunk"];
+    const defaultBranches = ["main", "master", "develop", "development", "dev", "developer", "trunk"];
     for (const branch of defaultBranches) {
       const raw = makeRaw({
         pullRequests: {

--- a/packages/shared/src/stats-aggregation.test.ts
+++ b/packages/shared/src/stats-aggregation.test.ts
@@ -499,5 +499,81 @@ describe("buildStatsFromRaw", () => {
     expect(result.prDescriptionRate).toBeUndefined();
     expect(result.featureBranchRate).toBeUndefined();
     expect(result.issueLinkageRate).toBeUndefined();
+    expect(result.microCommitRatio).toBeUndefined();
+  });
+
+  // --- Micro-commit ratio ---
+
+  it("computes microCommitRatio as fraction of merged PRs with < 10 lines changed", () => {
+    const raw = makeRaw({
+      pullRequests: {
+        totalCount: 4,
+        nodes: [
+          { additions: 3, deletions: 2, changedFiles: 1, merged: true, body: "tiny", headRefName: "fix/a", closingIssuesCount: 0 },
+          { additions: 1, deletions: 0, changedFiles: 1, merged: true, body: "typo", headRefName: "fix/b", closingIssuesCount: 0 },
+          { additions: 50, deletions: 10, changedFiles: 3, merged: true, body: "real", headRefName: "feat/c", closingIssuesCount: 0 },
+          { additions: 100, deletions: 20, changedFiles: 5, merged: true, body: "big", headRefName: "feat/d", closingIssuesCount: 0 },
+        ],
+      },
+    });
+    const result = buildStatsFromRaw(raw);
+    expect(result.microCommitRatio).toBeCloseTo(0.5, 2);
+  });
+
+  it("treats PRs at exactly 10 lines as non-micro (boundary)", () => {
+    const raw = makeRaw({
+      pullRequests: {
+        totalCount: 2,
+        nodes: [
+          { additions: 7, deletions: 3, changedFiles: 1, merged: true, body: "x", headRefName: "fix/a", closingIssuesCount: 0 },
+          { additions: 6, deletions: 3, changedFiles: 1, merged: true, body: "x", headRefName: "fix/b", closingIssuesCount: 0 },
+        ],
+      },
+    });
+    const result = buildStatsFromRaw(raw);
+    expect(result.microCommitRatio).toBeCloseTo(0.5, 2);
+  });
+
+  it("returns 0 microCommitRatio when all PRs are substantial", () => {
+    const raw = makeRaw({
+      pullRequests: {
+        totalCount: 2,
+        nodes: [
+          { additions: 50, deletions: 10, changedFiles: 3, merged: true, body: "x", headRefName: "feat/a", closingIssuesCount: 0 },
+          { additions: 100, deletions: 20, changedFiles: 5, merged: true, body: "x", headRefName: "feat/b", closingIssuesCount: 0 },
+        ],
+      },
+    });
+    const result = buildStatsFromRaw(raw);
+    expect(result.microCommitRatio).toBe(0);
+  });
+
+  it("returns 1.0 microCommitRatio when all PRs are micro", () => {
+    const raw = makeRaw({
+      pullRequests: {
+        totalCount: 2,
+        nodes: [
+          { additions: 1, deletions: 0, changedFiles: 1, merged: true, body: "x", headRefName: "fix/a", closingIssuesCount: 0 },
+          { additions: 2, deletions: 1, changedFiles: 1, merged: true, body: "x", headRefName: "fix/b", closingIssuesCount: 0 },
+        ],
+      },
+    });
+    const result = buildStatsFromRaw(raw);
+    expect(result.microCommitRatio).toBe(1);
+  });
+
+  it("excludes unmerged PRs from microCommitRatio", () => {
+    const raw = makeRaw({
+      pullRequests: {
+        totalCount: 3,
+        nodes: [
+          { additions: 1, deletions: 0, changedFiles: 1, merged: true, body: "x", headRefName: "fix/a", closingIssuesCount: 0 },
+          { additions: 50, deletions: 10, changedFiles: 3, merged: true, body: "x", headRefName: "feat/b", closingIssuesCount: 0 },
+          { additions: 1, deletions: 0, changedFiles: 1, merged: false, body: "x", headRefName: "fix/c", closingIssuesCount: 0 },
+        ],
+      },
+    });
+    const result = buildStatsFromRaw(raw);
+    expect(result.microCommitRatio).toBeCloseTo(0.5, 2);
   });
 });

--- a/packages/shared/src/stats-aggregation.ts
+++ b/packages/shared/src/stats-aggregation.ts
@@ -1,6 +1,6 @@
 import type { RawContributionData, StatsData, HeatmapDay } from "./types";
 import { computePrWeight } from "./scoring";
-import { PR_WEIGHT_AGG_CAP, REPO_DEPTH_THRESHOLD } from "./constants";
+import { MICRO_PR_LINE_THRESHOLD, PR_WEIGHT_AGG_CAP, REPO_DEPTH_THRESHOLD } from "./constants";
 
 /** Branch names that indicate a direct push (not a feature branch). */
 const DEFAULT_BRANCH_NAMES = new Set(["main", "master", "develop", "development", "dev", "developer", "trunk"]);
@@ -52,10 +52,9 @@ export function buildStatsFromRaw(raw: RawContributionData): StatsData {
     ? mergedPRs.filter((pr) => pr.closingIssuesCount > 0).length / prsMergedCount
     : undefined;
 
-  // 5c. Micro-commit ratio: fraction of merged PRs with < 10 total lines changed
-  // Threshold aligns with PR weight sizeMultiplier cutoff (totalChanges / 10)
+  // 5c. Micro-commit ratio: fraction of merged PRs below the line-change threshold
   const microCommitRatio = prsMergedCount > 0
-    ? mergedPRs.filter((pr) => pr.additions + pr.deletions < 10).length / prsMergedCount
+    ? mergedPRs.filter((pr) => pr.additions + pr.deletions < MICRO_PR_LINE_THRESHOLD).length / prsMergedCount
     : undefined;
 
   // 6. Reviews and issues

--- a/packages/shared/src/stats-aggregation.ts
+++ b/packages/shared/src/stats-aggregation.ts
@@ -3,7 +3,7 @@ import { computePrWeight } from "./scoring";
 import { PR_WEIGHT_AGG_CAP, REPO_DEPTH_THRESHOLD } from "./constants";
 
 /** Branch names that indicate a direct push (not a feature branch). */
-const DEFAULT_BRANCH_NAMES = new Set(["main", "master", "develop", "development", "trunk"]);
+const DEFAULT_BRANCH_NAMES = new Set(["main", "master", "develop", "development", "dev", "developer", "trunk"]);
 
 /**
  * Transform raw GitHub GraphQL contribution data into a StatsData object.

--- a/packages/shared/src/stats-aggregation.ts
+++ b/packages/shared/src/stats-aggregation.ts
@@ -52,6 +52,12 @@ export function buildStatsFromRaw(raw: RawContributionData): StatsData {
     ? mergedPRs.filter((pr) => pr.closingIssuesCount > 0).length / prsMergedCount
     : undefined;
 
+  // 5c. Micro-commit ratio: fraction of merged PRs with < 10 total lines changed
+  // Threshold aligns with PR weight sizeMultiplier cutoff (totalChanges / 10)
+  const microCommitRatio = prsMergedCount > 0
+    ? mergedPRs.filter((pr) => pr.additions + pr.deletions < 10).length / prsMergedCount
+    : undefined;
+
   // 6. Reviews and issues
   const reviewsSubmittedCount = raw.reviews.totalCount;
   const issuesClosedCount = raw.issues.totalCount;
@@ -114,6 +120,7 @@ export function buildStatsFromRaw(raw: RawContributionData): StatsData {
     ...(prDescriptionRate !== undefined && { prDescriptionRate }),
     ...(featureBranchRate !== undefined && { featureBranchRate }),
     ...(issueLinkageRate !== undefined && { issueLinkageRate }),
+    ...(microCommitRatio !== undefined && { microCommitRatio }),
     totalStars,
     totalForks,
     totalWatchers,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,16 +48,16 @@ importers:
         version: 1.37.0
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.2.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 2.0.1(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 2.0.0(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       canvas-confetti:
         specifier: ^1.9.4
         version: 1.9.4
       next:
-        specifier: ^16.2.0
-        version: 16.2.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^16.2.1
+        version: 16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -262,6 +262,9 @@ packages:
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
+
+  '@emnapi/runtime@1.9.1':
+    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
@@ -485,8 +488,8 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@img/colour@1.0.0':
-    resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
   '@img/sharp-darwin-arm64@0.34.5':
@@ -660,60 +663,60 @@ packages:
   '@next/bundle-analyzer@16.2.0':
     resolution: {integrity: sha512-3F8T1KYVWKBLUXzZPpYSYp134c3iwzNDMxfOE0kkqST+S5VaYao41F0SQogd6E4Od7+C3ReA/XJMDDw9P61n6w==}
 
-  '@next/env@16.2.0':
-    resolution: {integrity: sha512-OZIbODWWAi0epQRCRjNe1VO45LOFBzgiyqmTLzIqWq6u1wrxKnAyz1HH6tgY/Mc81YzIjRPoYsPAEr4QV4l9TA==}
+  '@next/env@16.2.1':
+    resolution: {integrity: sha512-n8P/HCkIWW+gVal2Z8XqXJ6aB3J0tuM29OcHpCsobWlChH/SITBs1DFBk/HajgrwDkqqBXPbuUuzgDvUekREPg==}
 
   '@next/eslint-plugin-next@16.1.6':
     resolution: {integrity: sha512-/Qq3PTagA6+nYVfryAtQ7/9FEr/6YVyvOtl6rZnGsbReGLf0jZU6gkpr1FuChAQpvV46a78p4cmHOVP8mbfSMQ==}
 
-  '@next/swc-darwin-arm64@16.2.0':
-    resolution: {integrity: sha512-/JZsqKzKt01IFoiLLAzlNqys7qk2F3JkcUhj50zuRhKDQkZNOz9E5N6wAQWprXdsvjRP4lTFj+/+36NSv5AwhQ==}
+  '@next/swc-darwin-arm64@16.2.1':
+    resolution: {integrity: sha512-BwZ8w8YTaSEr2HIuXLMLxIdElNMPvY9fLqb20LX9A9OMGtJilhHLbCL3ggyd0TwjmMcTxi0XXt+ur1vWUoxj2Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.0':
-    resolution: {integrity: sha512-/hV8erWq4SNlVgglUiW5UmQ5Hwy5EW/AbbXlJCn6zkfKxTy/E/U3V8U1Ocm2YCTUoFgQdoMxRyRMOW5jYy4ygg==}
+  '@next/swc-darwin-x64@16.2.1':
+    resolution: {integrity: sha512-/vrcE6iQSJq3uL3VGVHiXeaKbn8Es10DGTGRJnRZlkNQQk3kaNtAJg8Y6xuAlrx/6INKVjkfi5rY0iEXorZ6uA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.0':
-    resolution: {integrity: sha512-GkjL/Q7MWOwqWR9zoxu1TIHzkOI2l2BHCf7FzeQG87zPgs+6WDh+oC9Sw9ARuuL/FUk6JNCgKRkA6rEQYadUaw==}
+  '@next/swc-linux-arm64-gnu@16.2.1':
+    resolution: {integrity: sha512-uLn+0BK+C31LTVbQ/QU+UaVrV0rRSJQ8RfniQAHPghDdgE+SlroYqcmFnO5iNjNfVWCyKZHYrs3Nl0mUzWxbBw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.2.0':
-    resolution: {integrity: sha512-1ffhC6KY5qWLg5miMlKJp3dZbXelEfjuXt1qcp5WzSCQy36CV3y+JT7OC1WSFKizGQCDOcQbfkH/IjZP3cdRNA==}
+  '@next/swc-linux-arm64-musl@16.2.1':
+    resolution: {integrity: sha512-ssKq6iMRnHdnycGp9hCuGnXJZ0YPr4/wNwrfE5DbmvEcgl9+yv97/Kq3TPVDfYome1SW5geciLB9aiEqKXQjlQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.2.0':
-    resolution: {integrity: sha512-FmbDcZQ8yJRq93EJSL6xaE0KK/Rslraf8fj1uViGxg7K4CKBCRYSubILJPEhjSgZurpcPQq12QNOJQ0DRJl6Hg==}
+  '@next/swc-linux-x64-gnu@16.2.1':
+    resolution: {integrity: sha512-HQm7SrHRELJ30T1TSmT706IWovFFSRGxfgUkyWJZF/RKBMdbdRWJuFrcpDdE5vy9UXjFOx6L3mRdqH04Mmx0hg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.2.0':
-    resolution: {integrity: sha512-HzjIHVkmGAwRbh/vzvoBWWEbb8BBZPxBvVbDQDvzHSf3D8RP/4vjw7MNLDXFF9Q1WEzeQyEj2zdxBtVAHu5Oyw==}
+  '@next/swc-linux-x64-musl@16.2.1':
+    resolution: {integrity: sha512-aV2iUaC/5HGEpbBkE+4B8aHIudoOy5DYekAKOMSHoIYQ66y/wIVeaRx8MS2ZMdxe/HIXlMho4ubdZs/J8441Tg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.2.0':
-    resolution: {integrity: sha512-UMiFNQf5H7+1ZsZPxEsA064WEuFbRNq/kEXyepbCnSErp4f5iut75dBA8UeerFIG3vDaQNOfCpevnERPp2V+nA==}
+  '@next/swc-win32-arm64-msvc@16.2.1':
+    resolution: {integrity: sha512-IXdNgiDHaSk0ZUJ+xp0OQTdTgnpx1RCfRTalhn3cjOP+IddTMINwA7DXZrwTmGDO8SUr5q2hdP/du4DcrB1GxA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.0':
-    resolution: {integrity: sha512-DRrNJKW+/eimrZgdhVN1uvkN1OI4j6Lpefwr44jKQ0YQzztlmOBUUzHuV5GxOMPK3nmodAYElUVCY8ZXo/IWeA==}
+  '@next/swc-win32-x64-msvc@16.2.1':
+    resolution: {integrity: sha512-qvU+3a39Hay+ieIztkGSbF7+mccbbg1Tk25hc4JDylf8IHjYmY/Zm64Qq1602yPyQqvie+vf5T/uPwNxDNIoeg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1623,6 +1626,11 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  baseline-browser-mapping@2.10.10:
+    resolution: {integrity: sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
@@ -1661,6 +1669,9 @@ packages:
 
   caniuse-lite@1.0.30001769:
     resolution: {integrity: sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==}
+
+  caniuse-lite@1.0.30001780:
+    resolution: {integrity: sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==}
 
   canvas-confetti@1.9.4:
     resolution: {integrity: sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==}
@@ -2517,8 +2528,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@16.2.0:
-    resolution: {integrity: sha512-NLBVrJy1pbV1Yn00L5sU4vFyAHt5XuSjzrNyFnxo6Com0M0KrL6hHM5B99dbqXb2bE9pm4Ow3Zl1xp6HVY9edQ==}
+  next@16.2.1:
+    resolution: {integrity: sha512-VaChzNL7o9rbfdt60HUj8tev4m6d7iC1igAy157526+cJlXOQu5LzsBXNT+xaJnTP/k+utSX5vMv7m0G+zKH+Q==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -3367,6 +3378,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.9.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.1.0':
     dependencies:
       tslib: 2.8.1
@@ -3509,7 +3525,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.0.0':
+  '@img/colour@1.1.0':
     optional: true
 
   '@img/sharp-darwin-arm64@0.34.5':
@@ -3594,7 +3610,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.8.1
+      '@emnapi/runtime': 1.9.1
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -3639,34 +3655,34 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@next/env@16.2.0': {}
+  '@next/env@16.2.1': {}
 
   '@next/eslint-plugin-next@16.1.6':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@16.2.0':
+  '@next/swc-darwin-arm64@16.2.1':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.0':
+  '@next/swc-darwin-x64@16.2.1':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.0':
+  '@next/swc-linux-arm64-gnu@16.2.1':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.0':
+  '@next/swc-linux-arm64-musl@16.2.1':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.0':
+  '@next/swc-linux-x64-gnu@16.2.1':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.0':
+  '@next/swc-linux-x64-musl@16.2.1':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.0':
+  '@next/swc-win32-arm64-msvc@16.2.1':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.0':
+  '@next/swc-win32-x64-msvc@16.2.1':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -4255,14 +4271,14 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@2.0.1(next@16.2.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+  '@vercel/analytics@2.0.1(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
     optionalDependencies:
-      next: 16.2.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
-  '@vercel/speed-insights@2.0.0(next@16.2.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+  '@vercel/speed-insights@2.0.0(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
     optionalDependencies:
-      next: 16.2.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
   '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@29.0.0)(lightningcss@1.32.0))':
@@ -4442,6 +4458,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  baseline-browser-mapping@2.10.10: {}
+
   baseline-browser-mapping@2.9.19: {}
 
   bidi-js@1.0.3:
@@ -4484,6 +4502,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001769: {}
+
+  caniuse-lite@1.0.30001780: {}
 
   canvas-confetti@1.9.4: {}
 
@@ -4748,8 +4768,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -4771,7 +4791,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -4782,22 +4802,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -4808,7 +4828,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -5464,25 +5484,25 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.0(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      '@next/env': 16.2.0
+      '@next/env': 16.2.1
       '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.9.19
-      caniuse-lite: 1.0.30001769
+      baseline-browser-mapping: 2.10.10
+      caniuse-lite: 1.0.30001780
       postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.0
-      '@next/swc-darwin-x64': 16.2.0
-      '@next/swc-linux-arm64-gnu': 16.2.0
-      '@next/swc-linux-arm64-musl': 16.2.0
-      '@next/swc-linux-x64-gnu': 16.2.0
-      '@next/swc-linux-x64-musl': 16.2.0
-      '@next/swc-win32-arm64-msvc': 16.2.0
-      '@next/swc-win32-x64-msvc': 16.2.0
+      '@next/swc-darwin-arm64': 16.2.1
+      '@next/swc-darwin-x64': 16.2.1
+      '@next/swc-linux-arm64-gnu': 16.2.1
+      '@next/swc-linux-arm64-musl': 16.2.1
+      '@next/swc-linux-x64-gnu': 16.2.1
+      '@next/swc-linux-x64-musl': 16.2.1
+      '@next/swc-win32-arm64-msvc': 16.2.1
+      '@next/swc-win32-x64-msvc': 16.2.1
       '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.58.2
       sharp: 0.34.5
@@ -5804,7 +5824,7 @@ snapshots:
 
   sharp@0.34.5:
     dependencies:
-      '@img/colour': 1.0.0
+      '@img/colour': 1.1.0
       detect-libc: 2.1.2
       semver: 7.7.4
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,17 +20,17 @@ importers:
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@vitest/coverage-v8':
-        specifier: ^4.0.0
-        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@29.0.0)(lightningcss@1.32.0))
+        specifier: ^4.1.0
+        version: 4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0)))
       husky:
         specifier: ^9.1.7
         version: 9.1.7
       jsdom:
-        specifier: ^29.0.0
-        version: 29.0.0
+        specifier: ^29.0.1
+        version: 29.0.1
       vitest:
-        specifier: ^4.0.0
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@29.0.0)(lightningcss@1.32.0)
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0))
 
   apps/web:
     dependencies:
@@ -127,8 +127,8 @@ packages:
     resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
-  '@asamuzakjp/dom-selector@7.0.3':
-    resolution: {integrity: sha512-Q6mU0Z6bfj6YvnX2k9n0JxiIwrCFN59x/nWmYQnAqP000ruX/yV+5bp/GRcF5T8ncvfwJQ7fgfP74DlpKExILA==}
+  '@asamuzakjp/dom-selector@7.0.4':
+    resolution: {integrity: sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   '@asamuzakjp/nwsapi@2.3.9':
@@ -186,6 +186,11 @@ packages:
 
   '@babel/parser@7.29.0':
     resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -269,158 +274,158 @@ packages:
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
-  '@esbuild/aix-ppc64@0.27.3':
-    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+  '@esbuild/aix-ppc64@0.27.4':
+    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.3':
-    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+  '@esbuild/android-arm64@0.27.4':
+    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.3':
-    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+  '@esbuild/android-arm@0.27.4':
+    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.3':
-    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+  '@esbuild/android-x64@0.27.4':
+    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.3':
-    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+  '@esbuild/darwin-arm64@0.27.4':
+    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.3':
-    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+  '@esbuild/darwin-x64@0.27.4':
+    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.3':
-    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+  '@esbuild/freebsd-arm64@0.27.4':
+    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.3':
-    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+  '@esbuild/freebsd-x64@0.27.4':
+    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.3':
-    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+  '@esbuild/linux-arm64@0.27.4':
+    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.3':
-    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+  '@esbuild/linux-arm@0.27.4':
+    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.3':
-    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+  '@esbuild/linux-ia32@0.27.4':
+    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.3':
-    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+  '@esbuild/linux-loong64@0.27.4':
+    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.3':
-    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+  '@esbuild/linux-mips64el@0.27.4':
+    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.3':
-    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+  '@esbuild/linux-ppc64@0.27.4':
+    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.3':
-    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+  '@esbuild/linux-riscv64@0.27.4':
+    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.3':
-    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+  '@esbuild/linux-s390x@0.27.4':
+    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.3':
-    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+  '@esbuild/linux-x64@0.27.4':
+    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+  '@esbuild/netbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.3':
-    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+  '@esbuild/netbsd-x64@0.27.4':
+    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+  '@esbuild/openbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.3':
-    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+  '@esbuild/openbsd-x64@0.27.4':
+    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.3':
-    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+  '@esbuild/openharmony-arm64@0.27.4':
+    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.3':
-    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+  '@esbuild/sunos-x64@0.27.4':
+    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.3':
-    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+  '@esbuild/win32-arm64@0.27.4':
+    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.3':
-    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+  '@esbuild/win32-ia32@0.27.4':
+    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.3':
-    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+  '@esbuild/win32-x64@0.27.4':
+    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -933,141 +938,141 @@ packages:
     resolution: {integrity: sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==}
     engines: {node: '>= 10'}
 
-  '@rollup/rollup-android-arm-eabi@4.59.0':
-    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
+  '@rollup/rollup-android-arm-eabi@4.60.0':
+    resolution: {integrity: sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.59.0':
-    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
+  '@rollup/rollup-android-arm64@4.60.0':
+    resolution: {integrity: sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.59.0':
-    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
+  '@rollup/rollup-darwin-arm64@4.60.0':
+    resolution: {integrity: sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.59.0':
-    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
+  '@rollup/rollup-darwin-x64@4.60.0':
+    resolution: {integrity: sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.59.0':
-    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
+  '@rollup/rollup-freebsd-arm64@4.60.0':
+    resolution: {integrity: sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.59.0':
-    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
+  '@rollup/rollup-freebsd-x64@4.60.0':
+    resolution: {integrity: sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
-    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
+    resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
-    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
+  '@rollup/rollup-linux-arm-musleabihf@4.60.0':
+    resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.59.0':
-    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
+  '@rollup/rollup-linux-arm64-gnu@4.60.0':
+    resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.59.0':
-    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
+  '@rollup/rollup-linux-arm64-musl@4.60.0':
+    resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.59.0':
-    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
+  '@rollup/rollup-linux-loong64-gnu@4.60.0':
+    resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-loong64-musl@4.59.0':
-    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
+  '@rollup/rollup-linux-loong64-musl@4.60.0':
+    resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
-    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
+  '@rollup/rollup-linux-ppc64-gnu@4.60.0':
+    resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-musl@4.59.0':
-    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
+  '@rollup/rollup-linux-ppc64-musl@4.60.0':
+    resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
-    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
+  '@rollup/rollup-linux-riscv64-gnu@4.60.0':
+    resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-musl@4.59.0':
-    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
+  '@rollup/rollup-linux-riscv64-musl@4.60.0':
+    resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.59.0':
-    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
+  '@rollup/rollup-linux-s390x-gnu@4.60.0':
+    resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.59.0':
-    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
+  '@rollup/rollup-linux-x64-gnu@4.60.0':
+    resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.59.0':
-    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
+  '@rollup/rollup-linux-x64-musl@4.60.0':
+    resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.59.0':
-    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
+  '@rollup/rollup-openbsd-x64@4.60.0':
+    resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.59.0':
-    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
+  '@rollup/rollup-openharmony-arm64@4.60.0':
+    resolution: {integrity: sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.59.0':
-    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
+  '@rollup/rollup-win32-arm64-msvc@4.60.0':
+    resolution: {integrity: sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.59.0':
-    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
+  '@rollup/rollup-win32-ia32-msvc@4.60.0':
+    resolution: {integrity: sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.59.0':
-    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
+  '@rollup/rollup-win32-x64-gnu@4.60.0':
+    resolution: {integrity: sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.59.0':
-    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
+  '@rollup/rollup-win32-x64-msvc@4.60.0':
+    resolution: {integrity: sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==}
     cpu: [x64]
     os: [win32]
 
@@ -1482,43 +1487,43 @@ packages:
       vue-router:
         optional: true
 
-  '@vitest/coverage-v8@4.0.18':
-    resolution: {integrity: sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==}
+  '@vitest/coverage-v8@4.1.0':
+    resolution: {integrity: sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==}
     peerDependencies:
-      '@vitest/browser': 4.0.18
-      vitest: 4.0.18
+      '@vitest/browser': 4.1.0
+      vitest: 4.1.0
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.0.18':
-    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+  '@vitest/expect@4.1.0':
+    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
 
-  '@vitest/mocker@4.0.18':
-    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+  '@vitest/mocker@4.1.0':
+    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.0.18':
-    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+  '@vitest/pretty-format@4.1.0':
+    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
 
-  '@vitest/runner@4.0.18':
-    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+  '@vitest/runner@4.1.0':
+    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
 
-  '@vitest/snapshot@4.0.18':
-    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+  '@vitest/snapshot@4.1.0':
+    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
 
-  '@vitest/spy@4.0.18':
-    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+  '@vitest/spy@4.1.0':
+    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
 
-  '@vitest/utils@4.0.18':
-    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+  '@vitest/utils@4.1.0':
+    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1603,8 +1608,8 @@ packages:
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
-  ast-v8-to-istanbul@0.3.11:
-    resolution: {integrity: sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==}
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
@@ -1823,8 +1828,8 @@ packages:
     resolution: {integrity: sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==}
     engines: {node: '>= 0.4'}
 
-  es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -1842,8 +1847,8 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.27.3:
-    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+  esbuild@0.27.4:
+    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2321,8 +2326,8 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
-  jsdom@29.0.0:
-    resolution: {integrity: sha512-9FshNB6OepopZ08unmmGpsF7/qCjxGPbo3NbgfJAnPeHXnsODE9WWffXZtRFRFe0ntzaAOcSKNJFz8wiyvF1jQ==}
+  jsdom@29.0.1:
+    resolution: {integrity: sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
     peerDependencies:
       canvas: ^3.0.0
@@ -2751,8 +2756,8 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rollup@4.59.0:
-    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
+  rollup@4.60.0:
+    resolution: {integrity: sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -2847,8 +2852,8 @@ packages:
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -2925,23 +2930,23 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.0.2:
-    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+  tinyexec@1.0.4:
+    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
-  tinyrainbow@3.0.3:
-    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
-  tldts-core@7.0.26:
-    resolution: {integrity: sha512-5WJ2SqFsv4G2Dwi7ZFVRnz6b2H1od39QME1lc2y5Ew3eWiZMAeqOAfWpRP9jHvhUl881406QtZTODvjttJs+ew==}
+  tldts-core@7.0.27:
+    resolution: {integrity: sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==}
 
-  tldts@7.0.26:
-    resolution: {integrity: sha512-WiGwQjr0qYdNNG8KpMKlSvpxz652lqa3Rd+/hSaDcY4Uo6SKWZq2LAF+hsAhUewTtYhXlorBKgNF3Kk8hnjGoQ==}
+  tldts@7.0.27:
+    resolution: {integrity: sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==}
     hasBin: true
 
   to-regex-range@5.0.1:
@@ -3014,8 +3019,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.24.4:
-    resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
+  undici@7.24.5:
+    resolution: {integrity: sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==}
     engines: {node: '>=20.18.1'}
 
   unrs-resolver@1.11.1:
@@ -3074,20 +3079,21 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.0.18:
-    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+  vitest@4.1.0:
+    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.0.18
-      '@vitest/browser-preview': 4.0.18
-      '@vitest/browser-webdriverio': 4.0.18
-      '@vitest/ui': 4.0.18
+      '@vitest/browser-playwright': 4.1.0
+      '@vitest/browser-preview': 4.1.0
+      '@vitest/browser-webdriverio': 4.1.0
+      '@vitest/ui': 4.1.0
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -3221,7 +3227,7 @@ snapshots:
       '@csstools/css-tokenizer': 4.0.0
       lru-cache: 11.2.7
 
-  '@asamuzakjp/dom-selector@7.0.3':
+  '@asamuzakjp/dom-selector@7.0.4':
     dependencies:
       '@asamuzakjp/nwsapi': 2.3.9
       bidi-js: 1.0.3
@@ -3308,6 +3314,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@babel/runtime@7.28.6': {}
 
   '@babel/runtime@7.29.2': {}
@@ -3388,82 +3398,82 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.3':
+  '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
-  '@esbuild/android-arm64@0.27.3':
+  '@esbuild/android-arm64@0.27.4':
     optional: true
 
-  '@esbuild/android-arm@0.27.3':
+  '@esbuild/android-arm@0.27.4':
     optional: true
 
-  '@esbuild/android-x64@0.27.3':
+  '@esbuild/android-x64@0.27.4':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.3':
+  '@esbuild/darwin-arm64@0.27.4':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.3':
+  '@esbuild/darwin-x64@0.27.4':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.3':
+  '@esbuild/freebsd-arm64@0.27.4':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.3':
+  '@esbuild/freebsd-x64@0.27.4':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.3':
+  '@esbuild/linux-arm64@0.27.4':
     optional: true
 
-  '@esbuild/linux-arm@0.27.3':
+  '@esbuild/linux-arm@0.27.4':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.3':
+  '@esbuild/linux-ia32@0.27.4':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.3':
+  '@esbuild/linux-loong64@0.27.4':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.3':
+  '@esbuild/linux-mips64el@0.27.4':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.3':
+  '@esbuild/linux-ppc64@0.27.4':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.3':
+  '@esbuild/linux-riscv64@0.27.4':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.3':
+  '@esbuild/linux-s390x@0.27.4':
     optional: true
 
-  '@esbuild/linux-x64@0.27.3':
+  '@esbuild/linux-x64@0.27.4':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.3':
+  '@esbuild/netbsd-arm64@0.27.4':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.3':
+  '@esbuild/netbsd-x64@0.27.4':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.3':
+  '@esbuild/openbsd-arm64@0.27.4':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.3':
+  '@esbuild/openbsd-x64@0.27.4':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.3':
+  '@esbuild/openharmony-arm64@0.27.4':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.3':
+  '@esbuild/sunos-x64@0.27.4':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.3':
+  '@esbuild/win32-arm64@0.27.4':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.3':
+  '@esbuild/win32-ia32@0.27.4':
     optional: true
 
-  '@esbuild/win32-x64@0.27.3':
+  '@esbuild/win32-x64@0.27.4':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
@@ -3861,79 +3871,79 @@ snapshots:
       '@resvg/resvg-js-win32-ia32-msvc': 2.6.2
       '@resvg/resvg-js-win32-x64-msvc': 2.6.2
 
-  '@rollup/rollup-android-arm-eabi@4.59.0':
+  '@rollup/rollup-android-arm-eabi@4.60.0':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.59.0':
+  '@rollup/rollup-android-arm64@4.60.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.59.0':
+  '@rollup/rollup-darwin-arm64@4.60.0':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.59.0':
+  '@rollup/rollup-darwin-x64@4.60.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.59.0':
+  '@rollup/rollup-freebsd-arm64@4.60.0':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.59.0':
+  '@rollup/rollup-freebsd-x64@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+  '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+  '@rollup/rollup-linux-arm64-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.59.0':
+  '@rollup/rollup-linux-arm64-musl@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+  '@rollup/rollup-linux-loong64-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.59.0':
+  '@rollup/rollup-linux-loong64-musl@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+  '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+  '@rollup/rollup-linux-ppc64-musl@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+  '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+  '@rollup/rollup-linux-riscv64-musl@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+  '@rollup/rollup-linux-s390x-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.59.0':
+  '@rollup/rollup-linux-x64-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.59.0':
+  '@rollup/rollup-linux-x64-musl@4.60.0':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.59.0':
+  '@rollup/rollup-openbsd-x64@4.60.0':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.59.0':
+  '@rollup/rollup-openharmony-arm64@4.60.0':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+  '@rollup/rollup-win32-arm64-msvc@4.60.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+  '@rollup/rollup-win32-ia32-msvc@4.60.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.59.0':
+  '@rollup/rollup-win32-x64-gnu@4.60.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.59.0':
+  '@rollup/rollup-win32-x64-msvc@4.60.0':
     optional: true
 
   '@rtsao/scc@1.1.0': {}
@@ -4281,58 +4291,60 @@ snapshots:
       next: 16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@29.0.0)(lightningcss@1.32.0))':
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.0.18
-      ast-v8-to-istanbul: 0.3.11
+      '@vitest/utils': 4.1.0
+      ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.2
       obug: 2.1.1
-      std-env: 3.10.0
-      tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@29.0.0)(lightningcss@1.32.0)
+      std-env: 4.0.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0))
 
-  '@vitest/expect@4.0.18':
+  '@vitest/expect@4.1.0':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.0.18
-      '@vitest/utils': 4.0.18
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
       chai: 6.2.2
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@vitest/mocker@4.1.0(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
-      '@vitest/spy': 4.0.18
+      '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0)
 
-  '@vitest/pretty-format@4.0.18':
+  '@vitest/pretty-format@4.1.0':
     dependencies:
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.0.18':
+  '@vitest/runner@4.1.0':
     dependencies:
-      '@vitest/utils': 4.0.18
+      '@vitest/utils': 4.1.0
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.0.18':
+  '@vitest/snapshot@4.1.0':
     dependencies:
-      '@vitest/pretty-format': 4.0.18
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/utils': 4.1.0
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.0.18': {}
+  '@vitest/spy@4.1.0': {}
 
-  '@vitest/utils@4.0.18':
+  '@vitest/utils@4.1.0':
     dependencies:
-      '@vitest/pretty-format': 4.0.18
-      tinyrainbow: 3.0.3
+      '@vitest/pretty-format': 4.1.0
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -4440,7 +4452,7 @@ snapshots:
 
   ast-types-flow@0.0.8: {}
 
-  ast-v8-to-istanbul@0.3.11:
+  ast-v8-to-istanbul@1.0.0:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
@@ -4707,7 +4719,7 @@ snapshots:
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
 
-  es-module-lexer@1.7.0: {}
+  es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -4730,34 +4742,34 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
-  esbuild@0.27.3:
+  esbuild@0.27.4:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.3
-      '@esbuild/android-arm': 0.27.3
-      '@esbuild/android-arm64': 0.27.3
-      '@esbuild/android-x64': 0.27.3
-      '@esbuild/darwin-arm64': 0.27.3
-      '@esbuild/darwin-x64': 0.27.3
-      '@esbuild/freebsd-arm64': 0.27.3
-      '@esbuild/freebsd-x64': 0.27.3
-      '@esbuild/linux-arm': 0.27.3
-      '@esbuild/linux-arm64': 0.27.3
-      '@esbuild/linux-ia32': 0.27.3
-      '@esbuild/linux-loong64': 0.27.3
-      '@esbuild/linux-mips64el': 0.27.3
-      '@esbuild/linux-ppc64': 0.27.3
-      '@esbuild/linux-riscv64': 0.27.3
-      '@esbuild/linux-s390x': 0.27.3
-      '@esbuild/linux-x64': 0.27.3
-      '@esbuild/netbsd-arm64': 0.27.3
-      '@esbuild/netbsd-x64': 0.27.3
-      '@esbuild/openbsd-arm64': 0.27.3
-      '@esbuild/openbsd-x64': 0.27.3
-      '@esbuild/openharmony-arm64': 0.27.3
-      '@esbuild/sunos-x64': 0.27.3
-      '@esbuild/win32-arm64': 0.27.3
-      '@esbuild/win32-ia32': 0.27.3
-      '@esbuild/win32-x64': 0.27.3
+      '@esbuild/aix-ppc64': 0.27.4
+      '@esbuild/android-arm': 0.27.4
+      '@esbuild/android-arm64': 0.27.4
+      '@esbuild/android-x64': 0.27.4
+      '@esbuild/darwin-arm64': 0.27.4
+      '@esbuild/darwin-x64': 0.27.4
+      '@esbuild/freebsd-arm64': 0.27.4
+      '@esbuild/freebsd-x64': 0.27.4
+      '@esbuild/linux-arm': 0.27.4
+      '@esbuild/linux-arm64': 0.27.4
+      '@esbuild/linux-ia32': 0.27.4
+      '@esbuild/linux-loong64': 0.27.4
+      '@esbuild/linux-mips64el': 0.27.4
+      '@esbuild/linux-ppc64': 0.27.4
+      '@esbuild/linux-riscv64': 0.27.4
+      '@esbuild/linux-s390x': 0.27.4
+      '@esbuild/linux-x64': 0.27.4
+      '@esbuild/netbsd-arm64': 0.27.4
+      '@esbuild/netbsd-x64': 0.27.4
+      '@esbuild/openbsd-arm64': 0.27.4
+      '@esbuild/openbsd-x64': 0.27.4
+      '@esbuild/openharmony-arm64': 0.27.4
+      '@esbuild/sunos-x64': 0.27.4
+      '@esbuild/win32-arm64': 0.27.4
+      '@esbuild/win32-ia32': 0.27.4
+      '@esbuild/win32-x64': 0.27.4
 
   escalade@3.2.0: {}
 
@@ -4768,8 +4780,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -4791,7 +4803,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -4802,22 +4814,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -4828,7 +4840,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -5307,10 +5319,10 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@29.0.0:
+  jsdom@29.0.1:
     dependencies:
       '@asamuzakjp/css-color': 5.0.1
-      '@asamuzakjp/dom-selector': 7.0.3
+      '@asamuzakjp/dom-selector': 7.0.4
       '@bramus/specificity': 2.4.2
       '@csstools/css-syntax-patches-for-csstree': 1.1.1(css-tree@3.2.1)
       '@exodus/bytes': 1.15.0
@@ -5324,7 +5336,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.24.4
+      undici: 7.24.5
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -5444,7 +5456,7 @@ snapshots:
 
   magicast@0.5.2:
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
@@ -5736,35 +5748,35 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rollup@4.59.0:
+  rollup@4.60.0:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.59.0
-      '@rollup/rollup-android-arm64': 4.59.0
-      '@rollup/rollup-darwin-arm64': 4.59.0
-      '@rollup/rollup-darwin-x64': 4.59.0
-      '@rollup/rollup-freebsd-arm64': 4.59.0
-      '@rollup/rollup-freebsd-x64': 4.59.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
-      '@rollup/rollup-linux-arm64-gnu': 4.59.0
-      '@rollup/rollup-linux-arm64-musl': 4.59.0
-      '@rollup/rollup-linux-loong64-gnu': 4.59.0
-      '@rollup/rollup-linux-loong64-musl': 4.59.0
-      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
-      '@rollup/rollup-linux-ppc64-musl': 4.59.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
-      '@rollup/rollup-linux-riscv64-musl': 4.59.0
-      '@rollup/rollup-linux-s390x-gnu': 4.59.0
-      '@rollup/rollup-linux-x64-gnu': 4.59.0
-      '@rollup/rollup-linux-x64-musl': 4.59.0
-      '@rollup/rollup-openbsd-x64': 4.59.0
-      '@rollup/rollup-openharmony-arm64': 4.59.0
-      '@rollup/rollup-win32-arm64-msvc': 4.59.0
-      '@rollup/rollup-win32-ia32-msvc': 4.59.0
-      '@rollup/rollup-win32-x64-gnu': 4.59.0
-      '@rollup/rollup-win32-x64-msvc': 4.59.0
+      '@rollup/rollup-android-arm-eabi': 4.60.0
+      '@rollup/rollup-android-arm64': 4.60.0
+      '@rollup/rollup-darwin-arm64': 4.60.0
+      '@rollup/rollup-darwin-x64': 4.60.0
+      '@rollup/rollup-freebsd-arm64': 4.60.0
+      '@rollup/rollup-freebsd-x64': 4.60.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.0
+      '@rollup/rollup-linux-arm64-gnu': 4.60.0
+      '@rollup/rollup-linux-arm64-musl': 4.60.0
+      '@rollup/rollup-linux-loong64-gnu': 4.60.0
+      '@rollup/rollup-linux-loong64-musl': 4.60.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.0
+      '@rollup/rollup-linux-ppc64-musl': 4.60.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.0
+      '@rollup/rollup-linux-riscv64-musl': 4.60.0
+      '@rollup/rollup-linux-s390x-gnu': 4.60.0
+      '@rollup/rollup-linux-x64-gnu': 4.60.0
+      '@rollup/rollup-linux-x64-musl': 4.60.0
+      '@rollup/rollup-openbsd-x64': 4.60.0
+      '@rollup/rollup-openharmony-arm64': 4.60.0
+      '@rollup/rollup-win32-arm64-msvc': 4.60.0
+      '@rollup/rollup-win32-ia32-msvc': 4.60.0
+      '@rollup/rollup-win32-x64-gnu': 4.60.0
+      '@rollup/rollup-win32-x64-msvc': 4.60.0
       fsevents: 2.3.3
 
   run-parallel@1.2.0:
@@ -5907,7 +5919,7 @@ snapshots:
       '@stablelib/base64': 1.0.1
       fast-sha256: 1.3.0
 
-  std-env@3.10.0: {}
+  std-env@4.0.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -5999,20 +6011,20 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.0.2: {}
+  tinyexec@1.0.4: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
-  tinyrainbow@3.0.3: {}
+  tinyrainbow@3.1.0: {}
 
-  tldts-core@7.0.26: {}
+  tldts-core@7.0.27: {}
 
-  tldts@7.0.26:
+  tldts@7.0.27:
     dependencies:
-      tldts-core: 7.0.26
+      tldts-core: 7.0.27
 
   to-regex-range@5.0.1:
     dependencies:
@@ -6022,7 +6034,7 @@ snapshots:
 
   tough-cookie@6.0.1:
     dependencies:
-      tldts: 7.0.26
+      tldts: 7.0.27
 
   tr46@6.0.0:
     dependencies:
@@ -6102,7 +6114,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@7.24.4: {}
+  undici@7.24.5: {}
 
   unrs-resolver@1.11.1:
     dependencies:
@@ -6142,11 +6154,11 @@ snapshots:
 
   vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0):
     dependencies:
-      esbuild: 0.27.3
+      esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.8
-      rollup: 4.59.0
+      rollup: 4.60.0
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 25.3.0
@@ -6154,44 +6166,34 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.32.0
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jiti@2.6.1)(jsdom@29.0.0)(lightningcss@1.32.0):
+  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0)):
     dependencies:
-      '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0))
-      '@vitest/pretty-format': 4.0.18
-      '@vitest/runner': 4.0.18
-      '@vitest/snapshot': 4.0.18
-      '@vitest/spy': 4.0.18
-      '@vitest/utils': 4.0.18
-      es-module-lexer: 1.7.0
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.3
-      std-env: 3.10.0
+      std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 1.0.2
+      tinyexec: 1.0.4
       tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
       vite: 7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 25.3.0
-      jsdom: 29.0.0
+      jsdom: 29.0.1
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/supabase/migrations/017_add_campaign_type.sql
+++ b/supabase/migrations/017_add_campaign_type.sql
@@ -1,0 +1,6 @@
+-- Add campaign type: "announcement" (manual blast) vs "engagement" (automated template)
+ALTER TABLE email_campaigns
+  ADD COLUMN IF NOT EXISTS type TEXT NOT NULL DEFAULT 'announcement';
+
+CREATE INDEX IF NOT EXISTS idx_email_campaigns_type
+  ON email_campaigns(type);


### PR DESCRIPTION
## [2.1.0] - 2026-03-22

### Added
- Campaign type system: `announcement` (manual blast) vs `engagement` (automated score-bump template)
- Send test email endpoint for campaign drafts (`POST /api/admin/campaigns/:id/test`)
- BIMI logo for email branding
- `microCommitRatio` metric: fraction of merged PRs with < 10 lines changed
- `dev` and `developer` added to `DEFAULT_BRANCH_NAMES` for accurate feature branch detection
- 57 new tests (html-helpers, error boundaries, campaign a11y, experiment landmarks)

### Changed
- `low_activity_signal` confidence penalty: AND → OR (triggers on either low days or low commits)
- Score-bump notification threshold raised from 5 to 10 points
- Email templates: improved subject lines, multi-paragraph body support, shared `featureRow()` helper
- Next.js updated to 16.2.1
- Dev dependencies updated: vitest 4.1.0, jsdom 29.0.1

### Fixed
- Campaign template placeholder interpolation (ctaUrl, ctaText, features array, engagement fields)
- Email feature bullet spacing
- Campaign form a11y: added label associations and aria-labels
- 7 experiment pages: proper `<main>` landmark semantics
- Public scoring page: low_activity_signal AND → OR

---

**Pre-launch audit:** READY (all 14 findings remediated)
**Tests:** 5,763 passing across 337 files
**Typecheck:** Clean | **Lint:** Clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)