### PR TITLE
fix(scoring): preserve solo quality fields in mergeStats

### DIFF
--- a/apps/web/lib/github/merge.test.ts
+++ b/apps/web/lib/github/merge.test.ts
@@ -267,6 +267,55 @@ describe("mergeStats", () => {
     });
   });
 
+  describe("solo quality fields (prDescriptionRate, featureBranchRate, issueLinkageRate)", () => {
+    it("merges solo quality fields by weighted average", () => {
+      const primary = makeStats({
+        prsMergedCount: 10,
+        prDescriptionRate: 0.8,
+        featureBranchRate: 0.9,
+        issueLinkageRate: 0.6,
+      });
+      const supplemental = makeStats({
+        prsMergedCount: 5,
+        prDescriptionRate: 0.4,
+        featureBranchRate: 0.6,
+        issueLinkageRate: 0.0,
+      });
+
+      const merged = mergeStats(primary, supplemental);
+      // weighted avg: (10*0.8 + 5*0.4) / 15 = 10/15 ≈ 0.667
+      expect(merged.prDescriptionRate).toBeCloseTo(0.667, 2);
+      // (10*0.9 + 5*0.6) / 15 = 12/15 = 0.8
+      expect(merged.featureBranchRate).toBeCloseTo(0.8, 2);
+      // (10*0.6 + 5*0.0) / 15 = 6/15 = 0.4
+      expect(merged.issueLinkageRate).toBeCloseTo(0.4, 2);
+    });
+
+    it("preserves solo quality fields when only primary has them", () => {
+      const primary = makeStats({
+        prsMergedCount: 10,
+        prDescriptionRate: 0.7,
+        featureBranchRate: 0.85,
+        issueLinkageRate: 0.5,
+      });
+      const supplemental = makeStats({ prsMergedCount: 0 });
+
+      const merged = mergeStats(primary, supplemental);
+      expect(merged.prDescriptionRate).toBeCloseTo(0.7, 2);
+      expect(merged.featureBranchRate).toBeCloseTo(0.85, 2);
+      expect(merged.issueLinkageRate).toBeCloseTo(0.5, 2);
+    });
+
+    it("returns undefined when neither side has solo quality fields", () => {
+      const primary = makeStats({});
+      const supplemental = makeStats({});
+      const merged = mergeStats(primary, supplemental);
+      expect(merged.prDescriptionRate).toBeUndefined();
+      expect(merged.featureBranchRate).toBeUndefined();
+      expect(merged.issueLinkageRate).toBeUndefined();
+    });
+  });
+
   describe("determinism", () => {
     it("produces the same output for the same inputs", () => {
       const primary = makeStats({ commitsTotal: 50, prsMergedWeight: 15 });

--- a/apps/web/lib/github/merge.ts
+++ b/apps/web/lib/github/merge.ts
@@ -68,6 +68,18 @@ export function mergeStats(
       supplemental.medianPrLeadTimeHours, supplemental.prsMergedCount,
     ),
     docsOnlyPrRatio: mergeOptionalMax(primary.docsOnlyPrRatio, supplemental.docsOnlyPrRatio),
+    prDescriptionRate: mergeOptionalWeightedAvg(
+      primary.prDescriptionRate, primary.prsMergedCount,
+      supplemental.prDescriptionRate, supplemental.prsMergedCount,
+    ),
+    featureBranchRate: mergeOptionalWeightedAvg(
+      primary.featureBranchRate, primary.prsMergedCount,
+      supplemental.featureBranchRate, supplemental.prsMergedCount,
+    ),
+    issueLinkageRate: mergeOptionalWeightedAvg(
+      primary.issueLinkageRate, primary.prsMergedCount,
+      supplemental.issueLinkageRate, supplemental.prsMergedCount,
+    ),
     heatmapData: mergedHeatmap,
     hasSupplementalData: options?.markAsSupplemental ?? true,
   };


### PR DESCRIPTION
## Summary

**Hotfix for v2.5.0** — `mergeStats()` was dropping `prDescriptionRate`, `featureBranchRate`, and `issueLinkageRate` when merging multi-platform stats. These 3 fields power 85% of solo Quality scoring. Users with linked platforms (Bitbucket/Codeberg/EMU) saw Quality collapse to ~5.

## Root Cause

The `mergeStats()` function in `merge.ts` explicitly lists every field to include in the merged result. When `batchSizeScore` and `medianPrLeadTimeHours` were added in v6.1, the 3 solo quality fields were missed.

## Fix

Added weighted-average merging for all 3 fields (same pattern as `batchSizeScore`). Added 3 regression tests.

## Test plan

- [x] 6,615 tests pass (3 new)
- [x] Typecheck clean
- [x] Lint clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)