### PR TITLE
release: v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1] - 2026-03-27
+
+### Added
+- Share page Suspense boundary for progressive streaming — page shell renders immediately, badge content loads asynchronously with `BadgeSkeleton` fallback (#635)
+- 43 new tests: 6 new test files (5 loading.tsx + ClientAnalytics), heading hierarchy regression tests, health endpoint coverage; total test count: 6,414 (#637)
+
+### Fixed
+- Linked platforms now appear in Data Sources and badge footer even when stats fetch temporarily fails (expired token, API error) — DB link status is the source of truth (#632)
+- Health endpoint uses `dbsize()` instead of `ping()` for actual Redis data-access check; returns `"skipped"` (200 OK) instead of `"unavailable"` (503) when services are not configured (#634)
+- Cron auth logs a warning when `CRON_SECRET` is not set, making unprotected endpoints visible in logs (#633)
+- Heading hierarchy corrected in experiment pages — `h1` now precedes `h2` in DOM order (#636)
+- E2E health test updated to accept `"skipped"` status
+
+### Changed
+- UserMenu platform visibility driven by server-side status API instead of client-side sync flags — eliminates env var / DB flag mismatches
+- Parallelized linked-platform DB fallback checks via `Promise.all`; extracted `fetchPlatformStatus()` helper in UserMenu
+- 6 minor/patch dependency updates: @supabase/supabase-js, posthog-js, svix, @next/bundle-analyzer, @types/node, eslint-config-next (#638)
+
+### Documentation
+- Updated README test counts, CLAUDE.md health endpoint + agent report descriptions
+- Updated spec.md with Craft dimension, Artificer archetype, profile API + health endpoints
+- Updated badge specs: "Platform Branding" (was "GitHub Branding"), 4/5-axis radar chart, 3 missing render files
+- Removed stale Confidence references from badge design doc
+- Added CHANGELOG link reference definitions for all versions
+
 ## [2.4.0] - 2026-03-27
 
 ### Added
@@ -234,3 +259,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test suite (130+ test files, 2100+ tests)
 - CI/CD with GitHub Actions (tests, typecheck, lint, security scanning, bundle analysis)
 - Public release documentation (LICENSE, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY)
+
+[2.4.1]: https://github.com/juan294/chapa/compare/v2.4.0...v2.4.1
+[2.4.0]: https://github.com/juan294/chapa/compare/v2.3.0...v2.4.0
+[2.3.0]: https://github.com/juan294/chapa/compare/v2.2.0...v2.3.0
+[2.2.0]: https://github.com/juan294/chapa/compare/v2.1.0...v2.2.0
+[2.1.0]: https://github.com/juan294/chapa/compare/v2.0.0...v2.1.0
+[2.0.0]: https://github.com/juan294/chapa/compare/v1.0.0...v2.0.0
+[1.0.0]: https://github.com/juan294/chapa/releases/tag/v1.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Chapa generates a **live, embeddable, animated SVG badge** that showcases a deve
 - GET `/api/verify/:hash` Badge verification endpoint
 - GET `/api/profile/:handle` Public impact profile snapshot (rate-limited, CORS-enabled)
 - GET `/api/history/:handle` Score history, trend, and diff (rate-limited)
-- GET `/api/health` Health check (Redis + Supabase ping, rate-limited)
+- GET `/api/health` Health check (Redis dbsize + Supabase query, rate-limited; returns "skipped" for unconfigured services)
 - GET `/api/feature-flags` Public feature flag values
 - GET `/u/:handle/og-image` OG image for share page (dynamic, cached)
 - GET `/og-image` Default OG image
@@ -297,7 +297,7 @@ Go directly to these paths — never search the codebase for them.
 
 | Topic | Path | Notes |
 |-------|------|-------|
-| Agent reports | `docs/agents/*-report.md` | Gitignored. Local-only operational history. Never committed (Rule #70) |
+| Agent reports | `docs/agents/*-report.md` | Operational history. Committed to repo for team visibility |
 | Agent logs | `logs/<name>.log`, `<name>.error.log` | Gitignored. Read alongside reports to diagnose failures |
 | Agent scripts | `scripts/agents/` | Gitignored. Standalone bash files invoking Claude CLI headless |
 | ADRs | `docs/decisions/` | Architecture decision records |

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ An internal **confidence score** (50–100) reflects data completeness and gentl
 | Email | Resend |
 | CLI | Node.js, tsup, device auth flow |
 | Hosting | Vercel |
-| Testing | Vitest, 367+ test files, 5,920+ tests, TDD workflow |
+| Testing | Vitest, 378+ test files, 6,400+ tests, TDD workflow |
 
 ## Environment Variables
 

--- a/apps/web/app/admin/loading.test.tsx
+++ b/apps/web/app/admin/loading.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "loading.tsx"),
+  "utf-8",
+);
+
+describe("Admin loading.tsx", () => {
+  it("renders a default export function", () => {
+    expect(SOURCE).toMatch(/export default function/);
+  });
+
+  it("uses bg-bg for page background", () => {
+    expect(SOURCE).toContain("bg-bg");
+  });
+
+  it("uses animate-pulse for skeleton effect", () => {
+    expect(SOURCE).toContain("animate-pulse");
+  });
+
+  it("has role='status' and aria-label='Loading' on the main container", () => {
+    expect(SOURCE).toContain('role="status"');
+    expect(SOURCE).toContain('aria-label="Loading"');
+  });
+
+  it("has an sr-only loading text span", () => {
+    expect(SOURCE).toContain('className="sr-only"');
+    expect(SOURCE).toContain("Loading admin dashboard...");
+  });
+
+  it("uses design system border tokens", () => {
+    expect(SOURCE).toContain("border-stroke");
+  });
+
+  it("renders stats card skeletons", () => {
+    expect(SOURCE).toContain("bg-card");
+  });
+});

--- a/apps/web/app/api/health/route.test.ts
+++ b/apps/web/app/api/health/route.test.ts
@@ -56,29 +56,28 @@ describe("GET /api/health", () => {
     expect(body.dependencies.supabase).toBe("ok");
   });
 
-  it("returns 503 with status 'degraded' when Redis client is null (missing env vars)", async () => {
-    vi.mocked(pingRedis).mockResolvedValueOnce("unavailable");
+  it("returns 200 with 'skipped' when Redis env vars are not configured (#634)", async () => {
+    vi.mocked(pingRedis).mockResolvedValueOnce("skipped");
     vi.mocked(pingSupabase).mockResolvedValueOnce("ok");
 
     const response = await GET(makeRequest());
     const body = await response.json();
 
-    expect(response.status).toBe(503);
-    expect(body.status).toBe("degraded");
-    expect(body.dependencies.redis).toBe("unavailable");
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("ok");
+    expect(body.dependencies.redis).toBe("skipped");
   });
 
-  it("returns 503 with status 'degraded' when Supabase is unavailable", async () => {
+  it("returns 200 with 'skipped' when Supabase env vars are not configured (#634)", async () => {
     vi.mocked(pingRedis).mockResolvedValueOnce("ok");
-    vi.mocked(pingSupabase).mockResolvedValueOnce("unavailable");
+    vi.mocked(pingSupabase).mockResolvedValueOnce("skipped");
 
     const response = await GET(makeRequest());
     const body = await response.json();
 
-    expect(response.status).toBe(503);
-    expect(body.status).toBe("degraded");
-    expect(body.dependencies.redis).toBe("ok");
-    expect(body.dependencies.supabase).toBe("unavailable");
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("ok");
+    expect(body.dependencies.supabase).toBe("skipped");
   });
 
   it("returns 503 with status 'degraded' when Supabase errors", async () => {

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -24,9 +24,11 @@ export async function GET(request: NextRequest) {
     pingSupabase(),
   ]);
 
-  // Both Redis and Supabase are critical — either failing triggers degraded
+  // "skipped" = env vars not configured (preview deploys) — not degraded.
+  // Only "error" = configured but failing — triggers 503.
+  const isHealthy = (s: string) => s === "ok" || s === "skipped";
   const status =
-    redisStatus === "ok" && supabaseStatus === "ok" ? "ok" : "degraded";
+    isHealthy(redisStatus) && isHealthy(supabaseStatus) ? "ok" : "degraded";
   const httpStatus = status === "ok" ? 200 : 503;
 
   return NextResponse.json(

--- a/apps/web/app/cli/authorize/loading.test.tsx
+++ b/apps/web/app/cli/authorize/loading.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "loading.tsx"),
+  "utf-8",
+);
+
+describe("CLI authorize loading.tsx", () => {
+  it("renders a default export function", () => {
+    expect(SOURCE).toMatch(/export default function/);
+  });
+
+  it("uses bg-bg for page background", () => {
+    expect(SOURCE).toContain("bg-bg");
+  });
+
+  it("uses animate-pulse for skeleton effect", () => {
+    expect(SOURCE).toContain("animate-pulse");
+  });
+
+  it("has role='status' and aria-label='Loading' on the main container", () => {
+    expect(SOURCE).toContain('role="status"');
+    expect(SOURCE).toContain('aria-label="Loading"');
+  });
+
+  it("has an sr-only loading text span", () => {
+    expect(SOURCE).toContain('className="sr-only"');
+    expect(SOURCE).toContain("Loading...");
+  });
+
+  it("uses terminal aesthetic with font-heading", () => {
+    expect(SOURCE).toContain("font-heading");
+  });
+});

--- a/apps/web/app/experiments/loading.test.tsx
+++ b/apps/web/app/experiments/loading.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "loading.tsx"),
+  "utf-8",
+);
+
+describe("Experiments loading.tsx", () => {
+  it("renders a default export function", () => {
+    expect(SOURCE).toMatch(/export default function/);
+  });
+
+  it("uses bg-bg for page background", () => {
+    expect(SOURCE).toContain("bg-bg");
+  });
+
+  it("uses animate-pulse for skeleton effect", () => {
+    expect(SOURCE).toContain("animate-pulse");
+  });
+
+  it("has role='status' and aria-label='Loading' on the main container", () => {
+    expect(SOURCE).toContain('role="status"');
+    expect(SOURCE).toContain('aria-label="Loading"');
+  });
+
+  it("has an sr-only loading text span", () => {
+    expect(SOURCE).toContain('className="sr-only"');
+    expect(SOURCE).toContain("Loading experiment...");
+  });
+
+  it("uses terminal aesthetic with font-heading", () => {
+    expect(SOURCE).toContain("font-heading");
+  });
+});

--- a/apps/web/app/experiments/number-counters/page.test.tsx
+++ b/apps/web/app/experiments/number-counters/page.test.tsx
@@ -46,4 +46,19 @@ describe("number-counters experiment page", () => {
     });
     expect(container!.querySelector("div")).toBeTruthy();
   });
+
+  it("renders h1 before any h2 in DOM order", async () => {
+    const { default: Page } = await import("./page");
+    let container: HTMLElement;
+    await act(async () => {
+      const result = render(<Page />);
+      container = result.container;
+    });
+    const headings = container!.querySelectorAll("h1, h2");
+    expect(headings.length).toBeGreaterThanOrEqual(2);
+    expect(headings[0]!.tagName).toBe("H1");
+    for (let i = 1; i < headings.length; i++) {
+      expect(headings[i]!.tagName).toBe("H2");
+    }
+  });
 });

--- a/apps/web/app/experiments/tier-visuals/page.test.tsx
+++ b/apps/web/app/experiments/tier-visuals/page.test.tsx
@@ -23,4 +23,15 @@ describe("tier-visuals experiment page", () => {
     const { container } = render(<Page />);
     expect(container.querySelector("div")).toBeTruthy();
   });
+
+  it("renders h1 before any h2 in DOM order", async () => {
+    const { default: Page } = await import("./page");
+    const { container } = render(<Page />);
+    const headings = container.querySelectorAll("h1, h2");
+    expect(headings.length).toBeGreaterThanOrEqual(2);
+    expect(headings[0]!.tagName).toBe("H1");
+    for (let i = 1; i < headings.length; i++) {
+      expect(headings[i]!.tagName).toBe("H2");
+    }
+  });
 });

--- a/apps/web/app/privacy/loading.test.tsx
+++ b/apps/web/app/privacy/loading.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "loading.tsx"),
+  "utf-8",
+);
+
+describe("Privacy loading.tsx", () => {
+  it("renders a default export function", () => {
+    expect(SOURCE).toMatch(/export default function/);
+  });
+
+  it("uses bg-bg for page background", () => {
+    expect(SOURCE).toContain("bg-bg");
+  });
+
+  it("uses animate-pulse for skeleton effect", () => {
+    expect(SOURCE).toContain("animate-pulse");
+  });
+
+  it("has role='status' and aria-label='Loading' on the main container", () => {
+    expect(SOURCE).toContain('role="status"');
+    expect(SOURCE).toContain('aria-label="Loading"');
+  });
+
+  it("has an sr-only loading text span", () => {
+    expect(SOURCE).toContain('className="sr-only"');
+    expect(SOURCE).toContain("Loading...");
+  });
+
+  it("uses terminal aesthetic with font-heading", () => {
+    expect(SOURCE).toContain("font-heading");
+  });
+});

--- a/apps/web/app/terms/loading.test.tsx
+++ b/apps/web/app/terms/loading.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "loading.tsx"),
+  "utf-8",
+);
+
+describe("Terms loading.tsx", () => {
+  it("renders a default export function", () => {
+    expect(SOURCE).toMatch(/export default function/);
+  });
+
+  it("uses bg-bg for page background", () => {
+    expect(SOURCE).toContain("bg-bg");
+  });
+
+  it("uses animate-pulse for skeleton effect", () => {
+    expect(SOURCE).toContain("animate-pulse");
+  });
+
+  it("has role='status' and aria-label='Loading' on the main container", () => {
+    expect(SOURCE).toContain('role="status"');
+    expect(SOURCE).toContain('aria-label="Loading"');
+  });
+
+  it("has an sr-only loading text span", () => {
+    expect(SOURCE).toContain('className="sr-only"');
+    expect(SOURCE).toContain("Loading...");
+  });
+
+  it("uses terminal aesthetic with font-heading", () => {
+    expect(SOURCE).toContain("font-heading");
+  });
+});

--- a/apps/web/app/u/[handle]/page.test.ts
+++ b/apps/web/app/u/[handle]/page.test.ts
@@ -143,4 +143,20 @@ describe("SharePage", () => {
       expect(SOURCE).toContain("SharePageOwnerContent");
     });
   });
+
+  // #635 — Suspense boundary for streaming
+  describe("Suspense streaming", () => {
+    it("imports Suspense from react", () => {
+      expect(SOURCE).toContain('import { Suspense }');
+    });
+
+    it("wraps content in Suspense with BadgeSkeleton fallback", () => {
+      expect(SOURCE).toContain("<Suspense");
+      expect(SOURCE).toContain("BadgeSkeleton");
+    });
+
+    it("extracts data-dependent content into SharePageContent", () => {
+      expect(SOURCE).toContain("SharePageContent");
+    });
+  });
 });

--- a/apps/web/app/u/[handle]/page.test.tsx
+++ b/apps/web/app/u/[handle]/page.test.tsx
@@ -175,7 +175,7 @@ vi.mock("@/components/BadgeSkeleton", () => ({
 // Import the page after all mocks
 // ---------------------------------------------------------------------------
 
-import SharePage, { generateMetadata } from "./page";
+import SharePage, { generateMetadata, SharePageContent } from "./page";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -207,10 +207,9 @@ const FAKE_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="6
 const FAKE_SNAPSHOT = { adjustedComposite: 60, date: "2026-01-01" };
 
 async function renderPage(handle = "testuser") {
-  return SharePage({
-    params: Promise.resolve({ handle }),
-    searchParams: Promise.resolve({}),
-  });
+  // Test the data-dependent content directly (SharePageContent).
+  // SharePage is a thin Suspense wrapper around SharePageContent.
+  return SharePageContent({ handle });
 }
 
 // ---------------------------------------------------------------------------
@@ -463,7 +462,10 @@ describe("SharePage /u/[handle]", () => {
   describe("edge cases", () => {
     it("calls notFound for invalid handle", async () => {
       mockIsValidHandle.mockReturnValue(false);
-      await expect(renderPage("bad!!handle")).rejects.toThrow("NOT_FOUND");
+      // notFound() validation is in the outer SharePage wrapper, not SharePageContent
+      await expect(
+        SharePage({ params: Promise.resolve({ handle: "bad!!handle" }) }),
+      ).rejects.toThrow("NOT_FOUND");
       expect(mockNotFound).toHaveBeenCalled();
     });
 

--- a/apps/web/app/u/[handle]/page.tsx
+++ b/apps/web/app/u/[handle]/page.tsx
@@ -1,5 +1,6 @@
 export const revalidate = 3600;
 
+import { Suspense } from "react";
 import { after } from "next/server";
 import { getStats } from "@/lib/github/client";
 import { computeImpactV4 } from "@/lib/impact/v4";
@@ -95,6 +96,19 @@ export default async function SharePage({ params }: SharePageProps) {
     notFound();
   }
 
+  return (
+    <main id="main-content" className="min-h-screen bg-bg">
+      <Suspense fallback={<BadgeSkeleton />}>
+        <SharePageContent handle={handle} />
+      </Suspense>
+      <GlobalCommandBarLazy />
+    </main>
+  );
+}
+
+/** Data-dependent content — streams after shell via Suspense. */
+/** @internal Exported for tests — use SharePage as the page component. */
+export async function SharePageContent({ handle }: { handle: string }) {
   // ISR: No dynamic request APIs (next/headers, next/cookies) are called.
   // Session is checked client-side via SharePageOwnerContent and NavbarClient.
   // Stats fetch uses env GITHUB_TOKEN fallback (no per-user OAuth token).
@@ -194,7 +208,7 @@ export default async function SharePage({ params }: SharePageProps) {
   };
 
   return (
-    <main id="main-content" className="min-h-screen bg-bg">
+    <>
       <SharePageShortcuts
         embedMarkdown={embedMarkdown}
         handle={handle}
@@ -272,8 +286,6 @@ export default async function SharePage({ params }: SharePageProps) {
           impact={impact}
         />
       </div>
-
-      <GlobalCommandBarLazy />
-    </main>
+    </>
   );
 }

--- a/apps/web/components/ClientAnalytics.test.tsx
+++ b/apps/web/components/ClientAnalytics.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SOURCE = fs.readFileSync(
+  path.resolve(__dirname, "ClientAnalytics.tsx"),
+  "utf-8",
+);
+
+describe("ClientAnalytics", () => {
+  it("is a client component", () => {
+    expect(SOURCE).toContain('"use client"');
+  });
+
+  it("exports a named ClientAnalytics function", () => {
+    expect(SOURCE).toMatch(/export function ClientAnalytics/);
+  });
+
+  it("dynamically imports Vercel Analytics", () => {
+    expect(SOURCE).toContain("@vercel/analytics/react");
+  });
+
+  it("dynamically imports Vercel SpeedInsights", () => {
+    expect(SOURCE).toContain("@vercel/speed-insights/next");
+  });
+
+  it("disables SSR for analytics components", () => {
+    expect(SOURCE).toContain("ssr: false");
+  });
+
+  it("renders both Analytics and SpeedInsights components", () => {
+    expect(SOURCE).toContain("<Analytics />");
+    expect(SOURCE).toContain("<SpeedInsights />");
+  });
+});

--- a/apps/web/components/UserMenu.render.test.tsx
+++ b/apps/web/components/UserMenu.render.test.tsx
@@ -22,8 +22,6 @@ vi.mock("next/link", () => ({
 
 vi.mock("@/lib/feature-flags", () => ({
   isStudioEnabledSync: vi.fn(() => false),
-  isBitbucketEnabledSync: vi.fn(() => false),
-  isCodebergEnabledSync: vi.fn(() => false),
   isInsightsEnabledSync: vi.fn(() => false),
 }));
 
@@ -151,11 +149,9 @@ describe("UserMenu — all buttons have explicit type attribute", () => {
   it("every <button> in the component has type='button' or type='submit'", async () => {
     dropdownOpen = true;
 
-    // Enable all conditional sections so every button renders
+    // Enable conditional sections so every button renders
     const featureFlags = await import("@/lib/feature-flags");
     vi.mocked(featureFlags.isInsightsEnabledSync).mockReturnValue(true);
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(true);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(true);
 
     clearPlatformStatusCache();
     vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
@@ -191,8 +187,6 @@ describe("UserMenu — all buttons have explicit type attribute", () => {
 
     // Reset feature flag mocks to prevent leaking into subsequent tests
     vi.mocked(featureFlags.isInsightsEnabledSync).mockReturnValue(false);
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(false);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(false);
   });
 });
 
@@ -203,10 +197,6 @@ describe("UserMenu — platform status caching", () => {
 
   beforeEach(async () => {
     clearPlatformStatusCache();
-
-    const featureFlags = await import("@/lib/feature-flags");
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(true);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(true);
 
     fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
       const urlStr = typeof url === "string" ? url : url.toString();
@@ -617,8 +607,6 @@ describe("UserMenu — Bitbucket link/unlink in dropdown", () => {
   beforeEach(async () => {
     dropdownOpen = true;
     clearPlatformStatusCache();
-    const featureFlags = await import("@/lib/feature-flags");
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -838,8 +826,6 @@ describe("UserMenu — Codeberg link/unlink in dropdown", () => {
   beforeEach(async () => {
     dropdownOpen = true;
     clearPlatformStatusCache();
-    const featureFlags = await import("@/lib/feature-flags");
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(true);
   });
 
   afterEach(() => {

--- a/apps/web/components/UserMenu.test.tsx
+++ b/apps/web/components/UserMenu.test.tsx
@@ -25,10 +25,11 @@ vi.mock("next/link", () => ({
 
 vi.mock("@/lib/feature-flags", () => ({
   isStudioEnabledSync: vi.fn(() => false),
-  isBitbucketEnabledSync: vi.fn(() => false),
-  isCodebergEnabledSync: vi.fn(() => false),
   isInsightsEnabledSync: vi.fn(() => false),
 }));
+
+// Static import gets the mocked module (vi.mock is hoisted)
+import * as featureFlags from "@/lib/feature-flags";
 
 let dropdownOpen = false;
 const setIsOpenMock = vi.fn((updater: boolean | ((prev: boolean) => boolean)) => {
@@ -151,8 +152,8 @@ describe("UserMenu — admin link", () => {
 
 describe("UserMenu — Bitbucket integration", () => {
   it("fetches Bitbucket status on mount (server decides if enabled)", () => {
-    expect(SOURCE).toContain("/api/auth/bitbucket/status");
-    expect(SOURCE).toContain("useEffect");
+    expect(SOURCE).toContain("/api/auth/${platform}/status");
+    expect(SOURCE).toContain("fetchPlatformStatus");
   });
 
   it("renders Link Bitbucket item when status is loaded", () => {
@@ -205,8 +206,8 @@ describe("UserMenu — Bitbucket integration", () => {
 
 describe("UserMenu — Codeberg integration", () => {
   it("fetches Codeberg status on mount (server decides if enabled)", () => {
-    expect(SOURCE).toContain("/api/auth/codeberg/status");
-    expect(SOURCE).toContain("useEffect");
+    expect(SOURCE).toContain("fetchPlatformStatus");
+    expect(SOURCE).toContain('"codeberg"');
   });
 
   it("renders Link Codeberg item when status is loaded", () => {
@@ -458,10 +459,6 @@ describe("UserMenu — Bitbucket disconnect handler (runtime)", () => {
     dropdownOpen = true;
     clearPlatformStatusCache();
 
-    const featureFlags = await import("@/lib/feature-flags");
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(true);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(false);
-
     fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
       const urlStr = typeof url === "string" ? url : url.toString();
       if (urlStr.includes("/api/auth/bitbucket/status")) {
@@ -515,10 +512,6 @@ describe("UserMenu — Codeberg disconnect handler (runtime)", () => {
     dropdownOpen = true;
     clearPlatformStatusCache();
 
-    const featureFlags = await import("@/lib/feature-flags");
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(false);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(true);
-
     fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
       const urlStr = typeof url === "string" ? url : url.toString();
       if (urlStr.includes("/api/auth/codeberg/status")) {
@@ -566,10 +559,6 @@ describe("UserMenu — status fetch on mount (runtime)", () => {
   beforeEach(async () => {
     clearPlatformStatusCache();
 
-    const featureFlags = await import("@/lib/feature-flags");
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(true);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(true);
-
     fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
       const urlStr = typeof url === "string" ? url : url.toString();
       if (urlStr.includes("/api/auth/bitbucket/status")) {
@@ -607,10 +596,6 @@ describe("UserMenu — status fetch error handling (runtime)", () => {
   beforeEach(async () => {
     clearPlatformStatusCache();
 
-    const featureFlags = await import("@/lib/feature-flags");
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(true);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(true);
-
     fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(() => {
       return Promise.reject(new Error("Network error"));
     });
@@ -639,10 +624,6 @@ describe("UserMenu — cache invalidation after unlink (runtime)", () => {
   beforeEach(async () => {
     dropdownOpen = true;
     clearPlatformStatusCache();
-
-    const featureFlags = await import("@/lib/feature-flags");
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(true);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(false);
 
     fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
       const urlStr = typeof url === "string" ? url : url.toString();
@@ -700,10 +681,6 @@ describe("UserMenu — loading state during unlink (runtime)", () => {
   beforeEach(async () => {
     dropdownOpen = true;
     clearPlatformStatusCache();
-
-    const featureFlags = await import("@/lib/feature-flags");
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(true);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(false);
 
     fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
       const urlStr = typeof url === "string" ? url : url.toString();
@@ -771,10 +748,6 @@ describe("UserMenu — Codeberg disconnect callback details (runtime)", () => {
     dropdownOpen = true;
     clearPlatformStatusCache();
 
-    const featureFlags = await import("@/lib/feature-flags");
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(false);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(true);
-
     fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
       const urlStr = typeof url === "string" ? url : url.toString();
       if (urlStr.includes("/api/auth/codeberg/status")) {
@@ -829,10 +802,6 @@ describe("UserMenu — Codeberg disconnect loading state (runtime)", () => {
   beforeEach(async () => {
     dropdownOpen = true;
     clearPlatformStatusCache();
-
-    const featureFlags = await import("@/lib/feature-flags");
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(false);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(true);
 
     fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
       const urlStr = typeof url === "string" ? url : url.toString();
@@ -892,10 +861,6 @@ describe("UserMenu — Codeberg disconnect failure (runtime)", () => {
     dropdownOpen = true;
     clearPlatformStatusCache();
 
-    const featureFlags = await import("@/lib/feature-flags");
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(false);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(true);
-
     fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
       const urlStr = typeof url === "string" ? url : url.toString();
       if (urlStr.includes("/api/auth/codeberg/status")) {
@@ -948,10 +913,6 @@ describe("UserMenu — Bitbucket disconnect failure (runtime)", () => {
   beforeEach(async () => {
     dropdownOpen = true;
     clearPlatformStatusCache();
-
-    const featureFlags = await import("@/lib/feature-flags");
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(true);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(false);
 
     fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
       const urlStr = typeof url === "string" ? url : url.toString();
@@ -1010,10 +971,6 @@ describe("UserMenu — Bitbucket not-linked state (runtime)", () => {
     dropdownOpen = true;
     clearPlatformStatusCache();
 
-    const featureFlags = await import("@/lib/feature-flags");
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(true);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(false);
-
     fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
       const urlStr = typeof url === "string" ? url : url.toString();
       if (urlStr.includes("/api/auth/bitbucket/status")) {
@@ -1048,10 +1005,6 @@ describe("UserMenu — Codeberg not-linked state (runtime)", () => {
   beforeEach(async () => {
     dropdownOpen = true;
     clearPlatformStatusCache();
-
-    const featureFlags = await import("@/lib/feature-flags");
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(false);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(true);
 
     fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
       const urlStr = typeof url === "string" ? url : url.toString();
@@ -1092,10 +1045,6 @@ describe("UserMenu — Bitbucket linked state display (runtime)", () => {
     dropdownOpen = true;
     clearPlatformStatusCache();
 
-    const featureFlags = await import("@/lib/feature-flags");
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(true);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(false);
-
     fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
       const urlStr = typeof url === "string" ? url : url.toString();
       if (urlStr.includes("/api/auth/bitbucket/status")) {
@@ -1132,10 +1081,6 @@ describe("UserMenu — Codeberg linked state display (runtime)", () => {
   beforeEach(async () => {
     dropdownOpen = true;
     clearPlatformStatusCache();
-
-    const featureFlags = await import("@/lib/feature-flags");
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(false);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(true);
 
     fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
       const urlStr = typeof url === "string" ? url : url.toString();
@@ -1177,10 +1122,6 @@ describe("UserMenu — cancel Bitbucket unlink confirm (runtime)", () => {
   beforeEach(async () => {
     dropdownOpen = true;
     clearPlatformStatusCache();
-
-    const featureFlags = await import("@/lib/feature-flags");
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(true);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(false);
 
     fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
       const urlStr = typeof url === "string" ? url : url.toString();
@@ -1236,10 +1177,6 @@ describe("UserMenu — cancel Codeberg unlink confirm (runtime)", () => {
     dropdownOpen = true;
     clearPlatformStatusCache();
 
-    const featureFlags = await import("@/lib/feature-flags");
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(false);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(true);
-
     fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
       const urlStr = typeof url === "string" ? url : url.toString();
       if (urlStr.includes("/api/auth/codeberg/status")) {
@@ -1291,11 +1228,7 @@ describe("UserMenu — Studio menu item when enabled (runtime)", () => {
   beforeEach(async () => {
     dropdownOpen = true;
     clearPlatformStatusCache();
-
-    const featureFlags = await import("@/lib/feature-flags");
     vi.mocked(featureFlags.isStudioEnabledSync).mockReturnValue(true);
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(false);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(false);
     vi.mocked(featureFlags.isInsightsEnabledSync).mockReturnValue(false);
   });
 
@@ -1312,11 +1245,7 @@ describe("UserMenu — Studio hidden when disabled (runtime)", () => {
   beforeEach(async () => {
     dropdownOpen = true;
     clearPlatformStatusCache();
-
-    const featureFlags = await import("@/lib/feature-flags");
     vi.mocked(featureFlags.isStudioEnabledSync).mockReturnValue(false);
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(false);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(false);
     vi.mocked(featureFlags.isInsightsEnabledSync).mockReturnValue(false);
   });
 
@@ -1331,11 +1260,7 @@ describe("UserMenu — Admin Panel link (runtime)", () => {
   beforeEach(async () => {
     dropdownOpen = true;
     clearPlatformStatusCache();
-
-    const featureFlags = await import("@/lib/feature-flags");
     vi.mocked(featureFlags.isStudioEnabledSync).mockReturnValue(false);
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(false);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(false);
     vi.mocked(featureFlags.isInsightsEnabledSync).mockReturnValue(false);
   });
 
@@ -1358,11 +1283,7 @@ describe("UserMenu — Insights menu item (runtime)", () => {
   beforeEach(async () => {
     dropdownOpen = true;
     clearPlatformStatusCache();
-
-    const featureFlags = await import("@/lib/feature-flags");
     vi.mocked(featureFlags.isStudioEnabledSync).mockReturnValue(false);
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(false);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(false);
     vi.mocked(featureFlags.isInsightsEnabledSync).mockReturnValue(true);
   });
 
@@ -1373,7 +1294,7 @@ describe("UserMenu — Insights menu item (runtime)", () => {
   });
 
   it("does not render Import Claude Code Insights when insights flag is disabled", async () => {
-    const featureFlags = await import("@/lib/feature-flags");
+
     vi.mocked(featureFlags.isInsightsEnabledSync).mockReturnValue(false);
 
     render(<UserMenu {...baseProps} />);
@@ -1393,11 +1314,7 @@ describe("UserMenu — insights file upload flow (runtime)", () => {
   beforeEach(async () => {
     dropdownOpen = true;
     clearPlatformStatusCache();
-
-    const featureFlags = await import("@/lib/feature-flags");
     vi.mocked(featureFlags.isStudioEnabledSync).mockReturnValue(false);
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(false);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(false);
     vi.mocked(featureFlags.isInsightsEnabledSync).mockReturnValue(true);
 
     fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
@@ -1548,9 +1465,6 @@ describe("UserMenu — avatar image error fallback (runtime)", () => {
     dropdownOpen = false;
     clearPlatformStatusCache();
 
-    const featureFlags = await import("@/lib/feature-flags");
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(false);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(false);
   });
 
   it("shows fallback letter when image fails to load", () => {
@@ -1573,10 +1487,6 @@ describe("UserMenu — platform status cache (runtime)", () => {
 
   beforeEach(async () => {
     clearPlatformStatusCache();
-
-    const featureFlags = await import("@/lib/feature-flags");
-    vi.mocked(featureFlags.isBitbucketEnabledSync).mockReturnValue(true);
-    vi.mocked(featureFlags.isCodebergEnabledSync).mockReturnValue(false);
 
     fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((url) => {
       const urlStr = typeof url === "string" ? url : url.toString();

--- a/apps/web/components/UserMenu.test.tsx
+++ b/apps/web/components/UserMenu.test.tsx
@@ -150,18 +150,13 @@ describe("UserMenu — admin link", () => {
 });
 
 describe("UserMenu — Bitbucket integration", () => {
-  it("imports isBitbucketEnabledSync from feature-flags", () => {
-    expect(SOURCE).toContain("isBitbucketEnabledSync");
-    expect(SOURCE).toContain("@/lib/feature-flags");
-  });
-
-  it("fetches Bitbucket status on mount when feature enabled", () => {
+  it("fetches Bitbucket status on mount (server decides if enabled)", () => {
     expect(SOURCE).toContain("/api/auth/bitbucket/status");
     expect(SOURCE).toContain("useEffect");
   });
 
-  it("renders Link Bitbucket item conditionally on feature flag", () => {
-    expect(SOURCE).toContain("isBitbucketEnabledSync()");
+  it("renders Link Bitbucket item when status is loaded", () => {
+    expect(SOURCE).toContain("bbStatus");
     expect(SOURCE).toContain("Link Bitbucket");
     expect(SOURCE).toContain('href="/api/auth/bitbucket/connect"');
   });
@@ -209,18 +204,13 @@ describe("UserMenu — Bitbucket integration", () => {
 });
 
 describe("UserMenu — Codeberg integration", () => {
-  it("imports isCodebergEnabledSync from feature-flags", () => {
-    expect(SOURCE).toContain("isCodebergEnabledSync");
-    expect(SOURCE).toContain("@/lib/feature-flags");
-  });
-
-  it("fetches Codeberg status on mount when feature enabled", () => {
+  it("fetches Codeberg status on mount (server decides if enabled)", () => {
     expect(SOURCE).toContain("/api/auth/codeberg/status");
-    expect(SOURCE).toContain("isCodebergEnabledSync()");
+    expect(SOURCE).toContain("useEffect");
   });
 
-  it("renders Link Codeberg item conditionally on feature flag", () => {
-    expect(SOURCE).toContain("isCodebergEnabledSync()");
+  it("renders Link Codeberg item when status is loaded", () => {
+    expect(SOURCE).toContain("cbStatus");
     expect(SOURCE).toContain("Link Codeberg");
     expect(SOURCE).toContain('href="/api/auth/codeberg/connect"');
   });

--- a/apps/web/components/UserMenu.tsx
+++ b/apps/web/components/UserMenu.tsx
@@ -132,28 +132,25 @@ export function UserMenu({ login, name, avatarUrl, isAdmin }: UserMenuProps) {
       if (platformStatusCache.codeberg) setCbStatus(platformStatusCache.codeberg);
       return;
     }
-    // Always check platform status — server returns { enabled: false } if flag
-    // is off, so the client doesn't need sync flag checks. Fixes #632.
-    fetch("/api/auth/bitbucket/status")
-      .then((r) => r.json())
-      .then((data) => {
-        if (data.enabled) {
-          const status = { linked: data.linked, remoteLogin: data.remoteLogin };
-          platformStatusCache.bitbucket = status;
-          setBbStatus(status);
-        }
-      })
-      .catch(() => {}); // Graceful — menu works without status
-    fetch("/api/auth/codeberg/status")
-      .then((r) => r.json())
-      .then((data) => {
-        if (data.enabled) {
-          const status = { linked: data.linked, remoteLogin: data.remoteLogin };
-          platformStatusCache.codeberg = status;
-          setCbStatus(status);
-        }
-      })
-      .catch(() => {}); // Graceful
+    // Server returns { enabled: false } if flag is off — no client-side
+    // sync flag checks needed. Fixes #632.
+    function fetchPlatformStatus(
+      platform: "bitbucket" | "codeberg",
+      setter: typeof setBbStatus,
+    ) {
+      fetch(`/api/auth/${platform}/status`)
+        .then((r) => r.json())
+        .then((data) => {
+          if (data.enabled) {
+            const status = { linked: data.linked, remoteLogin: data.remoteLogin };
+            platformStatusCache[platform] = status;
+            setter(status);
+          }
+        })
+        .catch(() => {}); // Graceful — menu works without status
+    }
+    fetchPlatformStatus("bitbucket", setBbStatus);
+    fetchPlatformStatus("codeberg", setCbStatus);
     platformStatusCache.fetched = true;
   }, []);
 

--- a/apps/web/components/UserMenu.tsx
+++ b/apps/web/components/UserMenu.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
-import { isStudioEnabledSync, isBitbucketEnabledSync, isCodebergEnabledSync, isInsightsEnabledSync } from "@/lib/feature-flags";
+import { isStudioEnabledSync, isInsightsEnabledSync } from "@/lib/feature-flags";
 import { useDropdownMenu } from "@/hooks/useDropdownMenu";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { Toast } from "./Toast";
@@ -132,30 +132,28 @@ export function UserMenu({ login, name, avatarUrl, isAdmin }: UserMenuProps) {
       if (platformStatusCache.codeberg) setCbStatus(platformStatusCache.codeberg);
       return;
     }
-    if (isBitbucketEnabledSync()) {
-      fetch("/api/auth/bitbucket/status")
-        .then((r) => r.json())
-        .then((data) => {
-          if (data.enabled) {
-            const status = { linked: data.linked, remoteLogin: data.remoteLogin };
-            platformStatusCache.bitbucket = status;
-            setBbStatus(status);
-          }
-        })
-        .catch(() => {}); // Graceful — menu works without status
-    }
-    if (isCodebergEnabledSync()) {
-      fetch("/api/auth/codeberg/status")
-        .then((r) => r.json())
-        .then((data) => {
-          if (data.enabled) {
-            const status = { linked: data.linked, remoteLogin: data.remoteLogin };
-            platformStatusCache.codeberg = status;
-            setCbStatus(status);
-          }
-        })
-        .catch(() => {}); // Graceful
-    }
+    // Always check platform status — server returns { enabled: false } if flag
+    // is off, so the client doesn't need sync flag checks. Fixes #632.
+    fetch("/api/auth/bitbucket/status")
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.enabled) {
+          const status = { linked: data.linked, remoteLogin: data.remoteLogin };
+          platformStatusCache.bitbucket = status;
+          setBbStatus(status);
+        }
+      })
+      .catch(() => {}); // Graceful — menu works without status
+    fetch("/api/auth/codeberg/status")
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.enabled) {
+          const status = { linked: data.linked, remoteLogin: data.remoteLogin };
+          platformStatusCache.codeberg = status;
+          setCbStatus(status);
+        }
+      })
+      .catch(() => {}); // Graceful
     platformStatusCache.fetched = true;
   }, []);
 
@@ -344,7 +342,7 @@ export function UserMenu({ login, name, avatarUrl, isAdmin }: UserMenuProps) {
                 />
               </button>
             )}
-            {isBitbucketEnabledSync() && bbStatus && (
+            {bbStatus && (
               bbStatus.linked ? (
                 <div className="flex items-center justify-between rounded-xl px-3 py-2.5">
                   <a
@@ -379,7 +377,7 @@ export function UserMenu({ login, name, avatarUrl, isAdmin }: UserMenuProps) {
                 </a>
               )
             )}
-            {isCodebergEnabledSync() && cbStatus && (
+            {cbStatus && (
               cbStatus.linked ? (
                 <div className="flex items-center justify-between rounded-xl px-3 py-2.5">
                   <a

--- a/apps/web/e2e/integration.spec.ts
+++ b/apps/web/e2e/integration.spec.ts
@@ -228,22 +228,23 @@ test.describe("Integration — Health endpoint (/api/health)", () => {
     expect(body.dependencies).toHaveProperty("redis");
     expect(body.dependencies).toHaveProperty("supabase");
 
-    // Each dependency reports "ok", "error", or "unavailable" (when not configured)
-    expect(["ok", "error", "unavailable"]).toContain(body.dependencies.redis);
-    expect(["ok", "error", "unavailable"]).toContain(body.dependencies.supabase);
+    // Each dependency reports "ok", "error", "unavailable", or "skipped" (env vars not configured)
+    expect(["ok", "error", "unavailable", "skipped"]).toContain(body.dependencies.redis);
+    expect(["ok", "error", "unavailable", "skipped"]).toContain(body.dependencies.supabase);
   });
 
   test("status is 'ok' only when all dependencies are healthy", async ({ request }) => {
     const response = await request.get("/api/health");
     const body = await response.json();
 
-    // Per the route handler: status is "ok" only if both deps are "ok"
+    // Per the route handler: status is "ok" when both deps are healthy ("ok" or "skipped")
+    const isHealthy = (s: string) => s === "ok" || s === "skipped";
     if (body.status === "ok") {
-      expect(body.dependencies.redis).toBe("ok");
-      expect(body.dependencies.supabase).toBe("ok");
+      expect(isHealthy(body.dependencies.redis)).toBe(true);
+      expect(isHealthy(body.dependencies.supabase)).toBe(true);
     }
-    // Any non-"ok" dependency means degraded
-    if (body.dependencies.redis !== "ok" || body.dependencies.supabase !== "ok") {
+    // Any non-healthy dependency means degraded
+    if (!isHealthy(body.dependencies.redis) || !isHealthy(body.dependencies.supabase)) {
       expect(body.status).toBe("degraded");
     }
   });

--- a/apps/web/lib/auth/cron.test.ts
+++ b/apps/web/lib/auth/cron.test.ts
@@ -17,6 +17,17 @@ describe("verifyCronSecret", () => {
     expect(result).toBeNull();
   });
 
+  it("logs a warning when CRON_SECRET is not set", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { verifyCronSecret } = await import("@/lib/auth/cron");
+    const req = new NextRequest("https://example.com/api/cron/test");
+    verifyCronSecret(req);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[cron] CRON_SECRET not configured — cron endpoints are unprotected"
+    );
+    warnSpy.mockRestore();
+  });
+
   it("returns 401 when Authorization header is missing", async () => {
     process.env.CRON_SECRET = "test-secret";
     const { verifyCronSecret } = await import("@/lib/auth/cron");

--- a/apps/web/lib/auth/cron.ts
+++ b/apps/web/lib/auth/cron.ts
@@ -20,6 +20,9 @@ import { safeEqual } from "@/lib/crypto/safe-equal";
 export function verifyCronSecret(request: Request): NextResponse | null {
   const secret = process.env.CRON_SECRET?.trim();
   if (!secret) {
+    console.warn(
+      "[cron] CRON_SECRET not configured — cron endpoints are unprotected"
+    );
     return null;
   }
 

--- a/apps/web/lib/cache/redis.coverage.test.ts
+++ b/apps/web/lib/cache/redis.coverage.test.ts
@@ -19,7 +19,7 @@ const mockExpire = vi.fn();
 const mockPfadd = vi.fn();
 const mockPfcount = vi.fn();
 const mockMget = vi.fn();
-const mockPing = vi.fn();
+const mockDbsize = vi.fn();
 
 vi.mock("@upstash/redis", () => ({
   Redis: class MockRedis {
@@ -32,7 +32,7 @@ vi.mock("@upstash/redis", () => ({
     pfadd = mockPfadd;
     pfcount = mockPfcount;
     mget = mockMget;
-    ping = mockPing;
+    dbsize = mockDbsize;
   },
 }));
 
@@ -60,32 +60,32 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("pingRedis", () => {
-  it("returns 'ok' when Redis responds to PING", async () => {
-    mockPing.mockResolvedValueOnce("PONG");
+  it("returns 'ok' when Redis responds to DBSIZE", async () => {
+    mockDbsize.mockResolvedValueOnce(42);
 
     const result = await pingRedis();
 
     expect(result).toBe("ok");
-    expect(mockPing).toHaveBeenCalled();
+    expect(mockDbsize).toHaveBeenCalled();
   });
 
-  it("returns 'error' when Redis PING fails", async () => {
-    mockPing.mockRejectedValueOnce(new Error("Connection refused"));
+  it("returns 'error' when Redis DBSIZE fails", async () => {
+    mockDbsize.mockRejectedValueOnce(new Error("Connection refused"));
 
     const result = await pingRedis();
 
     expect(result).toBe("error");
   });
 
-  it("returns 'unavailable' when Redis client is null (no env vars)", async () => {
+  it("returns 'skipped' when Redis client is null (no env vars)", async () => {
     _resetClient();
     vi.stubEnv("UPSTASH_REDIS_REST_URL", "");
     vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "");
 
     const result = await pingRedis();
 
-    expect(result).toBe("unavailable");
-    expect(mockPing).not.toHaveBeenCalled();
+    expect(result).toBe("skipped");
+    expect(mockDbsize).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/lib/cache/redis.ts
+++ b/apps/web/lib/cache/redis.ts
@@ -247,18 +247,20 @@ export async function getBadgeStats(): Promise<BadgeStats> {
 // ---------------------------------------------------------------------------
 
 /**
- * Ping Redis and return a health status string.
- * - "ok" — Redis responded to PING.
- * - "error" — Redis client exists but PING failed.
- * - "unavailable" — Redis client is null (missing env vars).
+ * Check Redis health via a lightweight data-access operation.
+ * Uses `dbsize()` instead of `ping()` to verify actual data access,
+ * not just connectivity (satisfies CLAUDE.md health-check requirement).
+ * - "ok" — Redis responded to DBSIZE.
+ * - "error" — Redis client exists but DBSIZE failed.
+ * - "skipped" — Redis client is null (missing env vars).
  */
-export async function pingRedis(): Promise<"ok" | "error" | "unavailable"> {
+export async function pingRedis(): Promise<"ok" | "error" | "skipped"> {
   const redis = getRedis();
-  if (!redis) return "unavailable";
+  if (!redis) return "skipped";
 
   try {
     await Promise.race([
-      redis.ping(),
+      redis.dbsize(),
       new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error("ping timeout")), 5000),
       ),

--- a/apps/web/lib/db/supabase.test.ts
+++ b/apps/web/lib/db/supabase.test.ts
@@ -110,12 +110,12 @@ describe("pingSupabase", () => {
     expect(result).toBe("ok");
   });
 
-  it("returns 'unavailable' when env vars are missing", async () => {
+  it("returns 'skipped' when env vars are missing", async () => {
     vi.stubEnv("SUPABASE_URL", "");
     vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "");
 
     const result = await pingSupabase();
-    expect(result).toBe("unavailable");
+    expect(result).toBe("skipped");
   });
 
   it("returns 'error' when query fails", async () => {

--- a/apps/web/lib/db/supabase.ts
+++ b/apps/web/lib/db/supabase.ts
@@ -32,12 +32,12 @@ export function getSupabase(): SupabaseClient | null {
 
 /**
  * Lightweight health check — same pattern as pingRedis().
- * Returns "ok" if a trivial query succeeds, "unavailable" if env vars are
- * missing, or "error" if the query fails.
+ * Returns "ok" if a trivial query succeeds, "skipped" if env vars are
+ * not configured, or "error" if the query fails.
  */
-export async function pingSupabase(): Promise<"ok" | "error" | "unavailable"> {
+export async function pingSupabase(): Promise<"ok" | "error" | "skipped"> {
   const db = getSupabase();
-  if (!db) return "unavailable";
+  if (!db) return "skipped";
 
   try {
     const result = await Promise.race([

--- a/apps/web/lib/github/client.test.ts
+++ b/apps/web/lib/github/client.test.ts
@@ -853,6 +853,43 @@ describe("getStats", () => {
       expect(result).toEqual(cached);
     });
 
+    it("includes Bitbucket in linkedPlatforms when linked in DB but stats fetch returns null (fixes #632)", async () => {
+      const github = makeStats({ commitsTotal: 50 });
+
+      mockCacheGet
+        .mockResolvedValueOnce(null) // merged
+        .mockResolvedValueOnce(null) // stale
+        .mockResolvedValueOnce(null) // bitbucket cache
+        .mockResolvedValueOnce(null) // codeberg cache
+        .mockResolvedValueOnce(null); // supplemental
+      mockFetchStatsData.mockResolvedValue(github);
+      mockIsBitbucketEnabled.mockResolvedValue(true);
+      mockIsCodebergEnabled.mockResolvedValue(false);
+      mockDbGetLinkedPlatform.mockImplementation(
+        (_handle: string, platform: string) => {
+          if (platform === "bitbucket") {
+            return Promise.resolve({
+              remoteLogin: "bb-user",
+              tokens: {
+                accessToken: "bb-token",
+                refreshToken: "bb-refresh",
+                expiresAt: new Date("2027-12-31"),
+              },
+            });
+          }
+          return Promise.resolve(null);
+        },
+      );
+      mockIsTokenExpired.mockReturnValue(false);
+      mockFetchBitbucketStats.mockResolvedValue(null); // API returns null
+
+      const result = await getStats("test-user");
+
+      expect(result!.commitsTotal).toBe(50); // GitHub-only (no BB stats to merge)
+      expect(result!.linkedPlatforms).toEqual(["bitbucket"]);
+      expect(result!.linkedPlatformLogins).toEqual({ bitbucket: "bb-user" });
+    });
+
     it("caches Bitbucket stats separately", async () => {
       const github = makeStats({ commitsTotal: 50 });
       const bb = makeStats({ commitsTotal: 30 });
@@ -1161,6 +1198,36 @@ describe("getStats", () => {
       expect(result!.linkedPlatforms).toEqual(["codeberg"]);
     });
 
+    it("includes Codeberg in linkedPlatforms when linked in DB but stats fetch returns null (fixes #632)", async () => {
+      const github = makeStats({ commitsTotal: 50 });
+
+      mockCacheGet
+        .mockResolvedValueOnce(null) // merged
+        .mockResolvedValueOnce(null) // stale
+        .mockResolvedValueOnce(null) // bitbucket cache
+        .mockResolvedValueOnce(null) // codeberg cache
+        .mockResolvedValueOnce(null); // supplemental
+      mockFetchStatsData.mockResolvedValue(github);
+      mockIsBitbucketEnabled.mockResolvedValue(false);
+      mockIsCodebergEnabled.mockResolvedValue(true);
+      mockDbGetLinkedPlatform.mockResolvedValue({
+        remoteLogin: "cb-user",
+        tokens: {
+          accessToken: "cb-token",
+          refreshToken: null,
+          expiresAt: null,
+        },
+      });
+      mockIsTokenExpired.mockReturnValue(true);
+      mockFetchCodebergStats.mockResolvedValue(null); // fetch failed
+
+      const result = await getStats("test-user");
+
+      expect(result!.commitsTotal).toBe(50); // GitHub-only
+      expect(result!.linkedPlatforms).toEqual(["codeberg"]);
+      expect(result!.linkedPlatformLogins).toEqual({ codeberg: "cb-user" });
+    });
+
     it("sets linkedPlatforms to ['bitbucket', 'codeberg'] when both linked", async () => {
       const github = makeStats({ commitsTotal: 50 });
       const bb = makeStats({ commitsTotal: 20 });
@@ -1344,9 +1411,10 @@ describe("getStats", () => {
       const result = await getStats("test-user");
 
       // Should still return GitHub + Codeberg stats (BB error is swallowed)
+      // BB is still in linkedPlatforms because it's linked in DB (#632)
       expect(result).not.toBeNull();
       expect(result!.commitsTotal).toBe(65); // 50 + 15
-      expect(result!.linkedPlatforms).toEqual(["codeberg"]);
+      expect(result!.linkedPlatforms).toEqual(["bitbucket", "codeberg"]);
     });
 
     it("Codeberg error does not block Bitbucket fetch", async () => {
@@ -1398,9 +1466,10 @@ describe("getStats", () => {
       const result = await getStats("test-user");
 
       // Should still return GitHub + Bitbucket stats (CB error is swallowed)
+      // CB is still in linkedPlatforms because it's linked in DB (#632)
       expect(result).not.toBeNull();
       expect(result!.commitsTotal).toBe(70); // 50 + 20
-      expect(result!.linkedPlatforms).toEqual(["bitbucket"]);
+      expect(result!.linkedPlatforms).toEqual(["bitbucket", "codeberg"]);
     });
 
     it("handles Codeberg fetch failure gracefully (returns GitHub-only)", async () => {
@@ -1429,7 +1498,8 @@ describe("getStats", () => {
       const result = await getStats("test-user");
 
       expect(result!.commitsTotal).toBe(50); // GitHub-only
-      expect(result!.linkedPlatforms).toBeUndefined();
+      // Codeberg still appears in linkedPlatforms because it's linked in DB (#632)
+      expect(result!.linkedPlatforms).toEqual(["codeberg"]);
     });
 
     it("caches Codeberg stats separately", async () => {

--- a/apps/web/lib/github/client.ts
+++ b/apps/web/lib/github/client.ts
@@ -138,15 +138,35 @@ async function _fetchAndCache(
     stats = mergeStats(stats, supplemental.stats);
   }
 
-  // Set linkedPlatforms after all merges (so it survives EMU merge)
+  // Build linkedPlatforms from DB link status (source of truth), not stats fetch
+  // success. This ensures platforms appear in Data Sources and badge footer even
+  // when their stats fetch temporarily fails (expired token, API error). Fixes #632.
   const linkedPlatforms: Platform[] = [];
-  if (bbStats) linkedPlatforms.push("bitbucket");
-  if (cbStats) linkedPlatforms.push("codeberg");
+  let bbDbLink: Awaited<ReturnType<typeof dbGetLinkedPlatform>> = null;
+  let cbDbLink: Awaited<ReturnType<typeof dbGetLinkedPlatform>> = null;
+
+  if (bbStats) {
+    linkedPlatforms.push("bitbucket");
+  } else if (await isBitbucketEnabled()) {
+    bbDbLink = await dbGetLinkedPlatform(handle, "bitbucket");
+    if (bbDbLink) linkedPlatforms.push("bitbucket");
+  }
+  if (cbStats) {
+    linkedPlatforms.push("codeberg");
+  } else if (await isCodebergEnabled()) {
+    cbDbLink = await dbGetLinkedPlatform(handle, "codeberg");
+    if (cbDbLink) linkedPlatforms.push("codeberg");
+  }
+
   if (linkedPlatforms.length > 0) {
-    // Also fetch remote usernames for profile URLs (parallel DB queries)
+    // Fetch remote usernames for profile URLs (reuse DB results when available)
     const [bbLinked, cbLinked] = await Promise.all([
-      bbStats ? dbGetLinkedPlatform(handle, "bitbucket") : null,
-      cbStats ? dbGetLinkedPlatform(handle, "codeberg") : null,
+      linkedPlatforms.includes("bitbucket")
+        ? (bbDbLink ?? dbGetLinkedPlatform(handle, "bitbucket"))
+        : null,
+      linkedPlatforms.includes("codeberg")
+        ? (cbDbLink ?? dbGetLinkedPlatform(handle, "codeberg"))
+        : null,
     ]);
     const linkedPlatformLogins: Record<string, string> = {};
     if (bbLinked) linkedPlatformLogins.bitbucket = bbLinked.remoteLogin;

--- a/apps/web/lib/github/client.ts
+++ b/apps/web/lib/github/client.ts
@@ -139,38 +139,30 @@ async function _fetchAndCache(
   }
 
   // Build linkedPlatforms from DB link status (source of truth), not stats fetch
-  // success. This ensures platforms appear in Data Sources and badge footer even
-  // when their stats fetch temporarily fails (expired token, API error). Fixes #632.
-  const linkedPlatforms: Platform[] = [];
-  let bbDbLink: Awaited<ReturnType<typeof dbGetLinkedPlatform>> = null;
-  let cbDbLink: Awaited<ReturnType<typeof dbGetLinkedPlatform>> = null;
+  // success. Platforms appear in Data Sources even when their stats fetch
+  // temporarily fails (expired token, API error). Fixes #632.
+  const [bbDbLink, cbDbLink] = await Promise.all([
+    bbStats ? null : isBitbucketEnabled().then((ok) =>
+      ok ? dbGetLinkedPlatform(handle, "bitbucket") : null,
+    ),
+    cbStats ? null : isCodebergEnabled().then((ok) =>
+      ok ? dbGetLinkedPlatform(handle, "codeberg") : null,
+    ),
+  ]);
 
-  if (bbStats) {
-    linkedPlatforms.push("bitbucket");
-  } else if (await isBitbucketEnabled()) {
-    bbDbLink = await dbGetLinkedPlatform(handle, "bitbucket");
-    if (bbDbLink) linkedPlatforms.push("bitbucket");
-  }
-  if (cbStats) {
-    linkedPlatforms.push("codeberg");
-  } else if (await isCodebergEnabled()) {
-    cbDbLink = await dbGetLinkedPlatform(handle, "codeberg");
-    if (cbDbLink) linkedPlatforms.push("codeberg");
-  }
+  const linkedPlatforms: Platform[] = [];
+  if (bbStats || bbDbLink) linkedPlatforms.push("bitbucket");
+  if (cbStats || cbDbLink) linkedPlatforms.push("codeberg");
 
   if (linkedPlatforms.length > 0) {
-    // Fetch remote usernames for profile URLs (reuse DB results when available)
-    const [bbLinked, cbLinked] = await Promise.all([
-      linkedPlatforms.includes("bitbucket")
-        ? (bbDbLink ?? dbGetLinkedPlatform(handle, "bitbucket"))
-        : null,
-      linkedPlatforms.includes("codeberg")
-        ? (cbDbLink ?? dbGetLinkedPlatform(handle, "codeberg"))
-        : null,
+    // bbDbLink/cbDbLink already have remoteLogin; only re-fetch for stats-path
+    const [bbLogin, cbLogin] = await Promise.all([
+      bbDbLink ?? (bbStats ? dbGetLinkedPlatform(handle, "bitbucket") : null),
+      cbDbLink ?? (cbStats ? dbGetLinkedPlatform(handle, "codeberg") : null),
     ]);
     const linkedPlatformLogins: Record<string, string> = {};
-    if (bbLinked) linkedPlatformLogins.bitbucket = bbLinked.remoteLogin;
-    if (cbLinked) linkedPlatformLogins.codeberg = cbLinked.remoteLogin;
+    if (bbLogin) linkedPlatformLogins.bitbucket = bbLogin.remoteLogin;
+    if (cbLogin) linkedPlatformLogins.codeberg = cbLogin.remoteLogin;
 
     stats = {
       ...stats,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,29 +15,29 @@
   "dependencies": {
     "@chapa/shared": "workspace:*",
     "@resvg/resvg-js": "^2.6.2",
-    "@supabase/supabase-js": "^2.99.2",
+    "@supabase/supabase-js": "^2.100.1",
     "@upstash/redis": "^1.37.0",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "canvas-confetti": "^1.9.4",
     "next": "^16.2.1",
     "next-themes": "^0.4.6",
-    "posthog-js": "^1.362.0",
+    "posthog-js": "^1.364.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "resend": "^6.9.4",
-    "svix": "^1.88.0"
+    "svix": "^1.89.0"
   },
   "devDependencies": {
-    "@next/bundle-analyzer": "^16.2.0",
+    "@next/bundle-analyzer": "^16.2.1",
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.2.2",
     "@types/canvas-confetti": "^1.9.0",
-    "@types/node": "^25.3.0",
+    "@types/node": "^25.5.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.1.5",
     "eslint": "^9.27.0",
-    "eslint-config-next": "^16.0.0",
+    "eslint-config-next": "^16.2.1",
     "tailwindcss": "^4.2.2",
     "typescript": "^5.7.3"
   }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chapa/web",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/docs/agents/documentation-report.md
+++ b/docs/agents/documentation-report.md
@@ -1,235 +1,214 @@
 # Documentation Report
-> Generated: 2026-03-20 | Health status: **yellow**
+> Generated: 2026-03-27 | Health status: yellow
 
 ## Executive Summary
-Documentation is mostly accurate (env vars 100%, design tokens 98%, docs all present) but route coverage remains low at ~65% — 20+ routes including the entire campaigns API, platform connect/disconnect/status endpoints, OG images, and LLM endpoints are undocumented. Two HTTP method mismatches and two phantom routes need correction.
 
----
+Documentation is **well-maintained** overall (84% JSDoc coverage, 30/30 env vars documented, all 6 required docs present), but **route documentation has 6 method mismatches** and **1 undocumented API route**. Design system tokens are 98%+ accurate. Previous audit's phantom routes (`bitbucket/login`, `codeberg/login`) have been fixed. Key action: correct method signatures in CLAUDE.md and add JSDoc to 11 complex undocumented functions.
 
 ## Route Documentation
 
-### Pages
+### Pages (34 total)
 
-| Route | Documented in CLAUDE.md | Actually Exists | Status |
-|-------|:-----------------------:|:---------------:|--------|
-| GET `/` | ✓ | ✓ | OK |
-| GET `/studio` | ✓ | ✓ | OK |
-| GET `/admin` | ✓ | ✓ | OK |
-| GET `/u/:handle` | ✓ | ✓ | OK |
-| GET `/u/:handle/badge.svg` | ✓ | ✓ | OK |
-| GET `/verify/:hash` | ✓ | ✓ | OK |
-| GET `/about` | ✓ | ✓ | OK |
-| GET `/about/scoring` | ✓ | ✓ | OK |
-| GET `/about/verification` | ✓ | ✓ | OK |
-| GET `/archetypes/:type` | ✓ | ✓ (builder, guardian, marathoner, polymath, balanced, emerging) | OK |
-| GET `/generating/:handle` | ✓ | ✓ | OK |
-| GET `/cli/authorize` | ✓ | ✓ | OK |
-| GET `/privacy` | ✓ | ✓ | OK |
-| GET `/terms` | ✓ | ✓ | OK |
-| GET `/coming-soon` | ✗ | ✓ | **MISSING_DOCS** |
-| GET `/experiments/*` (13 pages) | ✗ | ✓ | **MISSING_DOCS** |
-| GET `/verify` (page) | ✗ | ✓ | **MISSING_DOCS** |
+All 34 page routes exist and match CLAUDE.md documentation. The 13 experiment pages are covered by the wildcard `/experiments/*` entry.
 
-### Auth API
+| Page Route | In CLAUDE.md | Status |
+|------------|-------------|--------|
+| `/` through `/verify/[hash]` (21 core pages) | Yes | OK |
+| `/experiments/*` (13 experiment pages) | Yes (wildcard) | OK |
+| `/archetypes/artificer` | Listed in archetype set | OK |
 
-| Route | Documented in CLAUDE.md | Actually Exists | Status |
-|-------|:-----------------------:|:---------------:|--------|
-| GET `/api/auth/login` | ✓ | ✓ | OK |
-| GET `/api/auth/callback` | ✓ | ✓ | OK |
-| GET `/api/auth/session` | ✓ | ✓ | OK |
-| POST `/api/auth/logout` | ✓ | ✓ | OK |
-| GET `/api/auth/bitbucket/login` | ✓ | ✗ | **PHANTOM** — route doesn't exist |
-| GET `/api/auth/bitbucket/callback` | ✓ | ✓ | OK |
-| GET `/api/auth/bitbucket/connect` | ✗ | ✓ | **MISSING_DOCS** |
-| GET `/api/auth/bitbucket/disconnect` | ✗ | ✓ | **MISSING_DOCS** |
-| GET `/api/auth/bitbucket/status` | ✗ | ✓ | **MISSING_DOCS** |
-| GET `/api/auth/codeberg/login` | ✓ | ✗ | **PHANTOM** — route doesn't exist |
-| GET `/api/auth/codeberg/callback` | ✓ | ✓ | OK |
-| GET `/api/auth/codeberg/connect` | ✗ | ✓ | **MISSING_DOCS** |
-| GET `/api/auth/codeberg/disconnect` | ✗ | ✓ | **MISSING_DOCS** |
-| GET `/api/auth/codeberg/status` | ✗ | ✓ | **MISSING_DOCS** |
+### API Routes (42 total)
 
-### Public API
+| Route | CLAUDE.md | Actual Methods | Status |
+|-------|-----------|---------------|--------|
+| `/api/auth/login` | GET | GET | OK |
+| `/api/auth/callback` | GET | GET | OK |
+| `/api/auth/session` | GET | GET | OK |
+| `/api/auth/logout` | POST | POST | OK |
+| `/api/auth/bitbucket/*` (4 routes) | All correct | All correct | OK |
+| `/api/auth/codeberg/*` (4 routes) | All correct | All correct | OK |
+| `/api/verify/[hash]` | GET | GET | OK |
+| `/api/profile/[handle]` | GET | GET | OK |
+| `/api/history/[handle]` | GET | GET | OK |
+| `/api/health` | GET | GET | OK |
+| `/api/feature-flags` | GET | GET | OK |
+| `/api/generate` | POST | POST | OK |
+| `/api/refresh` | POST | POST | OK |
+| `/api/recalculate` | POST | POST | OK |
+| `/api/supplemental` | POST | POST | OK |
+| `/api/insights/[handle]` | GET | GET | OK |
+| `/api/insights` | POST | POST | OK |
+| `/api/studio/config` | GET\|PUT | GET\|PUT | OK |
+| `/api/cli/auth/approve` | POST | POST | OK |
+| `/api/admin/users` | GET | GET | OK |
+| `/api/admin/stats` | GET | GET | OK |
+| `/api/admin/agents-summary` | GET | GET | OK |
+| `/api/admin/campaigns` | GET\|POST | GET\|POST | OK |
+| `/api/admin/campaigns/[id]` | GET\|PATCH\|DELETE | GET\|PATCH\|DELETE | OK |
+| `/api/admin/campaigns/[id]/preview` | GET | GET | OK |
+| `/api/admin/campaigns/[id]/send` | POST | POST | OK |
+| `/api/admin/campaigns/[id]/test` | POST | POST | OK |
+| `/api/webhooks/resend` | POST | POST | OK |
+| `/api/cron/warm-cache` | GET | GET | OK |
+| `/api/cron/sync-audience` | GET | GET | OK |
+| `/api/cron/process-campaigns` | GET | GET | OK |
+| `/u/[handle]/badge.svg` | GET | GET | OK |
+| `/u/[handle]/og-image` | GET | GET | OK |
+| `/og-image` | GET | GET | OK |
+| `/llms.txt` | GET | GET | OK |
+| `/llms-full.txt` | GET | GET | OK |
+| `/.well-known/security.txt` | GET | GET | OK |
+| **`/api/cli/auth/poll`** | **GET\|POST** | **GET only** | **MISMATCH** |
+| **`/api/admin/feature-flags`** | **GET\|PATCH** | **PATCH only** | **MISMATCH** |
+| **`/api/admin/engagement-flags`** | **GET\|PUT** | **GET only** | **MISMATCH** |
+| **`/api/admin/agents/run`** | **POST** | **POST\|GET\|DELETE** | **MISMATCH** |
+| **`/api/notifications/unsubscribe`** | **POST** | **GET** | **MISMATCH** |
+| **`/api/telemetry`** | **Not listed** | **POST** | **MISSING** |
 
-| Route | Documented in CLAUDE.md | Actually Exists | Status |
-|-------|:-----------------------:|:---------------:|--------|
-| GET `/api/verify/:hash` | ✓ | ✓ | OK |
-| GET `/api/history/:handle` | ✓ | ✓ | OK |
-| GET `/api/health` | ✓ | ✓ | OK |
-| GET `/api/feature-flags` | ✓ | ✓ | OK |
+### Summary
 
-### Authenticated API
-
-| Route | Documented in CLAUDE.md | Actually Exists | Status |
-|-------|:-----------------------:|:---------------:|--------|
-| POST `/api/supplemental` | ✓ | ✓ | OK |
-| GET\|PUT `/api/studio/config` | ✓ | ✓ | OK |
-| POST `/api/refresh` | ✓ | ✓ | OK |
-| POST `/api/generate` | ✓ | ✓ | OK |
-| POST `/api/recalculate` | ✓ | ✓ | OK |
-| GET `/api/insights/:handle` | ✓ | ✓ | OK |
-| POST `/api/insights` | ✓ | ✓ | OK |
-| GET\|POST `/api/cli/auth/poll` | ✓ | ✓ | OK |
-| POST `/api/cli/auth/approve` | ✓ | ✓ | OK |
-
-### Admin API
-
-| Route | Documented in CLAUDE.md | Actually Exists | Status |
-|-------|:-----------------------:|:---------------:|--------|
-| GET `/api/admin/users` | ✓ | ✓ | OK |
-| GET `/api/admin/stats` | ✓ | ✓ | OK |
-| POST `/api/admin/agents/run` | ✓ | ✓ | OK |
-| GET `/api/admin/agents-summary` | ✓ | ✓ | OK |
-| GET\|PUT `/api/admin/feature-flags` | ✓ | ✓ (GET\|PATCH) | **MISMATCH** — docs say PUT, code is PATCH |
-| GET\|PUT `/api/admin/engagement-flags` | ✓ | ✓ (GET only) | **MISMATCH** — docs say GET\|PUT, code has GET only |
-| POST `/api/notifications/unsubscribe` | ✓ | ✓ | OK |
-| GET\|POST `/api/admin/campaigns` | ✗ | ✓ | **MISSING_DOCS** |
-| GET\|PATCH\|DELETE `/api/admin/campaigns/:id` | ✗ | ✓ | **MISSING_DOCS** |
-| POST `/api/admin/campaigns/:id/preview` | ✗ | ✓ | **MISSING_DOCS** |
-| POST `/api/admin/campaigns/:id/send` | ✗ | ✓ | **MISSING_DOCS** |
-
-### Webhooks, Cron & Special
-
-| Route | Documented in CLAUDE.md | Actually Exists | Status |
-|-------|:-----------------------:|:---------------:|--------|
-| POST `/api/webhooks/resend` | ✓ | ✓ | OK |
-| GET `/api/cron/warm-cache` | ✓ | ✓ | OK |
-| POST `/api/telemetry` | ✓ | ✓ | OK |
-| GET `/api/cron/process-campaigns` | ✗ | ✓ | **MISSING_DOCS** |
-| GET `/api/cron/sync-audience` | ✗ | ✓ | **MISSING_DOCS** |
-| GET `/.well-known/security.txt` | ✗ | ✓ | **MISSING_DOCS** |
-| GET `/og-image` | ✗ | ✓ | **MISSING_DOCS** |
-| GET `/u/:handle/og-image` | ✗ | ✓ | **MISSING_DOCS** |
-| GET `/llms.txt` | ✗ | ✓ | **MISSING_DOCS** |
-| GET `/llms-full.txt` | ✗ | ✓ | **MISSING_DOCS** |
-
-### Route Summary
-- **Documented & exist**: 38 routes — OK
-- **Undocumented**: 20+ routes (campaigns API, platform connect/disconnect/status, crons, OG images, LLM endpoints, experiments, coming-soon)
-- **Phantom routes** (documented but don't exist): 2 (`/api/auth/bitbucket/login`, `/api/auth/codeberg/login`)
-- **Method mismatches**: 2 (`feature-flags` PUT→PATCH, `engagement-flags` missing PUT)
-
----
-
-## Design System Token Accuracy
-
-| Area | Documented | In CSS | Status |
-|------|:----------:|:------:|--------|
-| Color tokens | 50 | 51 | **98%** — `--color-complement` base token undocumented (light variant documented) |
-| Animation classes | 17 | 18 | **94%** — `animate-hex-cell-in` undocumented |
-| Hex values | All match | — | OK |
-
-### Discrepancies
-1. **`--color-complement`** (`#10B981`) — base token exists in CSS, only `-light` variant in docs
-2. **`animate-hex-cell-in`** — fully implemented (keyframe + utility class) but not in docs table
-3. **`animate-shimmer-sweep`** — documented but has NO utility class (keyframe only)
-4. **`animate-terminal-type`** — documented but has NO utility class (keyframe only, used inline per-element)
-
----
+- **Correct routes**: 36/42 (86%)
+- **Method mismatches**: 5
+- **Undocumented routes**: 1 (`/api/telemetry`)
+- **Phantom routes from previous audit**: 0 (fixed)
 
 ## Stale Documentation
 
-| Document | Issue | Severity |
-|----------|-------|----------|
-| CLAUDE.md — Auth API | Documents `/api/auth/bitbucket/login` and `/api/auth/codeberg/login` which don't exist; actual routes are `/connect`, `/disconnect`, `/status` | HIGH |
-| CLAUDE.md — Admin API | `feature-flags` documented as GET\|PUT, code is GET\|PATCH; `engagement-flags` documented as GET\|PUT, code is GET only | MEDIUM |
-| CLAUDE.md — Archetypes | Lists "artificer" in archetype list but no `/archetypes/artificer` page exists | LOW |
-| design-system.md | Missing `--color-complement` base token and `animate-hex-cell-in` animation | LOW |
-
----
+| Item | Document | Issue | Severity |
+|------|----------|-------|----------|
+| `/api/cli/auth/poll` methods | CLAUDE.md:290 | Docs say GET\|POST, code exports GET only | Medium |
+| `/api/admin/feature-flags` methods | CLAUDE.md:296 | Docs say GET\|PATCH, code exports PATCH only | Medium |
+| `/api/admin/engagement-flags` methods | CLAUDE.md:297 | Docs say GET\|PUT, code exports GET only | Medium |
+| `/api/admin/agents/run` methods | CLAUDE.md:298 | Docs say POST, code exports POST\|GET\|DELETE | Medium |
+| `/api/notifications/unsubscribe` method | CLAUDE.md:305 | Docs say POST, code exports GET | High |
+| `animate-hex-cell-in` duration | design-system.md | Docs say "(set per-element)", actual CSS defines 0.45s | Low |
+| `animate-shimmer-sweep` | design-system.md animation table | Exists in CSS, mentioned in tokens table but missing from animation table | Low |
 
 ## Missing Documentation
 
-### Undocumented Routes (20+)
-1. **Campaign Management API** (7 routes): `/api/admin/campaigns`, `/api/admin/campaigns/:id`, preview, send
-2. **Campaign Cron Jobs** (2 routes): `/api/cron/process-campaigns`, `/api/cron/sync-audience`
-3. **Platform Connect/Disconnect/Status** (6 routes): Bitbucket + Codeberg connect, disconnect, status
-4. **OG Image Routes** (2): `/og-image`, `/u/:handle/og-image`
-5. **LLM Endpoints** (2): `/llms.txt`, `/llms-full.txt`
-6. **Well-known** (1): `/.well-known/security.txt`
-7. **Pages**: `/coming-soon`, `/verify` (page), `/experiments/*`
+### Undocumented API Route
+- **`POST /api/telemetry`** — Client telemetry ingestion endpoint. Not listed in CLAUDE.md Key Routes section.
 
-### Undocumented Complex Functions (4 critical)
-| Function | File | Lines | Why it matters |
-|----------|------|-------|----------------|
-| `isValidTelemetryPayload()` | `lib/utils/validation.ts:85` | ~40 | Complex nested validation, no JSDoc |
-| `isValidStatsShape()` | `lib/utils/validation.ts:133` | ~45 | Complex object validation, no JSDoc |
-| `isValidInsightsUpload()` | `lib/insights/validation.ts:5` | ~130 | Largest undocumented function in codebase |
-| `fetchContributionData()` | `lib/github/queries.ts:13` | ~60 | Core GraphQL fetch, complex data transform |
+### Complex Functions Without JSDoc (11 total)
 
-### JSDoc Coverage
-- **Overall**: ~78% of exported functions in `lib/` have JSDoc
-- **Well-documented areas**: auth (100%), render (100%), history (95%), impact (100%), cache (95%)
-- **Gaps**: validation functions, agent report parsers, some utility helpers
+| File | Function | Lines | Priority |
+|------|----------|-------|----------|
+| `lib/validation.ts` | `isValidTelemetryPayload` | 43 | P1 — validates critical API payload |
+| `lib/validation.ts` | `isValidBadgeConfig` | 17 | P1 — validates badge config API payload |
+| `lib/dashboard/generate-insights.ts` | `generateInsights` | >30 | P1 — core feature: personalized insights |
+| `lib/db/campaigns.ts` | `dbCreateCampaign` | >30 | P2 — campaign CRUD |
+| `lib/db/campaigns.ts` | `dbUpdateCampaign` | >30 | P2 — campaign CRUD |
+| `lib/db/campaigns.ts` | `dbGetActiveEngagementCampaign` | >30 | P2 — campaign query |
+| `lib/db/campaigns.ts` | `dbGetCampaignStats` | >30 | P2 — JS aggregation (PostgREST limitation) |
+| `lib/email/score-bump.ts` | `notifyScoreBump` | >30 | P2 — email notification |
+| `lib/email/templates/announcement.ts` | `buildAnnouncementHtml` | >30 | P2 — email template |
+| `lib/effects/counters/use-animated-counter.ts` | `useAnimatedCounter` | >30 | P3 — UI hook |
+| `lib/hooks/use-trend-data.ts` | `useTrendData` | >30 | P3 — data hook |
 
----
+### JSDoc Coverage by Category
+
+| Category | Coverage | Status |
+|----------|----------|--------|
+| Auth & OAuth | 100% | Excellent |
+| Cache & Performance | 100% | Excellent |
+| Core Scoring & Impact | 100% | Excellent |
+| History & Trends | 100% | Excellent |
+| Utilities & Helpers | 100% | Excellent |
+| packages/shared | 100% | Excellent |
+| Database & ORM | 98% | Excellent |
+| Email & Templates | 50% | Needs attention |
+| UI Effects | 42% | Critical gaps |
+
+**Overall JSDoc coverage: 84% (284/338 exports)**
+
+### Previously Reported Gaps — Now Resolved
+- `lib/insights/validation.ts::isValidInsightsUpload` — now fully documented
+- `lib/github/queries.ts::fetchContributionData` — now fully documented
+- `lib/utils/validation.ts::isValidStatsShape` — now fully documented
+- Auth cookie functions — now documented per security agent
 
 ## Environment Variables
 
-| Variable | In CLAUDE.md | Used in Code | In .env.example | Status |
-|----------|:------------:|:------------:|:---------------:|--------|
-| GITHUB_CLIENT_ID | ✓ | ✓ | ✓ | OK |
-| GITHUB_CLIENT_SECRET | ✓ | ✓ | ✓ | OK |
-| NEXTAUTH_SECRET | ✓ | ✓ | ✓ | OK |
-| NEXT_PUBLIC_BASE_URL | ✓ | ✓ | ✓ | OK |
-| UPSTASH_REDIS_REST_URL | ✓ | ✓ | ✓ | OK |
-| UPSTASH_REDIS_REST_TOKEN | ✓ | ✓ | ✓ | OK |
-| SUPABASE_URL | ✓ | ✓ | ✓ | OK |
-| SUPABASE_SERVICE_ROLE_KEY | ✓ | ✓ | ✓ | OK |
-| NEXT_PUBLIC_POSTHOG_KEY | ✓ | ✓ | ✓ | OK |
-| NEXT_PUBLIC_POSTHOG_HOST | ✓ | ✓ | ✓ | OK |
-| RESEND_API_KEY | ✓ | ✓ | ✓ | OK |
-| RESEND_WEBHOOK_SECRET | ✓ | ✓ | ✓ | OK |
-| SUPPORT_FORWARD_EMAIL | ✓ | ✓ | ✓ | OK |
-| GITHUB_TOKEN | ✓ | ✓ | ✓ | OK |
-| CHAPA_VERIFICATION_SECRET | ✓ | ✓ | ✓ | OK |
-| NEXT_PUBLIC_STUDIO_ENABLED | ✓ | ✓ | ✓ | OK |
-| NEXT_PUBLIC_EXPERIMENTS_ENABLED | ✓ | ✓ | ✓ | OK |
-| NEXT_PUBLIC_INSIGHTS_ENABLED | ✓ | ✓ | ✓ | OK |
-| BITBUCKET_CLIENT_ID | ✓ | ✓ | ✓ | OK |
-| BITBUCKET_CLIENT_SECRET | ✓ | ✓ | ✓ | OK |
-| NEXT_PUBLIC_BITBUCKET_ENABLED | ✓ | ✓ | ✓ | OK |
-| CODEBERG_CLIENT_ID | ✓ | ✓ | ✓ | OK |
-| CODEBERG_CLIENT_SECRET | ✓ | ✓ | ✓ | OK |
-| NEXT_PUBLIC_CODEBERG_ENABLED | ✓ | ✓ | ✓ | OK |
-| ADMIN_HANDLES | ✓ | ✓ | ✓ | OK |
-| ADMIN_SECRET | ✓ | ✓ | ✓ | OK |
-| ALLOW_AGENT_RUN | ✓ | ✓ | ✓ | OK |
-| CRON_SECRET | ✓ | ✓ | ✓ | OK |
-| VERCEL_ENV | ✓ | ✓ | (commented) | OK |
-| ANALYZE | ✓ | ✓ | (commented) | OK |
+| Variable | In CLAUDE.md | Used in Code | Status |
+|----------|-------------|-------------|--------|
+| GITHUB_CLIENT_ID | Yes | Yes | OK |
+| GITHUB_CLIENT_SECRET | Yes | Yes | OK |
+| NEXTAUTH_SECRET | Yes | Yes | OK |
+| NEXT_PUBLIC_BASE_URL | Yes | Yes | OK |
+| UPSTASH_REDIS_REST_URL | Yes | Yes | OK |
+| UPSTASH_REDIS_REST_TOKEN | Yes | Yes | OK |
+| SUPABASE_URL | Yes | Yes | OK |
+| SUPABASE_SERVICE_ROLE_KEY | Yes | Yes | OK |
+| NEXT_PUBLIC_POSTHOG_KEY | Yes | Yes | OK |
+| NEXT_PUBLIC_POSTHOG_HOST | Yes | Yes | OK |
+| RESEND_API_KEY | Yes | Yes | OK |
+| RESEND_WEBHOOK_SECRET | Yes | Yes | OK |
+| SUPPORT_FORWARD_EMAIL | Yes | Yes | OK |
+| GITHUB_TOKEN | Yes | Yes | OK |
+| CHAPA_VERIFICATION_SECRET | Yes | Yes | OK |
+| NEXT_PUBLIC_STUDIO_ENABLED | Yes | Yes | OK |
+| NEXT_PUBLIC_EXPERIMENTS_ENABLED | Yes | Yes | OK |
+| NEXT_PUBLIC_INSIGHTS_ENABLED | Yes | Yes | OK |
+| BITBUCKET_CLIENT_ID | Yes | Yes | OK |
+| BITBUCKET_CLIENT_SECRET | Yes | Yes | OK |
+| NEXT_PUBLIC_BITBUCKET_ENABLED | Yes | Yes | OK |
+| CODEBERG_CLIENT_ID | Yes | Yes | OK |
+| CODEBERG_CLIENT_SECRET | Yes | Yes | OK |
+| NEXT_PUBLIC_CODEBERG_ENABLED | Yes | Yes | OK |
+| ADMIN_HANDLES | Yes | Yes | OK |
+| ADMIN_SECRET | Yes | Yes | OK |
+| ALLOW_AGENT_RUN | Yes | Yes | OK |
+| CRON_SECRET | Yes | Yes | OK |
+| VERCEL_ENV | Yes | Yes | OK |
+| ANALYZE | Yes | Yes | OK |
 
-**30/30 project-specific env vars fully consistent** across CLAUDE.md, codebase, and .env.example. All sensitive vars use `.trim()`. No mismatches.
+**30/30 documented env vars present in code. 0 documented vars missing from code.**
 
----
+### Undocumented Env Vars Found in Code
 
-## Required Documents
+| Variable | Context | Action Needed |
+|----------|---------|---------------|
+| `ICEBERG_TOKEN` | Unknown integration | Investigate — document if production |
+| `SVIX_SERVER_URL` | Webhook infrastructure | Document if production dependency |
+| `SVIX_TOKEN` | Webhook infrastructure | Document if production dependency |
+| `BOOK_LANG` | Template generation | Document if production dependency |
+| `HOST` | Dev server binding | Low priority (dev-only) |
+| `MY_SERVER_PORT` | Dev server port | Low priority (dev-only) |
+| `TESTPLATFORM_CLIENT_ID` | Test fixtures | No action (test-only) |
+| `TESTPLATFORM_CLIENT_SECRET` | Test fixtures | No action (test-only) |
 
-| Document | Exists | Non-empty | Status |
-|----------|:------:|:---------:|--------|
-| `docs/impact-v4.md` | ✓ | ✓ (6.7K) | OK — marked deprecated, references v6 |
-| `docs/impact-v5.md` | ✓ | ✓ (5.1K) | OK — marked superseded by v6 |
-| `docs/impact-v6.md` | ✓ | ✓ (8.9K) | OK — current spec |
-| `docs/svg-design.md` | ✓ | ✓ (6.0K) | OK |
-| `docs/agents/shared-context.md` | ✓ | ✓ (12.1K) | OK — 7 entries, latest 2026-03-19 |
-| `README.md` | ✓ | ✓ (195 lines) | OK — full setup instructions |
+### Design System Token Accuracy
 
----
+- **Color tokens**: 50/51 documented — `--color-complement` base token defined in `:root` and `@theme` but missing explicit dark override in `[data-theme="dark"]` block
+- **Animations**: 17/18 documented — `animate-hex-cell-in` exists but duration undocumented; `animate-shimmer-sweep` missing from animation table
+- **All hex values verified accurate** against `globals.css`
+- **Dimension colors**: 10/10 match
+- **Archetype colors**: 7/7 match
 
 ## Recommendations
 
-### Priority 1 — Fix stale/incorrect docs
-1. **Update Bitbucket/Codeberg auth routes** in CLAUDE.md: replace phantom `/login` routes with actual `/connect`, `/disconnect`, `/status` pattern
-2. **Fix method mismatches**: `feature-flags` PUT→PATCH, `engagement-flags` remove PUT
+### Priority 1 — Fix Stale Route Methods (5 mismatches)
+1. Update `/api/notifications/unsubscribe` in CLAUDE.md from POST to GET
+2. Update `/api/cli/auth/poll` from GET|POST to GET
+3. Update `/api/admin/feature-flags` from GET|PATCH to PATCH
+4. Update `/api/admin/engagement-flags` from GET|PUT to GET
+5. Update `/api/admin/agents/run` from POST to POST|GET|DELETE
 
-### Priority 2 — Document new features
-3. **Add Campaign Management API** to CLAUDE.md (7 routes + 2 cron jobs)
-4. **Add OG image routes**, LLM endpoints, and `/.well-known/security.txt`
-5. **Add `--color-complement`** base token and `animate-hex-cell-in` to design-system.md
+### Priority 2 — Document Missing Route
+6. Add `POST /api/telemetry` to CLAUDE.md Key Routes section
 
-### Priority 3 — JSDoc gaps
-6. **Add JSDoc** to 4 critical validation/query functions (`isValidTelemetryPayload`, `isValidStatsShape`, `isValidInsightsUpload`, `fetchContributionData`)
+### Priority 3 — Add JSDoc to Complex Functions (3 P1 items)
+7. `lib/validation.ts::isValidTelemetryPayload` (43 lines)
+8. `lib/validation.ts::isValidBadgeConfig` (17 lines)
+9. `lib/dashboard/generate-insights.ts::generateInsights` (>30 lines, core feature)
 
-### Priority 4 — Low-priority cleanup
-7. Decide whether `/archetypes/artificer` page should be created or removed from archetype list
-8. Clarify `animate-shimmer-sweep` and `animate-terminal-type` — either add utility classes or update docs to note they're keyframe-only
+### Priority 4 — Investigate Undocumented Env Vars
+10. Determine if `ICEBERG_TOKEN`, `SVIX_SERVER_URL`, `SVIX_TOKEN`, `BOOK_LANG` are production dependencies and document accordingly
+
+### Priority 5 — Design System Polish
+11. Add `animate-shimmer-sweep` to animation table in design-system.md
+12. Clarify `animate-hex-cell-in` duration (0.45s) in design-system.md
+
+### Priority 6 — JSDoc for Campaign & Email Functions (8 P2 items)
+13. Add JSDoc to `lib/db/campaigns.ts` (4 complex functions at 9% coverage)
+14. Add JSDoc to `lib/email/score-bump.ts` and `lib/email/templates/announcement.ts`

--- a/docs/agents/pre-launch-report.md
+++ b/docs/agents/pre-launch-report.md
@@ -1,14 +1,13 @@
-# Pre-Launch Audit Report (v39)
-
-> Generated on 2026-03-27 | Branch: `develop` | Commit: `2848ef3`
-> 6,354 tests | 372 test files | 83 routes | Next.js 16.2.1 (Turbopack)
-> CI: ALL GREEN (last 5 runs) | 6 parallel specialists
+# Pre-Launch Audit Report
+> Generated on 2026-03-27 | Branch: `develop` | Commit: `c91d7e4` | 6 parallel specialists
+> 6,371 tests | 372 test files | 63 static pages | Next.js 16.2.1 (Turbopack)
+> CI: ALL GREEN | Coverage: 92.44% statements
 
 ## Verdict: CONDITIONAL
 
-No blockers. 8 warnings — flaky test (W1), unpushed commits (W2), missing docs for new endpoint (W3), minor a11y (W4-W5), dev dependency vulns (W6), history API leaks confidence data (W7), MPL-2.0 license not in stated policy (W8). Release is safe once W1-W3 are addressed.
+No blockers found. 10 warnings across 4 specialists — all low-severity quality/observability gaps, none affecting correctness or security.
 
-## Blockers
+## Blockers (must fix before release)
 
 None.
 
@@ -16,100 +15,81 @@ None.
 
 | # | Issue | Severity | Found by | Risk |
 |---|-------|----------|----------|------|
-| W1 | Flaky test: `BadgeToolbar.render.test.tsx` "strips @keyframes..." — timing race in mock Image src setter | Medium | qa-lead | Spurious CI failures on release branch |
-| W2 | 4 commits on local `develop` not pushed to `origin/develop` (includes new profile endpoint) | Medium | devops | CI has not validated latest code |
-| W3 | New `/api/profile/[handle]` route not documented in CLAUDE.md Key Routes section | Low | devops | External devs/agents may not discover it |
-| W4 | `<tr onClick>` in campaigns dashboard lacks `tabIndex`, `role`, and `onKeyDown` | Medium | ux-reviewer | Keyboard users can't activate campaign rows (admin-only) |
-| W5 | Unsubscribe route HTML missing `lang="en"` and viewport meta | Low | ux-reviewer | Screen reader language detection, mobile rendering |
-| W6 | 5 dev-only dependency vulns: picomatch ReDoS (2 high, 2 moderate), brace-expansion DoS (1 moderate) | Low | security-reviewer | Dev-only — not in production bundle |
-| W7 | `/api/history/:handle` exposes `confidence` and `confidencePenalties` — CLAUDE.md says confidence is internal-only | Medium | security-reviewer | Penalty flags like `burst_activity` could be perceived as accusatory |
-| W8 | `lightningcss` is MPL-2.0 — stated policy allows MIT/Apache/BSD/ISC only | Low | security-reviewer | Weak copyleft, build-only dep — low real risk |
-
-## Recommendations
-
-| # | Recommendation | Found by | Priority |
-|---|---------------|----------|----------|
-| R1 | Migrate 4 admin routes to use `adminAuth()` helper (users, feature-flags, engagement-flags, agents-summary) | architect | Low |
-| R2 | Bump vitest 4.1.1 → 4.1.2 (patch) | architect | Low |
-| R3 | Improve share page test coverage (84% stmts → target 90%+) | qa-lead | Low |
-| R4 | Exclude `**/fonts/**` from coverage config to reduce noise | qa-lead | Low |
-| R5 | Run `ANALYZE=true pnpm build` periodically — Turbopack no longer shows per-route sizes | performance-eng | Low |
-| R6 | Add MPL-2.0 to accepted licenses in CLAUDE.md or document in accepted-risks.md | security-reviewer | Low |
+| W1 | CORS wildcard on public API endpoints (`/api/profile`, `/api/verify`) | Low | security | Intentional for embeddable badges; safe since endpoints serve public data only |
+| W2 | Fail-open rate limiting when Redis is down | Low | security | Documented accepted risk (#300); GitHub API limits + CDN provide secondary protection |
+| W3 | Cron routes pass-through when `CRON_SECRET` unset | Low | security | Dev-only concern; Vercel Pro auto-injects secret in production |
+| W4 | `NEXT_PUBLIC_POSTHOG_KEY` used server-side | Low | security | Standard PostHog usage; key is write-only by design |
+| W5 | `pingRedis` checks connectivity only, not data access | Low | devops | CLAUDE.md recommends actual data access check; Supabase ping is correct |
+| W6 | Health endpoint returns 503 for unconfigured services | Low | devops | Preview deploys without Supabase show as degraded |
+| W7 | CI run was in-progress at audit time | Info | devops | Previous 2 runs succeeded; latest confirmed green after audit |
+| W8 | Experiment pages have `"use client"` on full page.tsx | Low | performance | Feature-flagged, non-public; acceptable for experiments |
+| W9 | No `<Suspense>` boundaries for streaming on share page | Low | performance | Would improve perceived performance for slow GitHub API calls |
+| W10 | Heading hierarchy inverted in 2 experiment pages | Low | ux | Feature-flagged and `noindex`; not public-facing |
 
 ## Detailed Findings
 
-### 1. Quality Assurance (qa-lead) — YELLOW
+### 1. Quality Assurance (qa-lead) — GREEN
 
-- **6,354 tests pass** across 372 test files (1 flaky failure in initial run, passed on retry)
-- TypeScript strict mode: clean
-- ESLint: clean
-- **Coverage:** 92.36% statements, 93.76% lines, 88.15% branches, 87.69% functions
-- Critical path coverage:
-  - Scoring pipeline (`lib/impact/`): 99.46% stmts, 100% lines
-  - SVG rendering (`lib/render/`): 100% stmts, 100% lines
-  - Database access (`lib/db/`): 96.86% stmts, 99.38% lines
-  - Authentication (`lib/auth/`): 96.27% stmts, 98.87% lines
-  - Profile endpoint: 100% across all metrics
-- **Flaky test** (W1): `BadgeToolbar.render.test.tsx` — async race in mock Image `src` setter
-- All external service failures have fail-open behavior with tests
-- Every critical API route has a corresponding test file
+- **Tests:** 6,371 passing (100% pass rate), 372 test files
+- **Coverage:** 92.44% statements, 88.43% branches, 87.76% functions, 93.85% lines
+- **TypeScript:** Clean (0 errors)
+- **Lint:** Clean (0 warnings)
+- **Critical paths:** All covered — impact scoring, SVG rendering, OAuth, GitHub client, share page, badge route, all 42 API routes have matching test files
+- **Graceful degradation:** Verified — fail-open rate limiter, stale cache fallback, badge error SVG, OAuth redirect on error, Promise.allSettled for parallel I/O
+
+**Minor gaps:** 5 loading.tsx files lack tests (admin, cli/authorize, privacy, terms, experiments). `ClientAnalytics.tsx` lacks a test. Branch coverage 88.43% is lowest metric.
 
 ### 2. Security (security-reviewer) — GREEN
 
-- `pnpm audit`: 5 vulnerabilities (all dev-only — picomatch, brace-expansion)
-- No hardcoded secrets in source
-- No secrets in `NEXT_PUBLIC_*` env vars
-- OAuth: AES-256-GCM encrypted cookies, CSRF via `crypto.timingSafeEqual`, safe redirect validation
-- SVG XSS: all user input escaped via `escapeXml()` (5 XML special chars)
-- CSP headers: strict, no `unsafe-eval` in production
-- HSTS: 2-year with preload + subdomains
-- CORS: wildcard only on public read-only endpoints (profile, verify) — rate-limited
-- New profile endpoint: verified clean — does NOT expose confidence or penalties
-- Licenses: MIT/BSD/Apache/ISC dominant. MPL-2.0 only on lightningcss (build-only)
-- Webhook HMAC (Svix), error telemetry sanitization, security.txt all present
+- **Dependency audit:** 0 vulnerabilities
+- **Hardcoded secrets:** None found
+- **OAuth:** Cryptographic state tokens, timingSafeEqual validation, HttpOnly/SameSite cookies, CSRF protection, open-redirect prevention
+- **Sessions:** AES-256-GCM encryption, 24h expiry, GCM auth tag tamper detection
+- **SVG XSS:** All user input escaped via `escapeXml()` — 5 XML special characters
+- **Client secret leaks:** None — all `NEXT_PUBLIC_` vars are non-sensitive
+- **Rate limiting:** Covers all API routes with per-endpoint limits
+- **Security headers:** HSTS with preload, CSP, X-Frame-Options, Permissions-Policy
+- **Platform tokens:** Encrypted at rest with AES-256-GCM
+- **Licenses:** Clean — no GPL/AGPL. `@resvg/resvg-js` is MPL-2.0 (file-level copyleft, compliant as dependency)
 
 ### 3. Infrastructure (devops) — GREEN
 
-- **Build:** succeeds (83 routes, 63 static pages, 0 errors, 7.2s compile)
-- **CI:** all 5 recent runs passed (CI, Bundle Size, Dead Code, Security Scan, Secret Scanning)
-- **Env vars:** all 32 project vars documented and `.trim()`'d — code and docs fully aligned
-- **Error pages:** not-found.tsx, error.tsx, global-error.tsx all exist
-- **Health endpoint:** checks actual data access (Redis ping + Supabase query), returns "degraded" on failure
-- **Vercel config:** 3 crons with `verifyCronSecret()` auth + `maxDuration: 300`
-- **Git state:** clean working tree, no stale worktrees, 4 unpushed commits (W2)
-- **New profile endpoint:** confirmed present with 18 test cases
+- **Build:** PASS (Next.js 16.2.1 Turbopack, 63 static pages)
+- **CI:** All workflows green (Lint, Typecheck, Test, Build, E2E, Bundle Size, Security Scan, Dead Code, Secret Scanning)
+- **Env vars:** All 30 production env vars documented in CLAUDE.md
+- **Error pages:** `error.tsx`, `not-found.tsx`, `global-error.tsx` all present
+- **Health endpoint:** Checks Redis (ping) + Supabase (actual query) in parallel, 5s timeout, rate-limited
+- **Git state:** Clean — develop up-to-date, no stale worktrees or branches
+- **Vercel config:** 3 cron jobs with bearer auth, comprehensive security headers, badge embedding rules
+- **Badge headers:** `Cache-Control: public, s-maxage=21600, stale-while-revalidate=604800`, correct Content-Type, frame-ancestors override
 
 ### 4. Architecture (architect) — GREEN
 
-- TypeScript: strict mode, clean across all workspaces
-- Dependencies: only vitest patch behind (4.1.1 → 4.1.2)
-- Dead code (knip): 0 findings
-- Circular dependencies (madge): 0 across 695 files
-- Code duplication: minor — 5 admin routes inline auth instead of using `adminAuth()` helper (R1)
-- DB access properly centralized through `getSupabase()`
-- Platform OAuth properly factored via shared handler factories
+- **TypeScript:** Clean, strict mode + `noUncheckedIndexedAccess` enabled
+- **Dependencies:** 6 minor/patch updates available. 2 major: ESLint 10 (deferred #531), TypeScript 6 (not urgent)
+- **Circular dependencies:** None (675 files analyzed)
+- **Dead code (knip):** Clean — no unused files, exports, or dependencies
+- **Duplication:** 1.22% in lib source, 2.06% in API routes (OAuth boilerplate, admin auth patterns), 8.55% in test files (shared mock setup patterns)
 
 ### 5. Performance (performance-eng) — GREEN
 
-- **Bundle:** largest client chunk 228 KB — all well under 500 KB threshold
-- **Client JS total:** 2.0 MB across all chunks
-- **"use client":** no directives on layouts; only on interactive leaf components
-- **Root layout:** server component — ThemeProvider/PostHog/Keyboard properly isolated as children
-- **Parallel I/O:** profile endpoint uses `Promise.all`; badge route uses `Promise.allSettled`
-- **Fonts:** `display: "swap"`, preconnect hints for GitHub/PostHog
-- **`after()` deferred work:** badge route defers snapshot insert, verification, analytics to post-response
-- **Reduced motion:** 2 CSS global blocks + 14+ JS component checks
-- **Dynamic imports:** PostHog, canvas-confetti, heavy components all lazy-loaded
+- **Build:** PASS (compiled 3.4s, 63 pages in 317ms)
+- **Largest chunk:** 227 KB (well under 500 KB threshold)
+- **Routes over 500 KB:** None
+- **`"use client"` placement:** Correct — server components at layout level, client directives at leaf components
+- **Dynamic imports:** Effective — PostHog deferred to interaction, heavy effects lazy-loaded, admin dashboards split
+- **Font loading:** `display: "swap"` on both fonts, no CLS risk
+- **Image optimization:** All images use `next/image` with explicit dimensions
+- **Resource hints:** `preconnect` for GitHub API and PostHog
 
 ### 6. UX/Accessibility (ux-reviewer) — GREEN
 
-- **Headings:** proper h1 → h2 → h3 hierarchy on all production pages (verified via sr-only h1/h2 pattern)
-- **ARIA:** comprehensive — ThemeToggle, UserMenu, MobileNav, CopyButton, BadgeToolbar, InfoTooltip, RadarChart, AutocompleteDropdown, ConfirmDialog, DimensionCard all labeled
-- **Focus:** global `:focus-visible` outline (2px amber) + skip-to-content link
-- **Reduced motion:** universal catch-all at CSS level + per-component JS checks
-- **Alt text:** all images/SVGs have descriptive labels; decorative icons have `aria-hidden`
-- **Keyboard:** all handlers on native interactive elements; full keyboard support in autocomplete, radar chart, dimension cards
-- **Error states:** 13 route-specific error.tsx + global-error.tsx
-- **Loading states:** 13 loading.tsx covering all route groups
-- **Design tokens:** 0 hardcoded hex colors in production components — full design system adherence
-- **One gap:** campaigns `<tr onClick>` missing keyboard support (W4, admin-only)
+- **Heading hierarchy:** Correct on all public pages; sr-only h1 where appropriate
+- **ARIA labels:** Comprehensive — all icon buttons, tabs, dialogs, listboxes, data viz elements
+- **Focus indicators:** Global `focus-visible` outline (2px amber), skip-to-content link
+- **prefers-reduced-motion:** Global catch-all + 50+ component-specific checks (CSS + JS)
+- **Alt text:** All images have descriptive alt text
+- **Keyboard navigation:** No onClick on non-focusable elements without ARIA roles; all custom widgets keyboard-accessible
+- **Error states:** 13 error.tsx + 1 global-error.tsx covering every route
+- **Loading states:** 13 loading.tsx with `role="status"` and `aria-label`
+- **Design consistency:** Zero hardcoded colors; all pages use design system tokens

--- a/docs/agents/shared-context.md
+++ b/docs/agents/shared-context.md
@@ -55,24 +55,23 @@
 - [Documentation]: Previous knip/unused-exports documentation item RESOLVED (0 findings now). No remaining performance-documentation concerns.
 <!-- ENTRY:END -->
 
-<!-- ENTRY:START agent=documentation timestamp=2026-03-20T09:00:00Z -->
-## Documentation Agent — 2026-03-20
+<!-- ENTRY:START agent=documentation timestamp=2026-03-27T10:00:00Z -->
+## Documentation Agent — 2026-03-27
 - **Status**: YELLOW
-- Route coverage: 38/58+ routes documented in CLAUDE.md (~65%). 20+ undocumented routes: entire campaigns API (7 routes), platform connect/disconnect/status (6), OG images (2), LLM endpoints (2), campaign crons (2), well-known (1), pages (3).
-- **Phantom routes**: 2 documented routes don't exist (`/api/auth/bitbucket/login`, `/api/auth/codeberg/login`) — actual routes are `/connect`, `/disconnect`, `/status`.
-- **Method mismatches**: 2 — `feature-flags` docs say PUT, code is PATCH; `engagement-flags` docs say GET|PUT, code has GET only.
-- Design system: 50/51 tokens documented (98%). `--color-complement` base token undocumented. 17/18 animations documented — `animate-hex-cell-in` missing. All hex values accurate.
-- Env vars: **30/30 fully consistent** across CLAUDE.md, codebase, and .env.example. All `.trim()`ed. Previous `NEXT_PUBLIC_INSIGHTS_ENABLED` gap resolved.
-- JSDoc coverage: ~78% of exported functions in `lib/`. Auth, render, impact, history all 95–100%. 4 critical complex functions still lack JSDoc: `isValidTelemetryPayload`, `isValidStatsShape`, `isValidInsightsUpload` (130+ lines), `fetchContributionData`.
-- All 6 required docs exist and are non-empty. README has full setup instructions (195 lines). Shared-context has 7 entries, latest 2026-03-19.
-- Archetype naming: CLAUDE.md correctly documents "Quality Champion" display name vs "guardian" internal route. No `/archetypes/artificer` page despite archetype being listed.
+- Route coverage: **41/42 API routes documented** in CLAUDE.md (98%). 1 undocumented: `POST /api/telemetry`. Previous phantom routes (`bitbucket/login`, `codeberg/login`) RESOLVED. Campaign API routes now fully documented.
+- **Method mismatches**: 5 — `/api/cli/auth/poll` (docs: GET|POST, actual: GET), `/api/admin/feature-flags` (docs: GET|PATCH, actual: PATCH), `/api/admin/engagement-flags` (docs: GET|PUT, actual: GET), `/api/admin/agents/run` (docs: POST, actual: POST|GET|DELETE), `/api/notifications/unsubscribe` (docs: POST, actual: GET).
+- Design system: 50/51 tokens documented (98%). `--color-complement` base token still lacks explicit dark override. 17/18 animations documented — `animate-hex-cell-in` has undocumented 0.45s duration; `animate-shimmer-sweep` missing from animation table. All hex values accurate.
+- Env vars: **30/30 fully consistent**. 8 undocumented env vars found in code (ICEBERG_TOKEN, SVIX_SERVER_URL, SVIX_TOKEN, BOOK_LANG, HOST, MY_SERVER_PORT, TESTPLATFORM_CLIENT_ID/SECRET). Most are dev/test-only; SVIX_* and ICEBERG_TOKEN need investigation.
+- JSDoc coverage: **84% (284/338 exports)**. Up from ~78%. Previously flagged `isValidInsightsUpload`, `isValidStatsShape`, `fetchContributionData` all RESOLVED. Remaining P1 gaps: `isValidTelemetryPayload` (43 lines), `isValidBadgeConfig` (17 lines), `generateInsights` (>30 lines).
+- All 6 required docs exist and are non-empty. README has 215 lines with full setup. `/archetypes/artificer` page now exists.
+- Shared-context has 7 entries, latest 2026-03-27.
 
 **Cross-agent recommendations:**
-- [QA]: 2 phantom routes (`bitbucket/login`, `codeberg/login`) may have stale integration tests. `feature-flags` method mismatch (PUT vs PATCH) could affect admin tests. Archetype "artificer" listed but no page exists.
-- [Security]: Auth cookie functions now have JSDoc (resolved). No security-related doc gaps.
-- [Coverage]: 4 undocumented complex validation functions overlap with files at lower coverage. Priority JSDoc: `lib/insights/validation.ts` (79.5%, 130+ lines undocumented), `lib/utils/validation.ts` (2 functions ~40 lines each).
-- [Performance]: Design system token documentation nearly complete (98%). No remaining performance-documentation concerns.
-- [Cost Analyst]: Campaign API routes (7) and cron jobs (2) fully undocumented — ensure cost model includes campaign email sends.
+- [QA]: 5 method mismatches in CLAUDE.md may cause stale integration test expectations. `/api/notifications/unsubscribe` is GET in code but POST in docs — verify tests use correct method.
+- [Security]: No security-related doc gaps. Undocumented SVIX_* and ICEBERG_TOKEN env vars should be verified for production exposure.
+- [Coverage]: 11 complex undocumented functions overlap with lower-coverage files. Priority JSDoc: `lib/validation.ts` (2 functions), `lib/dashboard/generate-insights.ts`, `lib/db/campaigns.ts` (4 functions).
+- [Performance]: Design system token documentation at 98%. No performance-documentation concerns.
+- [Cost Analyst]: Campaign API routes now fully documented. Undocumented SVIX_* env vars may indicate webhook infrastructure costs not captured in cost model.
 <!-- ENTRY:END -->
 
 <!-- ENTRY:START agent=security timestamp=2026-03-23T10:00:00Z -->

--- a/docs/agents/update-docs-report.md
+++ b/docs/agents/update-docs-report.md
@@ -1,33 +1,39 @@
 # Documentation Update Report
 
-> Generated on 2026-03-27 | Branch: `develop` | Changes since v2.3.0
+> Generated on 2026-03-27 | Branch: `develop` | Changes since v2.4.0
 
 ## Summary
-
-- 1 document updated (CHANGELOG.md)
-- 0 diagrams refreshed (none exist in project)
-- 0 version references corrected (all current)
-- 0 inline doc blocks updated (none stale)
+- 6 documents updated
+- 3 diagrams/tables refreshed
+- 7 version/count references corrected
+- 0 inline doc blocks updated (none existed for changed code)
 - 0 items flagged [NEEDS REVIEW]
 
 ## Changes by File
 
-### CHANGELOG.md
-Added `[Unreleased]` section documenting all changes since v2.3.0:
-- **Added**: Profile API endpoint, 17 new tests, share page coverage boost
-- **Changed**: History API confidence stripping, admin auth migration, vitest bump, coverage config
-- **Fixed**: Flaky test, campaigns keyboard a11y, unsubscribe HTML lang
-- **Documentation**: CLAUDE.md profile route, accepted-risks MPL-2.0
+### 1. `README.md`
+- Updated test count: "367+ files, 5,920+ tests" → "378+ files, 6,400+ tests"
 
-### Verified Current (no changes needed)
-- `CLAUDE.md` — profile endpoint already added during remediation
-- `README.md` — feature list and badges current
-- `docs/accepted-risks.md` — MPL-2.0 already added during remediation
-- `docs/design-system.md` — no UI token changes
-- `docs/impact-v6.md` — scoring spec unchanged
-- `docs/how-it-works.md` — data flow unchanged
-- All version references aligned with v2.3.0
+### 2. `CLAUDE.md`
+- Fixed agent reports description: "Gitignored. Local-only. Never committed" → "Committed to repo for team visibility" (reports are tracked in git)
+- Updated health endpoint description: "Redis + Supabase ping" → "Redis dbsize + Supabase query; returns 'skipped' for unconfigured services"
+
+### 3. `docs/spec.md`
+- Updated radar chart description: "4 dimensions" → "4–5 dimensions" with Craft mention
+- Added Artificer to archetype list
+- Added `/api/profile/:handle` and `/api/health` to public endpoints list
+
+### 4. `docs/badge-svg-spec-v1.2.md`
+- Renamed section 8b: "GitHub Branding" → "Platform Branding"
+- Updated RadarChart table entry: "4-axis diamond" → "4/5-axis (pentagon/diamond)"
+- Added 3 missing files to Implementation Reference: `svg-to-png.ts`, `demoData.ts`, `archetypeDemoData.ts`
+
+### 5. `docs/badge-design-v1.md`
+- Removed `[Confidence %]` from ASCII layout diagram (confidence display was removed from rendering)
+- Removed "Confidence" text reference from section heading and description
+
+### 6. `CHANGELOG.md`
+- Added link reference definitions for all 6 versions (v1.0.0 through v2.4.0) — previously all `[X.Y.Z]` header links were broken
 
 ## Flagged for Review
-
 None.

--- a/docs/badge-design-v1.md
+++ b/docs/badge-design-v1.md
@@ -55,7 +55,6 @@ The layout has five vertical sections: **Header**, **Body** (two columns), **Dim
 │  │  │  │  │  │   │  └────────────────┘  │
 │  └──┴──┴──┴──┘   │  [Archetype Pill]    │
 │                   │  [Score] [Tier Pill] │
-│                   │  [Confidence %]      │
 └──────────────────┴──────────────────────┘
 ```
 
@@ -115,13 +114,11 @@ SVG container: `w-[140px] h-[140px]`, `viewBox="0 0 140 140"`.
 - Text: `text-xs font-semibold text-amber`
 - Content: `{TIER_SYMBOL} {impact.archetype}` where symbols: Emerging=○, Solid=◉, High=◆, Elite=★
 
-#### Composite Score + Tier + Confidence (`flex flex-col items-center gap-1`)
+#### Composite Score + Tier (`flex flex-col items-center gap-1`)
 
 Score row (`flex items-baseline gap-2`):
 - Score value: `ScoreEffectText` component with `text-3xl font-heading font-bold tracking-tighter leading-none`. Wrapped in `<div data-score-effect={scoreEffect}>`.
 - Tier pill: `inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold border w-fit` + `tierPillClasses(tier)`.
-
-Confidence: `text-xs text-text-secondary`. Content: `{confidence}% Confidence`.
 
 ---
 

--- a/docs/badge-svg-spec-v1.2.md
+++ b/docs/badge-svg-spec-v1.2.md
@@ -652,7 +652,7 @@ The `rotate(-90)` makes the arc start from the top (12 o'clock position).
 <line x1="60" y1="560" x2="1140" y2="560" stroke="rgba(139,92,246,0.12)" stroke-width="1"/>
 ```
 
-### 8b. GitHub Branding (left side)
+### 8b. Platform Branding (left side)
 
 Group transform: `translate(60, 583)` (i.e., `PAD`, `footerY - 2`)
 
@@ -965,13 +965,16 @@ Source files (in `apps/web/lib/render/`):
 | File | Responsibility |
 |------|---------------|
 | `BadgeSvg.tsx` | Main layout, header, pills, score ring, footer — orchestrates all sections |
-| `RadarChart.ts` | 4-axis diamond radar chart |
+| `RadarChart.ts` | 4/5-axis radar chart (pentagon when Craft present, diamond fallback) |
 | `heatmap.ts` | 13×7 heatmap grid cells + animation |
 | `theme.ts` | Color palette, tier colors, archetype colors, heatmap color mapping |
 | `BadgeBranding.tsx` | Footer branding: "Forged from purpose. Driven by curiosity." + dynamic platform logos |
 | `VerificationStrip.ts` | Right-edge verification seal |
 | `avatar.ts` | Avatar URL → base64 data URI conversion |
 | `escape.ts` | XML entity escaping for user-controlled text |
+| `svg-to-png.ts` | SVG → PNG conversion (for download) |
+| `demoData.ts` | Demo stats/impact data for preview |
+| `archetypeDemoData.ts` | Per-archetype demo data for guide pages |
 
 Route handler: `apps/web/app/u/[handle]/badge.svg/route.ts`
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -36,6 +36,10 @@ As a developer, I want a **beautiful, embeddable badge** that shows my multi-dim
   - Load/save Creator Studio badge customization (GET to load, PUT to save)
 - GET `/api/history/:handle`
   - Score history, trend analysis, and snapshot diffs (public, rate-limited)
+- GET `/api/profile/:handle`
+  - Public impact profile snapshot (rate-limited, CORS-enabled)
+- GET `/api/health`
+  - Health check (Redis dbsize + Supabase query, rate-limited)
 
 ## Data refresh
 - Default refresh schedule: once per day per handle.
@@ -45,9 +49,9 @@ As a developer, I want a **beautiful, embeddable badge** that shows my multi-dim
 
 ## Metrics displayed (badge)
 - Heatmap (13 weeks of daily activity, left column)
-- Radar chart (4 dimensions: Delivery, Quality, Consistency, Breadth — center column)
+- Radar chart (4–5 dimensions: Delivery, Quality, Consistency, Breadth + optional Craft — pentagon when Craft present, diamond fallback)
 - Score ring with adjusted composite score (0-100) + tier (right column)
-- Archetype label (Builder, Quality Champion, Marathoner, Polymath, Balanced, Emerging)
+- Archetype label (Builder, Quality Champion, Marathoner, Polymath, Artificer, Balanced, Emerging)
 - Stars, forks, watchers metric pills
 - Impact tier (Emerging/Solid/High/Elite)
 
@@ -72,8 +76,8 @@ Optional display:
 
 The badge and share page display a multi-dimensional developer profile:
 
-- **4 dimensions** (each 0-100): Delivery, Quality, Consistency, Breadth
-- **Archetype**: Derived from dimension shape (Builder, Quality Champion, Marathoner, Polymath, Balanced, Emerging)
+- **4–5 dimensions** (each 0-100): Delivery, Quality, Consistency, Breadth + optional Craft (AI tool insights)
+- **Archetype**: Derived from dimension shape (Builder, Quality Champion, Marathoner, Polymath, Artificer, Balanced, Emerging)
 - **Composite score**: Average of all four dimensions
 - **Confidence** (50-100): Signal clarity rating with transparent, non-accusatory explanations
 - **Adjusted score**: Composite gently weighted by confidence

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ importers:
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@vitest/coverage-v8':
         specifier: ^4.1.2
-        version: 4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0)))
+        version: 4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)))
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -32,7 +32,7 @@ importers:
         version: 29.0.1
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0))
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0))
 
   apps/web:
     dependencies:
@@ -43,8 +43,8 @@ importers:
         specifier: ^2.6.2
         version: 2.6.2
       '@supabase/supabase-js':
-        specifier: ^2.99.2
-        version: 2.99.2
+        specifier: ^2.100.1
+        version: 2.100.1
       '@upstash/redis':
         specifier: ^1.37.0
         version: 1.37.0
@@ -64,8 +64,8 @@ importers:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       posthog-js:
-        specifier: ^1.362.0
-        version: 1.362.0
+        specifier: ^1.364.0
+        version: 1.364.0
       react:
         specifier: ^19.1.0
         version: 19.2.4
@@ -76,12 +76,12 @@ importers:
         specifier: ^6.9.4
         version: 6.9.4
       svix:
-        specifier: ^1.88.0
-        version: 1.88.0
+        specifier: ^1.89.0
+        version: 1.89.0
     devDependencies:
       '@next/bundle-analyzer':
-        specifier: ^16.2.0
-        version: 16.2.0
+        specifier: ^16.2.1
+        version: 16.2.1
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
@@ -92,8 +92,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.0
       '@types/node':
-        specifier: ^25.3.0
-        version: 25.3.0
+        specifier: ^25.5.0
+        version: 25.5.0
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -104,8 +104,8 @@ importers:
         specifier: ^9.27.0
         version: 9.39.2(jiti@2.6.1)
       eslint-config-next:
-        specifier: ^16.0.0
-        version: 16.1.6(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+        specifier: ^16.2.1
+        version: 16.2.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -667,14 +667,14 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@next/bundle-analyzer@16.2.0':
-    resolution: {integrity: sha512-3F8T1KYVWKBLUXzZPpYSYp134c3iwzNDMxfOE0kkqST+S5VaYao41F0SQogd6E4Od7+C3ReA/XJMDDw9P61n6w==}
+  '@next/bundle-analyzer@16.2.1':
+    resolution: {integrity: sha512-fbj2WE6dnCyG8CvQnrBfpHyxdOIyZ4aEHJY0bSqAmamRiIXDqunFQPDvuSOPo24mJE9zQHw7TY6d+sGrXO98TQ==}
 
   '@next/env@16.2.1':
     resolution: {integrity: sha512-n8P/HCkIWW+gVal2Z8XqXJ6aB3J0tuM29OcHpCsobWlChH/SITBs1DFBk/HajgrwDkqqBXPbuUuzgDvUekREPg==}
 
-  '@next/eslint-plugin-next@16.1.6':
-    resolution: {integrity: sha512-/Qq3PTagA6+nYVfryAtQ7/9FEr/6YVyvOtl6rZnGsbReGLf0jZU6gkpr1FuChAQpvV46a78p4cmHOVP8mbfSMQ==}
+  '@next/eslint-plugin-next@16.2.1':
+    resolution: {integrity: sha512-r0epZGo24eT4g08jJlg2OEryBphXqO8aL18oajoTKLzHJ6jVr6P6FI58DLMug04MwD3j8Fj0YK0slyzneKVyzA==}
 
   '@next/swc-darwin-arm64@16.2.1':
     resolution: {integrity: sha512-BwZ8w8YTaSEr2HIuXLMLxIdElNMPvY9fLqb20LX9A9OMGtJilhHLbCL3ggyd0TwjmMcTxi0XXt+ur1vWUoxj2Q==}
@@ -824,11 +824,11 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@posthog/core@1.24.0':
-    resolution: {integrity: sha512-Wkp9mgNfgdf6+G4C1VMKakm2RXKQFf4bb5/CPQRAjpqv9l6BY36zZrD1+X5Y2XIAzZqbMKRxsDu3V1r6uKu7/A==}
+  '@posthog/core@1.24.2':
+    resolution: {integrity: sha512-Dpmodetbj4sASDKjmWfxJ2zC/rStd+hhW0E7Bru4IN5s2bTgpcPNwBoUwcCjdxPZ/02vbWwbJ88K3gmNJO5oxg==}
 
-  '@posthog/types@1.362.0':
-    resolution: {integrity: sha512-15wOI5uulkfzpkSQKVN4atZecAla2Hxr8IBIB8islqDvqY+42vbR+tMeDKMman9+FUoAqMzE0OnB8VIbM1QY0w==}
+  '@posthog/types@1.364.0':
+    resolution: {integrity: sha512-RMScs7CL6DYSVDEcePUpa/eDpunWvvjiN6+Cc8O0Wk8NvATVhtYC7EqdhrZGH+VpEmdxW2UNQf7eUhaSOnNUAQ==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -1087,28 +1087,31 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@supabase/auth-js@2.99.2':
-    resolution: {integrity: sha512-uRGNXMKEw4VhwouNW7N0XDAGqJP9redHNDmWi17dTrcO1lvFfyRiXsqqfgnVC8aqtRn8kLkLPEzHjiRWsni+oQ==}
+  '@supabase/auth-js@2.100.1':
+    resolution: {integrity: sha512-c5FB4nrG7cs1mLSzFGuIVl2iR2YO5XkSJ96uF4zubYm8YDn71XOi2emE9sBm/avfGCj61jaRBLOvxEAVnpys0Q==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/functions-js@2.99.2':
-    resolution: {integrity: sha512-xuXQARvjdfB1UPK1yUceZ5EGjOLkVz4rBAaloS9foXiAuseWEdgWBCxkIAFRxGBLGX8Uzo8kseq90jhPb+07Vg==}
+  '@supabase/functions-js@2.100.1':
+    resolution: {integrity: sha512-mo8QheoV4KR+wSubtyEWhZUxWnCM7YZ23TncccMAlbWAHb8YTDqRGRm9IalWCAswniKyud6buZCk9snRqI86KA==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/postgrest-js@2.99.2':
-    resolution: {integrity: sha512-ueiOVkbkTQ7RskwVmjR8zxWYw3VKOMxo1+qep+Dx/SgApqyhWBGd92waQb45tbLc7ydB5x8El8utXOLQTuTojQ==}
+  '@supabase/phoenix@0.4.0':
+    resolution: {integrity: sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==}
+
+  '@supabase/postgrest-js@2.100.1':
+    resolution: {integrity: sha512-OIh4mOSo2LdqF2kox76OAPDtcSs+PwKABJOjc6plUV4/LXhFEsI2uwdEEIs7K7fd141qehWEVl/Y+Ts0fNvYsw==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/realtime-js@2.99.2':
-    resolution: {integrity: sha512-J6Jm9601dkpZf3+EJ48ki2pM4sFtCNm/BI0l8iEnrczgg+JSEQkMoOW5VSpM54t0pNs69bsz5PTmYJahDZKiIQ==}
+  '@supabase/realtime-js@2.100.1':
+    resolution: {integrity: sha512-FHuRWPX4qZQ4x+0Q+ZrKaBZnOiVGiwsgiAUJM98pYRib1yeaE/fOM1lZ1ozd+4gA8Udw23OyaD8SxKS5mT5NYw==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/storage-js@2.99.2':
-    resolution: {integrity: sha512-V/FF8kX8JGSefsVCG1spCLSrHdNR/JFeUMn1jS9KG/Eizjx+evtdKQKLJXFgIylY/bKTXKhc2SYDPIGrIhzsug==}
+  '@supabase/storage-js@2.100.1':
+    resolution: {integrity: sha512-x9xpEIoWM4xKiAlwfWTgHPSN6N4Y0aS4FVU4F6ZPbq7Gayw08SrtC6/YH/gOr8CjXQr0HxXYXDop2xGTSjubYA==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/supabase-js@2.99.2':
-    resolution: {integrity: sha512-179rn5wq0wBAqqGwAwR7TUGg2NOaP+fkd5FCVbYJXby85fsRNPFoNJN8YRBepqX2tN7JJcnTjqaAMXuNjiyisA==}
+  '@supabase/supabase-js@2.100.1':
+    resolution: {integrity: sha512-CAeFm5sfX8sbTzxoxRafhohreIzl9a7R6qHTck3MrgTqm5M5g/u0IHfEKYzI9w/17r8NINl8UZrw2i08wrO7Iw==}
     engines: {node: '>=20.0.0'}
 
   '@swc/helpers@0.5.15':
@@ -1249,11 +1252,8 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
-  '@types/node@25.3.0':
-    resolution: {integrity: sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==}
-
-  '@types/phoenix@1.6.7':
-    resolution: {integrity: sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==}
+  '@types/node@25.5.0':
+    resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -1862,8 +1862,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-config-next@16.1.6:
-    resolution: {integrity: sha512-vKq40io2B0XtkkNDYyleATwblNt8xuh3FWp8SpSz3pt7P01OkBFlKsJZ2mWt5WsCySlDQLckb1zMY9yE9Qy0LA==}
+  eslint-config-next@16.2.1:
+    resolution: {integrity: sha512-qhabwjQZ1Mk53XzXvmogf8KQ0tG0CQXF0CZ56+2/lVhmObgmaqj7x5A1DSrWdZd3kwI7GTPGUjFne+krRxYmFg==}
     peerDependencies:
       eslint: '>=9.0.0'
       typescript: '>=3.3.1'
@@ -2667,8 +2667,8 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  posthog-js@1.362.0:
-    resolution: {integrity: sha512-qPHkAk9G19xVDAQLoQ1FOLNE9BBq+FDePhkOevbdUQcFJVNHVc+j7E/ndQ+olGnDuiSMdgAb5c6yGk7PD9Z0ug==}
+  posthog-js@1.364.0:
+    resolution: {integrity: sha512-eNq+Jh+OZh67iKMCTmKdxCPt6j3YJFNbBu/+9/PZDqG2po2Osutm/KJ9qJttHJ6JHzM3q7jUCf75PLc18A0Aow==}
 
   preact@10.29.0:
     resolution: {integrity: sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg==}
@@ -2912,8 +2912,8 @@ packages:
   svix@1.86.0:
     resolution: {integrity: sha512-/HTvXwjLJe1l/MsLXAO1ddCYxElJk4eNR4DzOjDOEmGrPN/3BtBE8perGwMAaJ2sT5T172VkBYzmHcjUfM1JRQ==}
 
-  svix@1.88.0:
-    resolution: {integrity: sha512-vm/JrrUd3bVyBE+3L33TIyVSs8gS5fYx7lrISvKlDJXTYX1ACH4REX8P1tHxsSKoZi/rvifM1t0XRc5Vc45THw==}
+  svix@1.89.0:
+    resolution: {integrity: sha512-Yg/5OtdjN3zjWoQSoX+mkauUtLKiW/+DQWKcG2VaEfWoBBB9NmZoKMw7rQQVU5Nn/Wko3kNbo4cvo/ms48d2KQ==}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -3178,8 +3178,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3656,7 +3656,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/bundle-analyzer@16.2.0':
+  '@next/bundle-analyzer@16.2.1':
     dependencies:
       webpack-bundle-analyzer: 4.10.1
     transitivePeerDependencies:
@@ -3665,7 +3665,7 @@ snapshots:
 
   '@next/env@16.2.1': {}
 
-  '@next/eslint-plugin-next@16.1.6':
+  '@next/eslint-plugin-next@16.2.1':
     dependencies:
       fast-glob: 3.3.1
 
@@ -3789,11 +3789,11 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@posthog/core@1.24.0':
+  '@posthog/core@1.24.2':
     dependencies:
       cross-spawn: 7.0.6
 
-  '@posthog/types@1.362.0': {}
+  '@posthog/types@1.364.0': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -3950,40 +3950,42 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@supabase/auth-js@2.99.2':
+  '@supabase/auth-js@2.100.1':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/functions-js@2.99.2':
+  '@supabase/functions-js@2.100.1':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/postgrest-js@2.99.2':
+  '@supabase/phoenix@0.4.0': {}
+
+  '@supabase/postgrest-js@2.100.1':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/realtime-js@2.99.2':
+  '@supabase/realtime-js@2.100.1':
     dependencies:
-      '@types/phoenix': 1.6.7
+      '@supabase/phoenix': 0.4.0
       '@types/ws': 8.18.1
       tslib: 2.8.1
-      ws: 8.19.0
+      ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@supabase/storage-js@2.99.2':
+  '@supabase/storage-js@2.100.1':
     dependencies:
       iceberg-js: 0.8.1
       tslib: 2.8.1
 
-  '@supabase/supabase-js@2.99.2':
+  '@supabase/supabase-js@2.100.1':
     dependencies:
-      '@supabase/auth-js': 2.99.2
-      '@supabase/functions-js': 2.99.2
-      '@supabase/postgrest-js': 2.99.2
-      '@supabase/realtime-js': 2.99.2
-      '@supabase/storage-js': 2.99.2
+      '@supabase/auth-js': 2.100.1
+      '@supabase/functions-js': 2.100.1
+      '@supabase/postgrest-js': 2.100.1
+      '@supabase/realtime-js': 2.100.1
+      '@supabase/storage-js': 2.100.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -4104,11 +4106,9 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
-  '@types/node@25.3.0':
+  '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
-
-  '@types/phoenix@1.6.7': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -4123,7 +4123,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
 
   '@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -4289,7 +4289,7 @@ snapshots:
       next: 16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
-  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0)))':
+  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.2
@@ -4301,7 +4301,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0))
+      vitest: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0))
 
   '@vitest/expect@4.1.2':
     dependencies:
@@ -4312,13 +4312,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@vitest/mocker@4.1.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)
 
   '@vitest/pretty-format@4.1.2':
     dependencies:
@@ -4773,13 +4773,13 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.1.6(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
+  eslint-config-next@16.2.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@next/eslint-plugin-next': 16.1.6
+      '@next/eslint-plugin-next': 16.2.1
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -4801,7 +4801,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -4812,22 +4812,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -4838,7 +4838,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -5635,15 +5635,15 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  posthog-js@1.362.0:
+  posthog-js@1.364.0:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.208.0
       '@opentelemetry/exporter-logs-otlp-http': 0.208.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
-      '@posthog/core': 1.24.0
-      '@posthog/types': 1.362.0
+      '@posthog/core': 1.24.2
+      '@posthog/types': 1.364.0
       core-js: 3.49.0
       dompurify: 3.3.3
       fflate: 0.4.8
@@ -5679,7 +5679,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
       long: 5.3.2
 
   punycode@2.3.1: {}
@@ -5994,7 +5994,7 @@ snapshots:
       standardwebhooks: 1.0.0
       uuid: 10.0.0
 
-  svix@1.88.0:
+  svix@1.89.0:
     dependencies:
       standardwebhooks: 1.0.0
       uuid: 10.0.0
@@ -6148,7 +6148,7 @@ snapshots:
 
   uuid@10.0.0: {}
 
-  vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0):
+  vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.4)
@@ -6157,15 +6157,15 @@ snapshots:
       rollup: 4.60.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
 
-  vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0)):
+  vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)):
     dependencies:
       '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0))
+      '@vitest/mocker': 4.1.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0))
       '@vitest/pretty-format': 4.1.2
       '@vitest/runner': 4.1.2
       '@vitest/snapshot': 4.1.2
@@ -6182,11 +6182,11 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 25.3.0
+      '@types/node': 25.5.0
       jsdom: 29.0.1
     transitivePeerDependencies:
       - msw
@@ -6282,7 +6282,7 @@ snapshots:
 
   ws@7.5.10: {}
 
-  ws@8.19.0: {}
+  ws@8.20.0: {}
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
## Release v2.4.1

### Added
- Share page Suspense boundary for progressive streaming (#635)
- 43 new tests: 6 new test files + heading hierarchy regression tests; total: 6,414 (#637)

### Fixed
- Linked platforms appear in Data Sources even when stats fetch fails — DB link status is source of truth (#632)
- Health endpoint uses `dbsize()` for actual data-access check; returns `"skipped"` (200) for unconfigured services (#634)
- Cron auth logs warning when `CRON_SECRET` unset (#633)
- Heading hierarchy in experiment pages (#636)
- E2E health test accepts `"skipped"` status

### Changed
- UserMenu platform visibility driven by server-side status API (not client sync flags)
- Parallelized linked-platform fallback checks; extracted `fetchPlatformStatus()` helper
- 6 minor/patch dependency updates (#638)

### Documentation
- Updated README, CLAUDE.md, spec.md, badge specs, CHANGELOG link references

---

**Pre-launch audit:** All 6 specialists GREEN, 0 blockers
**Tests:** 6,414 passing (378 files) | **Coverage:** 92.4% statements
**CI:** All workflows green

🤖 Generated with [Claude Code](https://claude.com/claude-code)