### PR TITLE
perf(bundle): defer SharePageOwnerContent + PostHogInit from initial render

### DIFF
--- a/apps/web/app/u/[handle]/page.tsx
+++ b/apps/web/app/u/[handle]/page.tsx
@@ -8,7 +8,7 @@ import { NavbarClient } from "@/components/NavbarClient";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { SharePageShortcuts } from "@/components/SharePageShortcuts";
-import { SharePageOwnerContent } from "@/components/SharePageOwnerContent";
+import { SharePageOwnerContentLazy } from "@/components/SharePageOwnerContentLazy";
 import { getBaseUrl } from "@/lib/env";
 import { renderJsonLd } from "@/lib/jsonld";
 import { toDateString } from "@/lib/utils/date";
@@ -205,7 +205,7 @@ export async function SharePageContent({ handle }: { handle: string }) {
         </div>
 
         {/* ── Owner/Visitor Content (client-side session check) ── */}
-        <SharePageOwnerContent
+        <SharePageOwnerContentLazy
           handle={handle}
           stats={stats}
           impact={impact}

--- a/apps/web/components/ClientInstrumentation.tsx
+++ b/apps/web/components/ClientInstrumentation.tsx
@@ -1,7 +1,12 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { ClientAnalytics } from "@/components/ClientAnalytics";
-import { PostHogInit } from "@/components/PostHogProvider";
+
+const PostHogInit = dynamic(
+  () => import("@/components/PostHogProvider").then((m) => ({ default: m.PostHogInit })),
+  { ssr: false },
+);
 
 export function ClientInstrumentation() {
   return (

--- a/apps/web/components/SharePageOwnerContentLazy.tsx
+++ b/apps/web/components/SharePageOwnerContentLazy.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { ImpactV6Result, StatsData } from "@chapa/shared";
+import { BadgeSkeleton } from "./BadgeSkeleton";
+
+const SharePageOwnerContent = dynamic(
+  () => import("./SharePageOwnerContent").then((m) => ({ default: m.SharePageOwnerContent })),
+  { ssr: false, loading: () => <BadgeSkeleton /> },
+);
+
+interface Props {
+  handle: string;
+  stats: StatsData | null;
+  impact: ImpactV6Result | null;
+}
+
+export function SharePageOwnerContentLazy(props: Props) {
+  return <SharePageOwnerContent {...props} />;
+}

--- a/apps/web/components/lazy-imports.test.ts
+++ b/apps/web/components/lazy-imports.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Bundle-reduction invariants. These tests assert that heavy client-only
+ * subtrees stay out of the initial JS bundle for public routes.
+ *
+ * Context: audit issues #719/#798/#729 measured ~700KB+ First Load JS via
+ * `route-bundle-stats.json`. That diagnostic sums ALL reachable chunks for
+ * a route, including dynamically-loaded ones — so the metric overstates what
+ * users actually download. The CI per-file 500KB budget (bundle-size.yml) is
+ * the authoritative bundle gate. Even so, deferring owner-only and PostHog
+ * client init from the initial render is a real win for share-page TTFB.
+ *
+ * If you remove a check here, also re-measure share-page chunks vs homepage
+ * chunks via `pnpm --filter @chapa/web build` and inspect
+ * `.next/diagnostics/route-bundle-stats.json` to confirm the share-only
+ * delta hasn't regressed.
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const read = (rel: string): string =>
+  fs.readFileSync(path.resolve(__dirname, "..", rel), "utf-8");
+
+describe("lazy imports — bundle-reduction invariants", () => {
+  describe("share page (#798): owner content is client-only via next/dynamic", () => {
+    it("share page does NOT statically import SharePageOwnerContent", () => {
+      // A static import here would pull ImpactDashboard + DataSources +
+      // CopyButton + useOwnerCacheWarm into the share page initial bundle.
+      const sharePage = read("app/u/[handle]/page.tsx");
+      expect(sharePage).not.toMatch(
+        /^import\s*\{\s*SharePageOwnerContent\s*\}\s*from/m,
+      );
+    });
+
+    it("share page imports the lazy wrapper instead", () => {
+      const sharePage = read("app/u/[handle]/page.tsx");
+      expect(sharePage).toMatch(/SharePageOwnerContentLazy/);
+    });
+
+    it("lazy wrapper uses next/dynamic", () => {
+      const wrapper = read("components/SharePageOwnerContentLazy.tsx");
+      expect(wrapper).toMatch(/from\s+["']next\/dynamic["']/);
+    });
+
+    it("lazy wrapper sets ssr: false so the heavy subtree is client-only", () => {
+      const wrapper = read("components/SharePageOwnerContentLazy.tsx");
+      expect(wrapper).toMatch(/ssr:\s*false/);
+    });
+
+    it("lazy wrapper imports SharePageOwnerContent inside the dynamic() factory", () => {
+      const wrapper = read("components/SharePageOwnerContentLazy.tsx");
+      expect(wrapper).toMatch(
+        /dynamic\(\s*\(\)\s*=>\s*import\(["']\.\/SharePageOwnerContent["']\)/,
+      );
+    });
+  });
+
+  describe("PostHog (#719): client init is dynamic with ssr: false", () => {
+    it("ClientInstrumentation does NOT statically import PostHogInit", () => {
+      // The component itself is small (~50 LOC) and posthog-js is already
+      // lazy-loaded inside its useEffect — this guard just keeps the
+      // component code off the initial render path.
+      const instrumentation = read("components/ClientInstrumentation.tsx");
+      expect(instrumentation).not.toMatch(
+        /^import\s*\{\s*PostHogInit\s*\}\s*from/m,
+      );
+    });
+
+    it("ClientInstrumentation uses next/dynamic with ssr: false for PostHog", () => {
+      const instrumentation = read("components/ClientInstrumentation.tsx");
+      expect(instrumentation).toMatch(/from\s+["']next\/dynamic["']/);
+      expect(instrumentation).toMatch(/ssr:\s*false/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Defers two heavy client subtrees from the initial render of every public route via `next/dynamic({ ssr: false })`:

- **`SharePageOwnerContent`** — the share-page subtree that brings in `ImpactDashboard`, `DataSources`, `CopyButton`, and `useOwnerCacheWarm`. Anonymous visitors to `/u/:handle` no longer pay for it eagerly.
- **`PostHogInit`** — the PostHog client init component (≈50 LOC). `posthog-js` itself was already lazy-loaded inside its `useEffect`; this just keeps the wrapper component code off the initial render path.

Adds `apps/web/components/lazy-imports.test.ts` to lock in these invariants.

Closes #798. Partially addresses #719 and #729 — see scope below.

## Scope (and what's deferred)

While auditing the current bundle I found that `route-bundle-stats.json` reports First Load JS by **summing every chunk reachable from a route, including dynamically-loaded ones**. That's why the original audit (#719) measured ~700KB+ "First Load JS" — the metric overstates what users actually download.

Real measurement on `develop` after this PR (uncompressed):

| Route | Total reachable | Shared shell | Route-only delta |
|-------|-----------------|--------------|-------------------|
| `/` | 956 KB | 933 KB | +25 KB |
| `/u/[handle]` | 977 KB | 933 KB | +44 KB |

The shared shell (~933 KB) is dominated by Next.js framework (~325 KB) and minified app code that every page needs. Splitting `UserMenu`'s dropdown body, which the audit recommended, wouldn't reduce per-route loads because UserMenu is in that shared shell. It would also touch ~2,500 LOC of `UserMenu.test.tsx` / `UserMenu.render.test.tsx`.

The CI per-file 500 KB budget (`bundle-size.yml`) is the authoritative gate and is comfortably met (largest individual JS file ≈ 328 KB).

**Not in this PR — deferred with reason:**
- `UserMenu` dropdown split (#719/#729 partial). The chunk is shared across every route, so splitting it doesn't reduce per-route load. Test rewrite cost is high. Will reconsider if real-world measurements (Lighthouse, RUM) flag UserMenu specifically.
- `AuthorTypewriter` lazy-load — already gated behind `GlobalCommandBarLazy`, no further win available.

## Files

- `apps/web/components/SharePageOwnerContentLazy.tsx` — new lazy wrapper
- `apps/web/components/ClientInstrumentation.tsx` — PostHogInit now via `next/dynamic({ ssr: false })`
- `apps/web/app/u/[handle]/page.tsx` — imports the lazy wrapper
- `apps/web/components/lazy-imports.test.ts` — invariant tests

## Test plan

- [x] `pnpm run test` (7,301 tests pass)
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [ ] CI green on the PR
- [ ] Manual: `/u/:handle` visitor flow renders correctly with skeleton fallback for the breakdown section
- [ ] Manual: PostHog client still initializes on first interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)