### PR TITLE
hotfix: recompute craft scores on recalculate (v2.7.1)

### DIFF
--- a/apps/web/app/api/recalculate/route.test.ts
+++ b/apps/web/app/api/recalculate/route.test.ts
@@ -10,7 +10,8 @@ const {
   mockRateLimit,
   mockGetStats,
   mockComputeImpactV6,
-  mockDbGetToolInsights,
+  mockDbRecomputeCraft,
+  mockUpdateCraftCache,
   mockBuildSnapshot,
   mockDbReplaceSnapshot,
   mockUpdateSnapshotCache,
@@ -20,7 +21,8 @@ const {
   mockRateLimit: vi.fn(),
   mockGetStats: vi.fn(),
   mockComputeImpactV6: vi.fn(),
-  mockDbGetToolInsights: vi.fn(),
+  mockDbRecomputeCraft: vi.fn(),
+  mockUpdateCraftCache: vi.fn(),
   mockBuildSnapshot: vi.fn(),
   mockDbReplaceSnapshot: vi.fn(),
   mockUpdateSnapshotCache: vi.fn(),
@@ -43,8 +45,12 @@ vi.mock("@/lib/impact/v6", () => ({
   computeImpactV6: mockComputeImpactV6,
 }));
 
+vi.mock("@/lib/db/tool-insights", () => ({
+  dbRecomputeCraft: mockDbRecomputeCraft,
+}));
+
 vi.mock("@/lib/cache/craft-cache", () => ({
-  getCachedCraftScore: mockDbGetToolInsights,
+  updateCraftCache: mockUpdateCraftCache,
 }));
 
 vi.mock("@/lib/history/snapshot", () => ({
@@ -119,10 +125,11 @@ beforeEach(() => {
   mockRateLimit.mockResolvedValue({ allowed: true, current: 1, limit: 20 });
   mockGetStats.mockResolvedValue(makeStats());
   mockComputeImpactV6.mockReturnValue(makeImpact());
-  mockDbGetToolInsights.mockResolvedValue({
+  mockDbRecomputeCraft.mockResolvedValue({
     craftScore: 69,
     tier: "Expert",
   });
+  mockUpdateCraftCache.mockResolvedValue(undefined);
   mockBuildSnapshot.mockReturnValue({ date: "2026-03-08" });
   mockDbReplaceSnapshot.mockResolvedValue(true);
   mockUpdateSnapshotCache.mockResolvedValue(undefined);
@@ -194,7 +201,7 @@ describe("POST /api/recalculate", () => {
   });
 
   it("works without craft score (no insights uploaded)", async () => {
-    mockDbGetToolInsights.mockResolvedValue(null);
+    mockDbRecomputeCraft.mockResolvedValue(null);
 
     const resp = await POST(makeRequest());
     const body = await resp.json();
@@ -237,7 +244,7 @@ describe("POST /api/recalculate", () => {
     await POST(makeRequest());
 
     expect(mockGetStats).toHaveBeenCalledWith("testuser", undefined);
-    expect(mockDbGetToolInsights).toHaveBeenCalledWith("testuser");
+    expect(mockDbRecomputeCraft).toHaveBeenCalledWith("testuser");
     expect(mockDbReplaceSnapshot).toHaveBeenCalledWith(
       "testuser",
       expect.any(Object),
@@ -245,7 +252,7 @@ describe("POST /api/recalculate", () => {
   });
 
   it("passes craft score to computeImpactV6", async () => {
-    mockDbGetToolInsights.mockResolvedValue({
+    mockDbRecomputeCraft.mockResolvedValue({
       craftScore: 69,
       tier: "Expert",
     });
@@ -259,7 +266,7 @@ describe("POST /api/recalculate", () => {
   });
 
   it("passes undefined craft score when no insights exist", async () => {
-    mockDbGetToolInsights.mockResolvedValue(null);
+    mockDbRecomputeCraft.mockResolvedValue(null);
 
     await POST(makeRequest());
 

--- a/apps/web/app/api/recalculate/route.ts
+++ b/apps/web/app/api/recalculate/route.ts
@@ -3,7 +3,8 @@ import { resolveRequestAuth } from "@/lib/auth/resolve-request-auth";
 import { rateLimit } from "@/lib/cache/redis";
 import { getStats } from "@/lib/github/client";
 import { computeImpactV6 } from "@/lib/impact/v6";
-import { getCachedCraftScore } from "@/lib/cache/craft-cache";
+import { dbRecomputeCraft } from "@/lib/db/tool-insights";
+import { updateCraftCache } from "@/lib/cache/craft-cache";
 import { buildSnapshot } from "@/lib/history/snapshot";
 import { dbReplaceSnapshot } from "@/lib/db/snapshots";
 import {
@@ -14,12 +15,12 @@ import { getTier } from "@/lib/impact/utils";
 /**
  * POST /api/recalculate — Force-recalculate impact score.
  *
- * Fetches stats (cached or fresh), gets craft score from DB,
- * computes fresh impact, replaces today's snapshot, and returns
- * the new score + dimensions.
+ * Fetches stats (cached or fresh), recomputes craft score from stored
+ * raw insights data (applying the current formula), computes fresh
+ * impact, replaces today's snapshot, and returns the new score.
  *
- * Use after any deliberate user action that changes the score
- * (insights upload, platform connect/disconnect).
+ * Craft recomputation ensures formula changes are retroactively applied
+ * without requiring the user to re-upload their insights report.
  *
  * Auth: Bearer token (CLI token or GitHub PAT) or session cookie.
  * Rate limited: 20 requests/handle/hour.
@@ -41,10 +42,12 @@ export async function POST(request: NextRequest): Promise<Response> {
     );
   }
 
-  // Fetch stats and craft score in parallel (independent operations)
+  // Fetch stats and recompute craft from stored raw data in parallel.
+  // dbRecomputeCraft reads raw_data from DB, runs computeCraftScore()
+  // with the current formula, and upserts the updated scores back.
   const [stats, craftResult] = await Promise.all([
     getStats(handle, auth.token),
-    getCachedCraftScore(handle),
+    dbRecomputeCraft(handle),
   ]);
 
   if (!stats) {
@@ -54,13 +57,16 @@ export async function POST(request: NextRequest): Promise<Response> {
     );
   }
 
-  // Compute fresh impact with craft included
+  // Update craft cache so subsequent badge views use the recomputed score
+  if (craftResult) {
+    updateCraftCache(handle, craftResult).catch(() => {});
+  }
+
+  // Compute fresh impact with recomputed craft
   const impact = computeImpactV6(stats, craftResult?.craftScore ?? undefined);
 
   // For recalculate: use the RAW adjusted composite, NOT EMA-smoothed.
   // This is a deliberate action — the user wants to see the actual score.
-  // The raw adjustedComposite already has recency + confidence applied,
-  // just no EMA dampening.
   impact.tier = getTier(impact.adjustedComposite);
 
   // Build snapshot and REPLACE today's (not insert-ignore)
@@ -68,7 +74,6 @@ export async function POST(request: NextRequest): Promise<Response> {
   const replaced = await dbReplaceSnapshot(handle, snapshot);
 
   if (replaced) {
-    // Update Redis cache so subsequent badge views use the new snapshot
     await updateSnapshotCache(handle, snapshot);
   }
 

--- a/apps/web/lib/db/tool-insights.ts
+++ b/apps/web/lib/db/tool-insights.ts
@@ -1,5 +1,6 @@
 import { getSupabase } from "./supabase";
 import { parseRow } from "./parse-row";
+import { computeCraftScore } from "@/lib/insights/scoring";
 import type { CraftResult, CraftTier, InsightsUpload, InsightsTool } from "@chapa/shared";
 
 // ---------------------------------------------------------------------------
@@ -131,6 +132,49 @@ export async function dbGetToolInsights(
     return row ? rowToCraftResult(row) : null;
   } catch (error) {
     console.error("[db] dbGetToolInsights failed:", (error as Error).message);
+    return null;
+  }
+}
+
+/**
+ * Recompute a user's Craft score from their stored raw insights data.
+ *
+ * Reads the raw InsightsUpload from the DB, runs `computeCraftScore()`
+ * with the current formula, and upserts the updated scores back. This
+ * ensures formula changes (e.g. removing friction/error penalties) are
+ * retroactively applied without requiring the user to re-upload.
+ *
+ * Returns the fresh CraftResult, or null if no raw data exists or DB is unavailable.
+ */
+export async function dbRecomputeCraft(
+  handle: string,
+): Promise<CraftResult | null> {
+  const db = getSupabase();
+  if (!db) return null;
+
+  try {
+    const { data, error } = await db
+      .from("tool_insights")
+      .select("raw_data")
+      .eq("handle", handle.toLowerCase())
+      .limit(1)
+      .single();
+
+    if (error) {
+      if (error.code === "PGRST116") return null;
+      throw error;
+    }
+
+    const rawData = data?.raw_data as InsightsUpload | undefined;
+    if (!rawData) return null;
+
+    // Recompute with current formula
+    const scores = computeCraftScore(rawData);
+
+    // Upsert updated scores back to DB
+    return dbUpsertToolInsights(handle, rawData, scores);
+  } catch (error) {
+    console.error("[db] dbRecomputeCraft failed:", (error as Error).message);
     return null;
   }
 }


### PR DESCRIPTION
## Summary

- `/api/recalculate` now recomputes craft scores from stored raw insights data using the current formula
- Previously it only read the cached score from DB, meaning the v2.7.0 scoring fix (excluding friction/errors) had no effect on existing users
- This ensures any scoring formula change is retroactively applied without requiring users to re-upload

## Test plan

- [x] 6,955 tests pass
- [x] Typecheck + lint clean
- [x] Recalculate route test updated to verify `dbRecomputeCraft` is called

🤖 Generated with [Claude Code](https://claude.com/claude-code)