### PR TITLE
fix(refresh): use dbReplaceSnapshot for same-day snapshot updates

### DIFF
--- a/apps/web/app/api/refresh/route.test.ts
+++ b/apps/web/app/api/refresh/route.test.ts
@@ -43,7 +43,7 @@ vi.mock("@/lib/history/snapshot", () => ({
 }));
 
 vi.mock("@/lib/db/snapshots", () => ({
-  dbInsertSnapshot: vi.fn(() => Promise.resolve(true)),
+  dbReplaceSnapshot: vi.fn(() => Promise.resolve(true)),
 }));
 
 vi.mock("@/lib/cache/snapshot-cache", () => ({
@@ -67,7 +67,7 @@ import { requireSession } from "@/lib/auth/require-session";
 import { cacheDel, rateLimit } from "@/lib/cache/redis";
 import { getStats } from "@/lib/github/client";
 import { invalidateHistoryCache } from "@/lib/history/history";
-import { dbInsertSnapshot } from "@/lib/db/snapshots";
+import { dbReplaceSnapshot } from "@/lib/db/snapshots";
 import { updateSnapshotCache } from "@/lib/cache/snapshot-cache";
 import { captureServerError } from "@/lib/analytics/server-errors";
 import { revalidatePath } from "next/cache";
@@ -282,7 +282,7 @@ describe("POST /api/refresh", () => {
       fetchedAt: new Date().toISOString(),
     });
 
-    vi.mocked(dbInsertSnapshot).mockReturnValue(deferredPromise);
+    vi.mocked(dbReplaceSnapshot).mockReturnValue(deferredPromise);
 
     const res = await POST(makeRequest("testuser"));
     expect(res.status).toBe(200);
@@ -325,7 +325,7 @@ describe("POST /api/refresh", () => {
       fetchedAt: new Date().toISOString(),
     });
 
-    vi.mocked(dbInsertSnapshot).mockReturnValue(deferredPromise);
+    vi.mocked(dbReplaceSnapshot).mockReturnValue(deferredPromise);
 
     const res = await POST(makeRequest("testuser"));
     expect(res.status).toBe(200);
@@ -360,7 +360,7 @@ describe("POST /api/refresh", () => {
     });
 
     // Make the insert reject — the .catch(() => {}) should swallow the error
-    vi.mocked(dbInsertSnapshot).mockRejectedValue(new Error("DB down"));
+    vi.mocked(dbReplaceSnapshot).mockRejectedValue(new Error("DB down"));
 
     const res = await POST(makeRequest("testuser"));
     expect(res.status).toBe(200);

--- a/apps/web/app/api/refresh/route.ts
+++ b/apps/web/app/api/refresh/route.ts
@@ -5,7 +5,7 @@ import { getStats } from "@/lib/github/client";
 import { computeImpactV4 } from "@/lib/impact/v4";
 import { isValidHandle } from "@/lib/validation";
 import { buildSnapshot } from "@/lib/history/snapshot";
-import { dbInsertSnapshot } from "@/lib/db/snapshots";
+import { dbReplaceSnapshot } from "@/lib/db/snapshots";
 import { updateSnapshotCache } from "@/lib/cache/snapshot-cache";
 import { invalidateHistoryCache } from "@/lib/history/history";
 import { captureServerError } from "@/lib/analytics/server-errors";
@@ -75,11 +75,14 @@ export async function POST(request: NextRequest): Promise<Response> {
 
     const impact = computeImpactV4(stats);
 
-    // Record daily metrics snapshot (fire-and-forget, deduplicates by date)
+    // Replace today's snapshot — a user-initiated refresh means the score has
+    // legitimately changed (e.g. after a scoring fix). dbReplaceSnapshot uses
+    // UPSERT so it overwrites the existing same-day row instead of silently
+    // skipping via ON CONFLICT DO NOTHING.
     const snapshot = buildSnapshot(stats, impact);
-    dbInsertSnapshot(handle, snapshot)
-      .then((inserted) => {
-        if (inserted) updateSnapshotCache(handle, snapshot);
+    dbReplaceSnapshot(handle, snapshot)
+      .then((replaced) => {
+        if (replaced) updateSnapshotCache(handle, snapshot);
       })
       .catch(() => {});
 


### PR DESCRIPTION
## Summary
- Refresh endpoint now uses `dbReplaceSnapshot` (UPSERT) instead of `dbInsertSnapshot` (ON CONFLICT DO NOTHING)
- This allows corrected scores from user-initiated refreshes to overwrite today's stale snapshot
- Fixes `/api/profile/:handle` returning old data to external consumers (portfolio sites)

## Test plan
- [x] All 6879 tests pass
- [x] TypeScript + ESLint clean
- [ ] After deploy: visit share page while logged in → refresh fires → `/api/profile/juan294` returns updated dimensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)