### PR TITLE
fix(share-page): restore Refresh button via client-side session check

### DIFF
--- a/apps/web/app/u/[handle]/page.test.ts
+++ b/apps/web/app/u/[handle]/page.test.ts
@@ -65,12 +65,8 @@ describe("SharePage", () => {
       expect(SOURCE).toContain("BadgeToolbar");
     });
 
-    it("passes studioEnabled to toolbar", () => {
-      expect(SOURCE).toContain("studioEnabled");
-    });
-
-    it("passes isOwner to toolbar", () => {
-      expect(SOURCE).toContain("isOwner");
+    it("passes handle to toolbar", () => {
+      expect(SOURCE).toContain("handle=");
     });
   });
 

--- a/apps/web/app/u/[handle]/page.tsx
+++ b/apps/web/app/u/[handle]/page.tsx
@@ -18,7 +18,6 @@ import { DEFAULT_BADGE_CONFIG } from "@chapa/shared";
 import { ShareBadgePreviewLazy } from "@/components/ShareBadgePreviewLazy";
 import { SharePageShortcuts } from "@/components/SharePageShortcuts";
 import { SharePageOwnerContent } from "@/components/SharePageOwnerContent";
-import { isStudioEnabled } from "@/lib/feature-flags";
 import { getCachedCraftScore } from "@/lib/cache/craft-cache";
 import { getBaseUrl } from "@/lib/env";
 import { toDateString } from "@/lib/utils/date";
@@ -114,12 +113,11 @@ export async function SharePageContent({ handle }: { handle: string }) {
   // Stats fetch uses env GITHUB_TOKEN fallback (no per-user OAuth token).
 
   // Fetch stats, config, snapshot, craft score, and feature flags in parallel
-  const [stats, savedConfig, latestSnapshot, craftResult, studioEnabled] = await Promise.all([
+  const [stats, savedConfig, latestSnapshot, craftResult] = await Promise.all([
     getStats(handle),
     cacheGet<BadgeConfig>(`config:${handle}`),
     getCachedLatestSnapshot(handle),
     getCachedCraftScore(handle),
-    isStudioEnabled(),
   ]);
 
   const impact = stats ? computeImpactV4(stats, craftResult?.craftScore ?? undefined) : null;
@@ -212,7 +210,7 @@ export async function SharePageContent({ handle }: { handle: string }) {
       <SharePageShortcuts
         embedMarkdown={embedMarkdown}
         handle={handle}
-        isOwner={false}
+
       />
       {/* SAFETY: JSON-LD uses JSON.stringify (auto-escapes quotes/special chars) + explicit < escape to prevent </script> injection. User handle is a URL param but only appears as a JSON string value, never raw HTML. */}
       <script
@@ -274,8 +272,6 @@ export async function SharePageContent({ handle }: { handle: string }) {
         <div className="relative z-30 flex justify-end mb-10 animate-fade-in-up [animation-delay:250ms]">
           <BadgeToolbar
             handle={handle}
-            isOwner={false}
-            studioEnabled={studioEnabled}
           />
         </div>
 

--- a/apps/web/components/BadgeToolbar.render.test.tsx
+++ b/apps/web/components/BadgeToolbar.render.test.tsx
@@ -41,9 +41,21 @@ vi.mock("next/link", () => ({
   ),
 }));
 
+/** Mock session fetch — defaults to owner. Override with mockSessionAs(). */
+function mockSessionAs(login: string | null) {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+    if (typeof url === "string" && url.includes("/api/auth/session")) {
+      return new Response(JSON.stringify({ user: login ? { login } : null }));
+    }
+    // Default passthrough for other fetches (refresh, badge.svg, etc.)
+    return new Response("ok");
+  });
+}
+
 beforeEach(() => {
   dropdownOpen = false;
   setIsOpenMock.mockClear();
+  mockSessionAs("testuser"); // default: logged in as the handle used in tests
 });
 
 afterEach(() => {
@@ -55,7 +67,7 @@ describe("BadgeToolbar render", () => {
   describe("smoke test", () => {
     it("renders Share and Download buttons", () => {
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
       expect(screen.getByLabelText("Share badge")).toBeDefined();
       expect(screen.getByLabelText("Download badge as PNG")).toBeDefined();
@@ -63,184 +75,146 @@ describe("BadgeToolbar render", () => {
   });
 
   describe("owner-only controls", () => {
-    it("shows Refresh button when isOwner", () => {
-      render(
-        <BadgeToolbar handle="testuser" isOwner={true} studioEnabled={false} />,
-      );
-      expect(screen.getByLabelText("Refresh badge data")).toBeDefined();
+    it("shows Refresh button when session matches handle", async () => {
+      mockSessionAs("testuser");
+      render(<BadgeToolbar handle="testuser" />);
+      await waitFor(() => {
+        expect(screen.getByLabelText("Refresh badge data")).toBeDefined();
+      });
     });
 
-    it("hides Refresh button when not owner", () => {
-      render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
-      );
-      expect(screen.queryByLabelText("Refresh badge data")).toBeNull();
+    it("hides Refresh button when not owner", async () => {
+      mockSessionAs("otheruser");
+      render(<BadgeToolbar handle="testuser" />);
+      await waitFor(() => {
+        expect(screen.queryByLabelText("Refresh badge data")).toBeNull();
+      });
     });
 
-    it("shows Customize link when isOwner and studioEnabled", () => {
-      render(
-        <BadgeToolbar handle="testuser" isOwner={true} studioEnabled={true} />,
-      );
-      expect(screen.getByText("Customize")).toBeDefined();
-    });
-
-    it("hides Customize link when not owner", () => {
-      render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={true} />,
-      );
-      expect(screen.queryByText("Customize")).toBeNull();
-    });
-
-    it("hides Customize when studioEnabled is false", () => {
-      render(
-        <BadgeToolbar handle="testuser" isOwner={true} studioEnabled={false} />,
-      );
-      expect(screen.queryByText("Customize")).toBeNull();
+    it("hides Refresh button when not logged in", async () => {
+      mockSessionAs(null);
+      render(<BadgeToolbar handle="testuser" />);
+      await waitFor(() => {
+        expect(screen.queryByLabelText("Refresh badge data")).toBeNull();
+      });
     });
   });
 
+  /** Mock that returns session for the session call, and a custom response for refresh */
+  function mockSessionAndRefresh(handle: string, refreshResponse: Promise<{ ok: boolean }> | { ok: boolean } | Error) {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      if (typeof url === "string" && url.includes("/api/auth/session")) {
+        return new Response(JSON.stringify({ user: { login: handle } }));
+      }
+      if (refreshResponse instanceof Error) throw refreshResponse;
+      const result = refreshResponse instanceof Promise ? await refreshResponse : refreshResponse;
+      return new Response(null, { status: result.ok ? 200 : 500 });
+    });
+  }
+
   describe("refresh flow", () => {
     it("calls refresh API on click", async () => {
-      const mockFetch = vi.fn().mockResolvedValue({ ok: true });
-      vi.stubGlobal("fetch", mockFetch);
-
-      render(
-        <BadgeToolbar handle="myuser" isOwner={true} studioEnabled={false} />,
-      );
+      mockSessionAndRefresh("myuser", { ok: true });
+      render(<BadgeToolbar handle="myuser" />);
+      await waitFor(() => expect(screen.getByLabelText("Refresh badge data")).toBeDefined());
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Refresh badge data"));
       });
 
-      expect(mockFetch).toHaveBeenCalledWith("/api/refresh?handle=myuser", {
+      expect(globalThis.fetch).toHaveBeenCalledWith("/api/refresh?handle=myuser", {
         method: "POST",
       });
-      vi.unstubAllGlobals();
     });
 
     it("shows loading state during refresh", async () => {
-      const mockFetch = vi.fn(
-        () =>
-          new Promise<{ ok: boolean }>((resolve) =>
-            setTimeout(() => resolve({ ok: true }), 200),
-          ),
-      );
-      vi.stubGlobal("fetch", mockFetch);
+      mockSessionAndRefresh("testuser", new Promise((resolve) => setTimeout(() => resolve({ ok: true }), 200)));
+      render(<BadgeToolbar handle="testuser" />);
+      await waitFor(() => expect(screen.getByLabelText("Refresh badge data")).toBeDefined());
 
-      render(
-        <BadgeToolbar handle="testuser" isOwner={true} studioEnabled={false} />,
-      );
       fireEvent.click(screen.getByLabelText("Refresh badge data"));
-
       await waitFor(() => {
         expect(screen.getByText(/Refreshing/)).toBeDefined();
       });
-
-      vi.unstubAllGlobals();
     });
 
     it("shows error state on refresh failure", async () => {
-      const mockFetch = vi.fn().mockResolvedValue({ ok: false });
-      vi.stubGlobal("fetch", mockFetch);
-
-      render(
-        <BadgeToolbar handle="testuser" isOwner={true} studioEnabled={false} />,
-      );
+      mockSessionAndRefresh("testuser", { ok: false });
+      render(<BadgeToolbar handle="testuser" />);
+      await waitFor(() => expect(screen.getByLabelText("Refresh badge data")).toBeDefined());
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Refresh badge data"));
       });
 
       expect(screen.getByText("Failed")).toBeDefined();
-      vi.unstubAllGlobals();
     });
 
     it("shows error state on network failure", async () => {
-      const mockFetch = vi
-        .fn()
-        .mockRejectedValue(new Error("network error"));
-      vi.stubGlobal("fetch", mockFetch);
-
-      render(
-        <BadgeToolbar handle="testuser" isOwner={true} studioEnabled={false} />,
-      );
+      mockSessionAndRefresh("testuser", new Error("network error"));
+      render(<BadgeToolbar handle="testuser" />);
+      await waitFor(() => expect(screen.getByLabelText("Refresh badge data")).toBeDefined());
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Refresh badge data"));
       });
 
       expect(screen.getByText("Failed")).toBeDefined();
-      vi.unstubAllGlobals();
     });
 
     it("disables refresh button during loading", async () => {
-      const mockFetch = vi.fn(
-        () =>
-          new Promise<{ ok: boolean }>((resolve) =>
-            setTimeout(() => resolve({ ok: true }), 200),
-          ),
-      );
-      vi.stubGlobal("fetch", mockFetch);
+      mockSessionAndRefresh("testuser", new Promise((resolve) => setTimeout(() => resolve({ ok: true }), 200)));
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={true} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
+      await waitFor(() => expect(screen.getByLabelText("Refresh badge data")).toBeDefined());
       const refreshBtn = screen.getByLabelText("Refresh badge data");
       fireEvent.click(refreshBtn);
 
       await waitFor(() => {
         expect(refreshBtn.hasAttribute("disabled")).toBe(true);
       });
-
-      vi.unstubAllGlobals();
     });
 
     it("sets aria-busy during refresh loading", async () => {
-      const mockFetch = vi.fn(
-        () =>
-          new Promise<{ ok: boolean }>((resolve) =>
-            setTimeout(() => resolve({ ok: true }), 200),
-          ),
-      );
-      vi.stubGlobal("fetch", mockFetch);
+      mockSessionAndRefresh("testuser", new Promise((resolve) => setTimeout(() => resolve({ ok: true }), 200)));
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={true} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
+      await waitFor(() => expect(screen.getByLabelText("Refresh badge data")).toBeDefined());
       const refreshBtn = screen.getByLabelText("Refresh badge data");
       fireEvent.click(refreshBtn);
 
       await waitFor(() => {
         expect(refreshBtn.getAttribute("aria-busy")).toBe("true");
       });
-
-      vi.unstubAllGlobals();
     });
 
     it("encodes handle in refresh API URL", async () => {
-      const mockFetch = vi.fn().mockResolvedValue({ ok: true });
-      vi.stubGlobal("fetch", mockFetch);
+      mockSessionAndRefresh("user name", { ok: true });
 
       render(
-        <BadgeToolbar handle="user name" isOwner={true} studioEnabled={false} />,
+        <BadgeToolbar handle="user name" />,
       );
+      await waitFor(() => expect(screen.getByLabelText("Refresh badge data")).toBeDefined());
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Refresh badge data"));
       });
 
-      expect(mockFetch).toHaveBeenCalledWith(
+      expect(globalThis.fetch).toHaveBeenCalledWith(
         "/api/refresh?handle=user%20name",
         { method: "POST" },
       );
-      vi.unstubAllGlobals();
     });
   });
 
   describe("download flow", () => {
     it("shows Download text by default", () => {
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
       expect(screen.getByText("Download")).toBeDefined();
     });
@@ -253,7 +227,7 @@ describe("BadgeToolbar render", () => {
       vi.stubGlobal("fetch", mockFetch);
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
 
       await act(async () => {
@@ -273,7 +247,7 @@ describe("BadgeToolbar render", () => {
       vi.stubGlobal("fetch", mockFetch);
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
 
       await act(async () => {
@@ -303,7 +277,7 @@ describe("BadgeToolbar render", () => {
       vi.stubGlobal("fetch", mockFetch);
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
       const downloadBtn = screen.getByLabelText("Download badge as PNG");
       fireEvent.click(downloadBtn);
@@ -319,7 +293,7 @@ describe("BadgeToolbar render", () => {
   describe("share dropdown", () => {
     it("share button has aria-haspopup", () => {
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
       const shareBtn = screen.getByLabelText("Share badge");
       expect(shareBtn.getAttribute("aria-haspopup")).toBe("true");
@@ -327,7 +301,7 @@ describe("BadgeToolbar render", () => {
 
     it("share button has aria-expanded", () => {
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
       const shareBtn = screen.getByLabelText("Share badge");
       expect(shareBtn.getAttribute("aria-expanded")).toBeDefined();
@@ -335,7 +309,7 @@ describe("BadgeToolbar render", () => {
 
     it("clicking share button toggles dropdown", () => {
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
       const shareBtn = screen.getByLabelText("Share badge");
       fireEvent.click(shareBtn);
@@ -346,7 +320,7 @@ describe("BadgeToolbar render", () => {
     it("renders share menu when open", () => {
       dropdownOpen = true;
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
       expect(screen.getByRole("menu")).toBeDefined();
       expect(screen.getByText("Copy link")).toBeDefined();
@@ -355,7 +329,7 @@ describe("BadgeToolbar render", () => {
     it("share menu has aria-label", () => {
       dropdownOpen = true;
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
       expect(
         screen.getByRole("menu").getAttribute("aria-label"),
@@ -365,7 +339,7 @@ describe("BadgeToolbar render", () => {
     it("renders social share links (X, LinkedIn, Bluesky)", () => {
       dropdownOpen = true;
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
       const menuItems = screen.getAllByRole("menuitem");
       expect(menuItems.length).toBeGreaterThanOrEqual(4); // X, LinkedIn, Bluesky, Copy link
@@ -374,7 +348,7 @@ describe("BadgeToolbar render", () => {
     it("social links open in new tab", () => {
       dropdownOpen = true;
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
       const links = screen
         .getAllByRole("menuitem")
@@ -396,7 +370,7 @@ describe("BadgeToolbar render", () => {
       const { trackEvent } = await import("@/lib/analytics/posthog");
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
 
       await act(async () => {
@@ -414,7 +388,7 @@ describe("BadgeToolbar render", () => {
       Object.assign(navigator, { clipboard: { writeText } });
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
 
       await act(async () => {
@@ -435,7 +409,7 @@ describe("BadgeToolbar render", () => {
       });
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
 
       await act(async () => {
@@ -451,7 +425,7 @@ describe("BadgeToolbar render", () => {
     it("X link includes correct intent URL with handle", () => {
       dropdownOpen = true;
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
       const links = screen.getAllByRole("menuitem").filter((el) => el.tagName === "A") as HTMLAnchorElement[];
       const xLink = links.find((l) => l.href.includes("x.com"));
@@ -462,7 +436,7 @@ describe("BadgeToolbar render", () => {
     it("LinkedIn link includes correct share URL", () => {
       dropdownOpen = true;
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
       const links = screen.getAllByRole("menuitem").filter((el) => el.tagName === "A") as HTMLAnchorElement[];
       const linkedinLink = links.find((l) => l.href.includes("linkedin.com"));
@@ -473,7 +447,7 @@ describe("BadgeToolbar render", () => {
     it("Bluesky link includes compose intent", () => {
       dropdownOpen = true;
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
       const links = screen.getAllByRole("menuitem").filter((el) => el.tagName === "A") as HTMLAnchorElement[];
       const bskyLink = links.find((l) => l.href.includes("bsky.app"));
@@ -486,7 +460,7 @@ describe("BadgeToolbar render", () => {
       const { trackEvent } = await import("@/lib/analytics/posthog");
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
       const links = screen.getAllByRole("menuitem").filter((el) => el.tagName === "A") as HTMLAnchorElement[];
       const xLink = links.find((l) => l.href.includes("x.com"));
@@ -502,7 +476,7 @@ describe("BadgeToolbar render", () => {
       const { trackEvent } = await import("@/lib/analytics/posthog");
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
       const links = screen.getAllByRole("menuitem").filter((el) => el.tagName === "A") as HTMLAnchorElement[];
       const linkedinLink = links.find((l) => l.href.includes("linkedin.com"));
@@ -518,7 +492,7 @@ describe("BadgeToolbar render", () => {
       const { trackEvent } = await import("@/lib/analytics/posthog");
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
       const links = screen.getAllByRole("menuitem").filter((el) => el.tagName === "A") as HTMLAnchorElement[];
       const bskyLink = links.find((l) => l.href.includes("bsky.app"));
@@ -535,7 +509,7 @@ describe("BadgeToolbar render", () => {
       Object.assign(navigator, { clipboard: { writeText } });
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
 
       await act(async () => {
@@ -556,7 +530,7 @@ describe("BadgeToolbar render", () => {
       });
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
 
       // Should not throw
@@ -602,7 +576,7 @@ describe("BadgeToolbar render", () => {
       const appendChildSpy = vi.spyOn(document.body, "appendChild");
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
 
       await act(async () => {
@@ -660,7 +634,7 @@ describe("BadgeToolbar render", () => {
       const appendChildSpy = vi.spyOn(document.body, "appendChild");
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
 
       await act(async () => {
@@ -702,7 +676,7 @@ describe("BadgeToolbar render", () => {
       const appendChildSpy = vi.spyOn(document.body, "appendChild");
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
 
       await act(async () => {
@@ -734,7 +708,7 @@ describe("BadgeToolbar render", () => {
       const appendChildSpy = vi.spyOn(document.body, "appendChild");
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
 
       await act(async () => {
@@ -762,7 +736,7 @@ describe("BadgeToolbar render", () => {
       const appendChildSpy = vi.spyOn(document.body, "appendChild");
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
 
       await act(async () => {
@@ -798,7 +772,7 @@ describe("BadgeToolbar render", () => {
       vi.stubGlobal("fetch", mockFetch);
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
       fireEvent.click(screen.getByLabelText("Download badge as PNG"));
 
@@ -826,7 +800,7 @@ describe("BadgeToolbar render", () => {
       vi.stubGlobal("fetch", mockFetch);
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
       const btn = screen.getByLabelText("Download badge as PNG");
       fireEvent.click(btn);
@@ -841,8 +815,7 @@ describe("BadgeToolbar render", () => {
 
   describe("refresh success state", () => {
     it("shows Refreshed! text on success", async () => {
-      const mockFetch = vi.fn().mockResolvedValue({ ok: true });
-      vi.stubGlobal("fetch", mockFetch);
+      mockSessionAndRefresh("testuser", { ok: true });
 
       // Prevent reload
       Object.defineProperty(window, "location", {
@@ -851,21 +824,19 @@ describe("BadgeToolbar render", () => {
       });
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={true} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
+      await waitFor(() => expect(screen.getByLabelText("Refresh badge data")).toBeDefined());
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Refresh badge data"));
       });
 
       expect(screen.getByText("Refreshed!")).toBeDefined();
-
-      vi.unstubAllGlobals();
     });
 
     it("disables refresh button after success", async () => {
-      const mockFetch = vi.fn().mockResolvedValue({ ok: true });
-      vi.stubGlobal("fetch", mockFetch);
+      mockSessionAndRefresh("testuser", { ok: true });
 
       Object.defineProperty(window, "location", {
         value: { ...window.location, reload: vi.fn() },
@@ -873,8 +844,9 @@ describe("BadgeToolbar render", () => {
       });
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={true} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
+      await waitFor(() => expect(screen.getByLabelText("Refresh badge data")).toBeDefined());
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Refresh badge data"));
@@ -882,18 +854,6 @@ describe("BadgeToolbar render", () => {
 
       const btn = screen.getByLabelText("Refresh badge data");
       expect(btn.hasAttribute("disabled")).toBe(true);
-
-      vi.unstubAllGlobals();
-    });
-  });
-
-  describe("customize link", () => {
-    it("customize link points to /studio", () => {
-      render(
-        <BadgeToolbar handle="testuser" isOwner={true} studioEnabled={true} />,
-      );
-      const link = screen.getByText("Customize").closest("a");
-      expect(link?.getAttribute("href")).toBe("/studio");
     });
   });
 
@@ -911,7 +871,7 @@ describe("BadgeToolbar render", () => {
       });
 
       const { rerender } = render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
 
       await act(async () => {
@@ -920,7 +880,7 @@ describe("BadgeToolbar render", () => {
 
       // Force re-render with dropdown still open to see Copied! text
       rerender(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
 
       expect(screen.getByText("Copied!")).toBeDefined();
@@ -929,19 +889,20 @@ describe("BadgeToolbar render", () => {
 
   describe("refresh error resets to idle after timeout", () => {
     it("returns to idle state after error timeout", async () => {
-      vi.useFakeTimers();
-      const mockFetch = vi.fn().mockResolvedValue({ ok: false });
-      vi.stubGlobal("fetch", mockFetch);
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      mockSessionAndRefresh("testuser", { ok: false });
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={true} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
+
+      await waitFor(() => expect(screen.getByLabelText("Refresh badge data")).toBeDefined());
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Refresh badge data"));
       });
 
-      expect(screen.getByText("Failed")).toBeDefined();
+      await waitFor(() => expect(screen.getByText("Failed")).toBeDefined());
 
       // After 3000ms, status resets to idle
       await act(async () => {
@@ -951,23 +912,29 @@ describe("BadgeToolbar render", () => {
       expect(screen.getByText("Refresh")).toBeDefined();
 
       vi.useRealTimers();
-      vi.unstubAllGlobals();
     });
 
     it("returns to idle after network error timeout", async () => {
-      vi.useFakeTimers();
-      const mockFetch = vi.fn().mockRejectedValue(new Error("network"));
-      vi.stubGlobal("fetch", mockFetch);
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      // Session succeeds, but refresh rejects
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+        if (typeof url === "string" && url.includes("/api/auth/session")) {
+          return new Response(JSON.stringify({ user: { login: "testuser" } }));
+        }
+        throw new Error("network");
+      });
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={true} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
+
+      await waitFor(() => expect(screen.getByLabelText("Refresh badge data")).toBeDefined());
 
       await act(async () => {
         fireEvent.click(screen.getByLabelText("Refresh badge data"));
       });
 
-      expect(screen.getByText("Failed")).toBeDefined();
+      await waitFor(() => expect(screen.getByText("Failed")).toBeDefined());
 
       await act(async () => {
         vi.advanceTimersByTime(3000);
@@ -976,7 +943,6 @@ describe("BadgeToolbar render", () => {
       expect(screen.getByText("Refresh")).toBeDefined();
 
       vi.useRealTimers();
-      vi.unstubAllGlobals();
     });
   });
 
@@ -991,11 +957,15 @@ describe("BadgeToolbar render", () => {
       </svg>`;
 
       let capturedSrc = "";
-      const mockFetch = vi.fn().mockResolvedValue({
-        ok: true,
-        text: () => Promise.resolve(svgWithAnimations),
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+        if (typeof url === "string" && url.includes("/api/auth/session")) {
+          return new Response(JSON.stringify({ user: { login: "testuser" } }));
+        }
+        return {
+          ok: true,
+          text: () => Promise.resolve(svgWithAnimations),
+        } as Response;
       });
-      vi.stubGlobal("fetch", mockFetch);
 
       // Use class-based Image mock to avoid vitest warning.
       // Use queueMicrotask (not setTimeout) so the onerror fires within the
@@ -1021,7 +991,7 @@ describe("BadgeToolbar render", () => {
       vi.stubGlobal("Image", MockImage);
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
 
       await act(async () => {
@@ -1038,18 +1008,21 @@ describe("BadgeToolbar render", () => {
       expect(decodedSvg).toContain('opacity="1"'); // opacity="0" replaced
 
       vi.stubGlobal("Image", origImage);
-      vi.unstubAllGlobals();
     });
   });
 
   describe("successful PNG download (full canvas path)", () => {
     it("creates a PNG blob and downloads it", async () => {
       const svgText = '<svg><rect width="100" height="100"/></svg>';
-      const mockFetch = vi.fn().mockResolvedValue({
-        ok: true,
-        text: () => Promise.resolve(svgText),
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+        if (typeof url === "string" && url.includes("/api/auth/session")) {
+          return new Response(JSON.stringify({ user: { login: "testuser" } }));
+        }
+        return {
+          ok: true,
+          text: () => Promise.resolve(svgText),
+        } as Response;
       });
-      vi.stubGlobal("fetch", mockFetch);
 
       const mockBlob = new Blob(["png-data"], { type: "image/png" });
       const mockCtx = { scale: vi.fn(), drawImage: vi.fn() };
@@ -1097,7 +1070,7 @@ describe("BadgeToolbar render", () => {
       const removeChildSpy = vi.spyOn(document.body, "removeChild");
 
       render(
-        <BadgeToolbar handle="testuser" isOwner={false} studioEnabled={false} />,
+        <BadgeToolbar handle="testuser" />,
       );
 
       await act(async () => {
@@ -1126,7 +1099,6 @@ describe("BadgeToolbar render", () => {
       appendChildSpy.mockRestore();
       removeChildSpy.mockRestore();
       vi.stubGlobal("Image", origImage);
-      vi.unstubAllGlobals();
     });
   });
 });

--- a/apps/web/components/BadgeToolbar.test.tsx
+++ b/apps/web/components/BadgeToolbar.test.tsx
@@ -91,16 +91,6 @@ describe("BadgeToolbar", () => {
     });
   });
 
-  describe("customize link", () => {
-    it("links to /studio", () => {
-      expect(SOURCE).toContain('href="/studio"');
-    });
-
-    it("is gated behind studioEnabled", () => {
-      expect(SOURCE).toContain("studioEnabled");
-    });
-  });
-
   describe("dropdown behavior (via useDropdownMenu hook)", () => {
     it("uses useRef for dropdown container", () => {
       expect(SOURCE).toContain("useRef");

--- a/apps/web/components/BadgeToolbar.tsx
+++ b/apps/web/components/BadgeToolbar.tsx
@@ -1,21 +1,26 @@
 "use client";
 
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import { trackEvent } from "@/lib/analytics/posthog";
 import { useDropdownMenu } from "@/hooks/useDropdownMenu";
-import Link from "next/link";
 
 interface BadgeToolbarProps {
   handle: string;
-  isOwner: boolean;
-  studioEnabled: boolean;
 }
 
 export function BadgeToolbar({
   handle,
-  isOwner,
-  studioEnabled,
 }: BadgeToolbarProps) {
+  const [isOwner, setIsOwner] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/auth/session")
+      .then((res) => res.json())
+      .then((data: { user: { login: string } | null }) => {
+        setIsOwner(data.user?.login === handle);
+      })
+      .catch(() => setIsOwner(false));
+  }, [handle]);
   const [refreshStatus, setRefreshStatus] = useState<
     "idle" | "loading" | "success" | "error"
   >("idle");
@@ -326,24 +331,6 @@ export function BadgeToolbar({
         {downloadStatus === "loading" ? "Downloading\u2026" : "Download"}
       </button>
 
-      {/* Customize (owner + studio enabled) */}
-      {isOwner && studioEnabled && (
-        <Link href="/studio" className={btnClass}>
-          <svg
-            className="w-3.5 h-3.5"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M12 3l1.912 5.813h6.088l-4.956 3.574 1.912 5.813L12 14.626 7.044 18.2l1.912-5.813L4 8.813h6.088z" />
-          </svg>
-          Customize
-        </Link>
-      )}
     </div>
   );
 }

--- a/apps/web/components/SharePageShortcuts.render.test.tsx
+++ b/apps/web/components/SharePageShortcuts.render.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, cleanup, waitFor } from "@testing-library/react";
 import { SharePageShortcuts } from "./SharePageShortcuts";
 
 const mockRegister = vi.fn(() => vi.fn());
@@ -11,9 +11,25 @@ vi.mock("./KeyboardShortcutsListener", () => ({
   }),
 }));
 
+/** Mock session fetch — defaults to no login. */
+function mockSessionAs(login: string | null) {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+    if (typeof url === "string" && url.includes("/api/auth/session")) {
+      return new Response(JSON.stringify({ user: login ? { login } : null }));
+    }
+    // Default passthrough for other fetches (refresh, etc.)
+    return new Response("ok");
+  });
+}
+
+beforeEach(() => {
+  mockSessionAs(null); // default: not logged in
+});
+
 afterEach(() => {
   cleanup();
   mockRegister.mockClear();
+  vi.restoreAllMocks();
 });
 
 describe("SharePageShortcuts", () => {
@@ -22,7 +38,7 @@ describe("SharePageShortcuts", () => {
       <SharePageShortcuts
         embedMarkdown="![badge](url)"
         handle="testuser"
-        isOwner={true}
+       
       />,
     );
     expect(container.innerHTML).toBe("");
@@ -33,7 +49,7 @@ describe("SharePageShortcuts", () => {
       <SharePageShortcuts
         embedMarkdown="![badge](url)"
         handle="testuser"
-        isOwner={true}
+       
       />,
     );
     expect(mockRegister).toHaveBeenCalledWith("share", expect.any(Function));
@@ -47,7 +63,7 @@ describe("SharePageShortcuts", () => {
       <SharePageShortcuts
         embedMarkdown="![badge](url)"
         handle="testuser"
-        isOwner={true}
+       
       />,
     );
 
@@ -72,7 +88,7 @@ describe("SharePageShortcuts", () => {
       <SharePageShortcuts
         embedMarkdown="![badge](url)"
         handle="testuser"
-        isOwner={true}
+       
       />,
     );
 
@@ -81,42 +97,71 @@ describe("SharePageShortcuts", () => {
     expect(clickSpy).toHaveBeenCalled();
   });
 
-  it("handler handles refresh-badge shortcut when owner", () => {
-    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
-    vi.stubGlobal("fetch", mockFetch);
+  it("handler handles refresh-badge shortcut when owner", async () => {
+    // Mock session returning matching handle + refresh returning ok
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (url, init) => {
+      if (typeof url === "string" && url.includes("/api/auth/session")) {
+        return new Response(JSON.stringify({ user: { login: "testuser" } }));
+      }
+      return new Response("ok");
+    });
 
     render(
       <SharePageShortcuts
         embedMarkdown="![badge](url)"
         handle="testuser"
-        isOwner={true}
       />,
     );
 
-    const handler = (mockRegister.mock.calls as unknown[][])[0]![1] as (id: string) => void;
+    // Wait for session fetch to resolve and handler to be re-registered with isOwner=true
+    await waitFor(() => {
+      expect(mockRegister.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    // Get the latest handler (registered after isOwner became true)
+    const lastCall = mockRegister.mock.calls[mockRegister.mock.calls.length - 1] as unknown[];
+    const handler = lastCall[1] as (id: string) => void;
     handler("refresh-badge");
-    expect(mockFetch).toHaveBeenCalledWith(
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
       "/api/refresh?handle=testuser",
       { method: "POST" },
     );
-    vi.unstubAllGlobals();
   });
 
-  it("handler does not refresh when not owner", () => {
-    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
-    vi.stubGlobal("fetch", mockFetch);
+  it("handler does not refresh when not owner", async () => {
+    // Mock session returning a different handle (not the owner)
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      if (typeof url === "string" && url.includes("/api/auth/session")) {
+        return new Response(JSON.stringify({ user: { login: "otheruser" } }));
+      }
+      return new Response("ok");
+    });
 
     render(
       <SharePageShortcuts
         embedMarkdown="![badge](url)"
         handle="testuser"
-        isOwner={false}
       />,
     );
 
+    // Wait for the session fetch to complete (isOwner stays false since handles don't match,
+    // so the handler is not re-registered — just wait for the fetch to have been called)
+    await waitFor(() => {
+      const sessionCalls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (call: unknown[]) => typeof call[0] === "string" && (call[0] as string).includes("/api/auth/session"),
+      );
+      expect(sessionCalls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    // Get the handler (only registered once since isOwner stayed false)
     const handler = (mockRegister.mock.calls as unknown[][])[0]![1] as (id: string) => void;
     handler("refresh-badge");
-    expect(mockFetch).not.toHaveBeenCalled();
-    vi.unstubAllGlobals();
+
+    // Fetch should only have been called for the session, NOT for the refresh
+    const refreshCalls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (call: unknown[]) => typeof call[0] === "string" && (call[0] as string).includes("/api/refresh"),
+    );
+    expect(refreshCalls).toHaveLength(0);
   });
 });

--- a/apps/web/components/SharePageShortcuts.tsx
+++ b/apps/web/components/SharePageShortcuts.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { useEffect, useCallback } from "react";
+import { useEffect, useCallback, useState } from "react";
 import { useKeyboardShortcutsContext } from "./KeyboardShortcutsListener";
 
 interface SharePageShortcutsProps {
   embedMarkdown: string;
   handle: string;
-  isOwner: boolean;
 }
 
 /**
@@ -16,8 +15,17 @@ interface SharePageShortcutsProps {
 export function SharePageShortcuts({
   embedMarkdown,
   handle,
-  isOwner,
 }: SharePageShortcutsProps) {
+  const [isOwner, setIsOwner] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/auth/session")
+      .then((res) => res.json())
+      .then((data: { user: { login: string } | null }) => {
+        setIsOwner(data.user?.login === handle);
+      })
+      .catch(() => setIsOwner(false));
+  }, [handle]);
   const { registerPageShortcuts } = useKeyboardShortcutsContext();
 
   const handler = useCallback(


### PR DESCRIPTION
## Summary

Fixes #647 — `isOwner` was hardcoded to `false` in the server component, hiding the Refresh button for logged-in users viewing their own badge. Both `BadgeToolbar` and `SharePageShortcuts` now determine ownership via client-side `/api/auth/session` fetch, matching the pattern used by `SharePageOwnerContent`.

Also removes the Customize button (Studio not ready for release).

## Test plan
- [x] 6,609 tests pass
- [x] Typecheck clean
- [x] Lint clean (1 warning, non-blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)