### PR TITLE
hotfix: update scoring explainer video

### DIFF
--- a/apps/web/app/about/scoring/page.tsx
+++ b/apps/web/app/about/scoring/page.tsx
@@ -131,7 +131,7 @@ export default function ScoringMethodologyPage() {
               </h2>
             </div>
             <LiteYouTubeEmbed
-              videoId="hJfXESKmTSo"
+              videoId="wcXXGn3JYyw"
               title="How Chapa Scores Developer Impact"
             />
             <p className="text-text-secondary text-sm mt-2">


### PR DESCRIPTION
## Summary
- Replace NotebookLM explainer video with regenerated version covering v6.1 scoring methodology

One-line change: `videoId` on `/about/scoring` page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)