### PR TITLE
hotfix: restore OG image text rendering

### DIFF
--- a/apps/web/app/og-image/route.ts
+++ b/apps/web/app/og-image/route.ts
@@ -99,10 +99,10 @@ function renderOgSvg(): string {
   <rect width="${W}" height="${H}" fill="${bg}"/>
 
   <!-- Logo: Chapa_ — centered -->
-  <text x="${W / 2}" y="200" fill="${textPrimary}" font-family="JetBrains Mono, monospace" font-size="88" font-weight="800" text-anchor="middle" letter-spacing="-3">Chapa<tspan fill="${accent}">_</tspan></text>
+  <text x="${W / 2}" y="200" fill="${textPrimary}" font-family="JetBrains Mono, monospace" font-size="88" font-weight="700" text-anchor="middle" letter-spacing="-3">Chapa<tspan fill="${accent}">_</tspan></text>
 
   <!-- Tagline — centered -->
-  <text x="${W / 2}" y="260" fill="${textSecondary}" font-family="Plus Jakarta Sans, sans-serif" font-size="24" font-weight="500" text-anchor="middle">Developer Impact, Decoded</text>
+  <text x="${W / 2}" y="260" fill="${textSecondary}" font-family="Plus Jakarta Sans, sans-serif" font-size="24" font-weight="600" text-anchor="middle">Developer Impact, Decoded</text>
 
   <!-- Heatmap grid — centered, full year width -->
   ${heatmapSvg}

--- a/apps/web/lib/render/svg-to-png.test.ts
+++ b/apps/web/lib/render/svg-to-png.test.ts
@@ -52,6 +52,14 @@ describe("getFontPaths", () => {
     expect(names).toContain("JetBrainsMono-Regular.ttf");
     expect(names).toContain("JetBrainsMono-Bold.ttf");
   });
+
+  it("resolves to font files that exist on disk", async () => {
+    const { existsSync } = await import("fs");
+    const paths = getFontPaths();
+    for (const p of paths) {
+      expect(existsSync(p), `font file should exist: ${p}`).toBe(true);
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/lib/render/svg-to-png.ts
+++ b/apps/web/lib/render/svg-to-png.ts
@@ -6,6 +6,7 @@
  */
 
 import { Resvg } from "@resvg/resvg-js";
+import { existsSync } from "fs";
 import { join } from "path";
 
 /**
@@ -25,12 +26,17 @@ const FONT_FILES = [
 /**
  * Resolve absolute paths to the bundled TTF font files.
  *
- * Uses `path.join(__dirname, "fonts", ...)` so Next.js output file tracing
- * can detect the dependency and include the font files in the serverless
- * function bundle on Vercel.
+ * Turbopack rewrites `__dirname` to the compiled chunk directory
+ * (`.next/server/chunks/`), where the font files don't exist. We use
+ * `process.cwd()` instead, which resolves to the app root (`apps/web`)
+ * in Next.js dev/production. For test runners invoked from the monorepo
+ * root, we fall back to `apps/web/` prefixed paths.
  */
 export function getFontPaths(): string[] {
-  return FONT_FILES.map((f) => join(__dirname, "fonts", f));
+  const appRelative = join(process.cwd(), "lib", "render", "fonts");
+  const monoRelative = join(process.cwd(), "apps", "web", "lib", "render", "fonts");
+  const fontsDir = existsSync(appRelative) ? appRelative : monoRelative;
+  return FONT_FILES.map((f) => join(fontsDir, f));
 }
 
 /**

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -89,6 +89,11 @@ const defaultHeaders = [
 const nextConfig: NextConfig = {
   serverExternalPackages: ["@resvg/resvg-js"],
   transpilePackages: ["@chapa/shared"],
+  outputFileTracingIncludes: {
+    "/og-image": ["./lib/render/fonts/**/*.ttf"],
+    "/u/[handle]/og-image": ["./lib/render/fonts/**/*.ttf"],
+    "/u/[handle]/badge.svg": ["./lib/render/fonts/**/*.ttf"],
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary
- Fix font path resolution for SVG-to-PNG conversion — Turbopack rewrites `__dirname` to `.next/server/chunks/` where fonts don't exist, causing all text to silently disappear from the social share card
- Fix font-weight mismatches (800→700, 500→600) to match bundled TTF weights
- Add `outputFileTracingIncludes` so Vercel bundles the font files

## Risk
Low — rendering-only fix. No logic, auth, scoring, or data changes.

## Test plan
- [x] All 6655 tests pass
- [x] Typecheck + lint clean
- [x] Verified locally: `Chapa_` logo, tagline, heatmap, and URL all render in the OG PNG

🤖 Generated with [Claude Code](https://claude.com/claude-code)