### PR TITLE
perf(share-page): read cached SVG before re-rendering (#720)

### DIFF
--- a/apps/web/app/u/[handle]/badge.svg/route.ts
+++ b/apps/web/app/u/[handle]/badge.svg/route.ts
@@ -7,11 +7,14 @@ import { escapeXml } from "@/lib/render/escape";
 import { fireAndForget } from "@/lib/async/fire-and-forget";
 import {
   cacheDel,
-  cacheGet,
-  cacheSet,
   cacheSetNx,
   rateLimit,
 } from "@/lib/cache/redis";
+import {
+  buildBadgeSvgCacheKey,
+  readBadgeSvgCache,
+  writeBadgeSvgCache,
+} from "@/lib/render/badge-svg-cache";
 import { CACHE_VERSION } from "@/lib/cache/version";
 import { getClientIp } from "@/lib/http/client-ip";
 import { captureServerError } from "@/lib/analytics/server-errors";
@@ -57,10 +60,6 @@ function fallbackSvg(handle: string, message: string): string {
 </svg>`;
 }
 
-function buildBadgeSvgCacheKey(handle: string, date: string): string {
-  return `badge:${CACHE_VERSION}:${handle.toLowerCase()}:warm-amber:${date}`;
-}
-
 function buildBadgeRenderLockKey(handle: string, date: string): string {
   return `badge-lock:${CACHE_VERSION}:${handle.toLowerCase()}:warm-amber:${date}`;
 }
@@ -82,30 +81,12 @@ async function withBadgeFallback<T>(
   }
 }
 
-async function readBadgeSvgCache(key: string): Promise<string | null> {
-  return withBadgeFallback(
-    cacheGet<string>(key),
-    null,
-    BADGE_CACHE_DEADLINE_MS,
-    "badge cache read",
-  );
-}
-
 async function acquireBadgeRenderLock(key: string): Promise<boolean> {
   return withBadgeFallback(
     cacheSetNx(key, BADGE_RENDER_LOCK_TTL_SECONDS),
     false,
     BADGE_CACHE_DEADLINE_MS,
     "badge render lock",
-  );
-}
-
-async function writeBadgeSvgCache(key: string, svg: string): Promise<boolean> {
-  return withBadgeFallback(
-    cacheSet(key, svg, 86400),
-    false,
-    BADGE_CACHE_DEADLINE_MS,
-    "badge cache write",
   );
 }
 

--- a/apps/web/app/u/[handle]/page.tsx
+++ b/apps/web/app/u/[handle]/page.tsx
@@ -13,6 +13,11 @@ import { getBaseUrl } from "@/lib/env";
 import { renderJsonLd } from "@/lib/jsonld";
 import { toDateString } from "@/lib/utils/date";
 import { renderBadgeSvg } from "@/lib/render/BadgeSvg";
+import {
+  buildBadgeSvgCacheKey,
+  readBadgeSvgCache,
+  writeBadgeSvgCache,
+} from "@/lib/render/badge-svg-cache";
 import { getAvatarBase64 } from "@/lib/render/avatar";
 import { GlobalCommandBarLazy } from "@/components/GlobalCommandBarLazy";
 import { BadgeSkeleton } from "@/components/BadgeSkeleton";
@@ -90,35 +95,50 @@ export async function SharePageContent({ handle }: { handle: string }) {
   const materialized = await materializePublicProfile(handle);
   const stats = materialized?.stats ?? null;
   const impact = materialized?.displayImpact ?? null;
-
-  // Start avatar fetch immediately (runs concurrently with EMA computation)
-  const avatarPromise = stats?.avatarUrl
-    ? getAvatarBase64(handle, stats.avatarUrl).catch(() => undefined)
-    : Promise.resolve(undefined);
-
-  // Render badge SVG inline during SSR. Cap avatar wait at 500ms so a slow
-  // external image server can't block TTFB — badge renders with placeholder on miss.
-  const AVATAR_DEADLINE_MS = 500;
-  const avatarDataUri = await Promise.race([
-    avatarPromise,
-    new Promise<undefined>((resolve) =>
-      setTimeout(() => resolve(undefined), AVATAR_DEADLINE_MS),
-    ),
-  ]);
   const verification = materialized
     ? getPublicProfileVerification(materialized)
     : null;
-  const inlineSvg = stats && impact
-    ? renderBadgeSvg(stats, impact, {
-        avatarDataUri,
-        verificationHash: verification?.hash,
-        verificationDate: verification?.date,
-      })
-    : null;
 
-  // Deferred work: verification storage, tracking, snapshots (runs after response)
+  // #720 — try the shared SVG cache first. The /u/[handle]/badge.svg route
+  // writes here after every successful render, so on warm caches the share
+  // page can skip avatar fetch + render entirely.
+  const today = toDateString(new Date());
+  const svgCacheKey = buildBadgeSvgCacheKey(handle, today);
+  const cachedSvg = await readBadgeSvgCache(svgCacheKey);
+
+  let inlineSvg: string | null = cachedSvg;
+  let renderedFresh = false;
+
+  if (!cachedSvg && stats && impact) {
+    // Cache miss — render inline. Avatar fetch is best-effort with a 500ms
+    // deadline so a slow external image server can't block TTFB.
+    const avatarPromise = stats.avatarUrl
+      ? getAvatarBase64(handle, stats.avatarUrl).catch(() => undefined)
+      : Promise.resolve(undefined);
+    const AVATAR_DEADLINE_MS = 500;
+    const avatarDataUri = await Promise.race([
+      avatarPromise,
+      new Promise<undefined>((resolve) =>
+        setTimeout(() => resolve(undefined), AVATAR_DEADLINE_MS),
+      ),
+    ]);
+    inlineSvg = renderBadgeSvg(stats, impact, {
+      avatarDataUri,
+      verificationHash: verification?.hash,
+      verificationDate: verification?.date,
+    });
+    renderedFresh = true;
+  }
+
+  // Deferred work: verification storage, tracking, snapshots, and (on
+  // fresh render) cache write so future requests / the badge.svg route
+  // can hit the cache.
   if (materialized && inlineSvg) {
+    const svgToCache = renderedFresh ? inlineSvg : null;
     after(() => {
+      if (svgToCache) {
+        void writeBadgeSvgCache(svgCacheKey, svgToCache);
+      }
       return runPublicProfileSideEffects(handle, materialized, { verification });
     });
   }

--- a/apps/web/lib/render/badge-svg-cache.test.ts
+++ b/apps/web/lib/render/badge-svg-cache.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { CACHE_VERSION } from "@/lib/cache/version";
+
+vi.mock("@/lib/cache/redis", () => ({
+  cacheGet: vi.fn(),
+  cacheSet: vi.fn(),
+}));
+
+import {
+  buildBadgeSvgCacheKey,
+  readBadgeSvgCache,
+  writeBadgeSvgCache,
+} from "./badge-svg-cache";
+import * as redis from "@/lib/cache/redis";
+
+const cacheGet = vi.mocked(redis.cacheGet);
+const cacheSet = vi.mocked(redis.cacheSet);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("badge-svg-cache", () => {
+  describe("buildBadgeSvgCacheKey", () => {
+    it("uses the format badge:<version>:<lowercase-handle>:warm-amber:<date>", () => {
+      const key = buildBadgeSvgCacheKey("Octocat", "2026-05-01");
+      expect(key).toBe(`badge:${CACHE_VERSION}:octocat:warm-amber:2026-05-01`);
+    });
+
+    it("lowercases the handle so case variants share a cache slot", () => {
+      const a = buildBadgeSvgCacheKey("OCTOCAT", "2026-05-01");
+      const b = buildBadgeSvgCacheKey("octocat", "2026-05-01");
+      expect(a).toBe(b);
+    });
+  });
+
+  describe("readBadgeSvgCache", () => {
+    it("returns the cached SVG on hit", async () => {
+      cacheGet.mockResolvedValueOnce("<svg>cached</svg>");
+      const result = await readBadgeSvgCache("badge:v2:octocat:warm-amber:2026-05-01");
+      expect(result).toBe("<svg>cached</svg>");
+    });
+
+    it("returns null on cache miss", async () => {
+      cacheGet.mockResolvedValueOnce(null);
+      const result = await readBadgeSvgCache("badge:v2:nope:warm-amber:2026-05-01");
+      expect(result).toBeNull();
+    });
+
+    it("returns null instead of throwing when Redis errors (fail-open)", async () => {
+      cacheGet.mockRejectedValueOnce(new Error("redis down"));
+      const result = await readBadgeSvgCache("badge:v2:octocat:warm-amber:2026-05-01");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("writeBadgeSvgCache", () => {
+    it("writes the SVG with a 24h TTL", async () => {
+      cacheSet.mockResolvedValueOnce(true);
+      await writeBadgeSvgCache(
+        "badge:v2:octocat:warm-amber:2026-05-01",
+        "<svg>fresh</svg>",
+      );
+      expect(cacheSet).toHaveBeenCalledWith(
+        "badge:v2:octocat:warm-amber:2026-05-01",
+        "<svg>fresh</svg>",
+        86400,
+      );
+    });
+
+    it("does not throw when Redis errors", async () => {
+      cacheSet.mockRejectedValueOnce(new Error("redis down"));
+      await expect(
+        writeBadgeSvgCache("k", "<svg/>"),
+      ).resolves.not.toThrow();
+    });
+  });
+});

--- a/apps/web/lib/render/badge-svg-cache.ts
+++ b/apps/web/lib/render/badge-svg-cache.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared full-response SVG cache for the badge — read by both the
+ * `/u/[handle]/badge.svg` route and the share page (#720). Centralizing
+ * the key format here ensures both paths point at the same Redis slot and
+ * one cannot drift away from the other.
+ */
+import { cacheGet, cacheSet } from "@/lib/cache/redis";
+import { CACHE_VERSION } from "@/lib/cache/version";
+import { withTimeout } from "@/lib/async/with-timeout";
+
+const CACHE_DEADLINE_MS = 250;
+const CACHE_TTL_SECONDS = 86_400; // 24h, matches the badge route
+
+export function buildBadgeSvgCacheKey(handle: string, date: string): string {
+  return `badge:${CACHE_VERSION}:${handle.toLowerCase()}:warm-amber:${date}`;
+}
+
+async function withCacheFallback<T>(
+  promise: Promise<T>,
+  fallback: T,
+  label: string,
+): Promise<T> {
+  try {
+    return await withTimeout(promise, CACHE_DEADLINE_MS, label);
+  } catch {
+    return fallback;
+  }
+}
+
+export async function readBadgeSvgCache(key: string): Promise<string | null> {
+  return withCacheFallback(
+    cacheGet<string>(key),
+    null,
+    "badge cache read",
+  );
+}
+
+export async function writeBadgeSvgCache(
+  key: string,
+  svg: string,
+): Promise<boolean> {
+  return withCacheFallback(
+    cacheSet(key, svg, CACHE_TTL_SECONDS),
+    false,
+    "badge cache write",
+  );
+}

--- a/apps/web/lib/render/share-page-cache-usage.test.ts
+++ b/apps/web/lib/render/share-page-cache-usage.test.ts
@@ -1,0 +1,44 @@
+/**
+ * #720 — share page must try the badge SVG cache before re-rendering.
+ *
+ * The badge.svg route writes to `badge:<version>:<handle>:warm-amber:<date>`
+ * after every successful render. The share page used to ignore this cache
+ * and call renderBadgeSvg() unconditionally during SSR, duplicating render
+ * work on every ISR regeneration. This test locks in the cache-first flow.
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SHARE_PAGE = fs.readFileSync(
+  path.resolve(__dirname, "../../app/u/[handle]/page.tsx"),
+  "utf-8",
+);
+
+describe("share page (#720) cache-first SVG", () => {
+  it("imports the shared badge-svg-cache helpers", () => {
+    expect(SHARE_PAGE).toMatch(
+      /from\s+["']@\/lib\/render\/badge-svg-cache["']/,
+    );
+  });
+
+  it("calls readBadgeSvgCache before falling through to renderBadgeSvg", () => {
+    // Skip past imports — only check ordering inside the SharePageContent body.
+    const bodyStart = SHARE_PAGE.indexOf("export async function SharePageContent");
+    expect(bodyStart).toBeGreaterThan(-1);
+    const body = SHARE_PAGE.slice(bodyStart);
+    const readIdx = body.indexOf("readBadgeSvgCache(");
+    const renderIdx = body.indexOf("renderBadgeSvg(");
+    expect(readIdx).toBeGreaterThan(-1);
+    expect(renderIdx).toBeGreaterThan(-1);
+    expect(readIdx).toBeLessThan(renderIdx);
+  });
+
+  it("writes the freshly rendered SVG back to cache (so future requests hit it)", () => {
+    expect(SHARE_PAGE).toContain("writeBadgeSvgCache");
+  });
+
+  it("uses buildBadgeSvgCacheKey (does not duplicate the key format)", () => {
+    expect(SHARE_PAGE).toContain("buildBadgeSvgCacheKey");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #720. The `/u/[handle]/badge.svg` route writes its rendered output to a 24h Redis cache after every successful render. The share page used to ignore that cache and call `renderBadgeSvg()` unconditionally during SSR — duplicating render work on every ISR regeneration. Now the share page tries the cache first and only renders + writes back on miss.

## Changes

- **New `apps/web/lib/render/badge-svg-cache.ts`** — extracts `buildBadgeSvgCacheKey`, `readBadgeSvgCache`, `writeBadgeSvgCache` (plus the 250ms timeout / fail-open wrapper) into one module so the badge route and share page point at the same Redis slot. Eliminates the risk of the key format drifting between the two.
- **`badge.svg/route.ts`** — now imports from the shared module. Pure refactor, no behavior change. The `cacheGet` / `cacheSet` direct imports from `@/lib/cache/redis` are dropped (dead after the extraction).
- **`u/[handle]/page.tsx`** — cache-first flow:
  - Read cached SVG via `readBadgeSvgCache(buildBadgeSvgCacheKey(handle, today))`
  - On hit → use cached SVG, skip avatar fetch + render entirely
  - On miss → render inline (current behavior), then write to cache via `after()` so subsequent requests (including badge.svg) hit the cache

## Tests

- **`badge-svg-cache.test.ts`** (new) — 7 tests covering key format, read hit/miss/error, write TTL/error.
- **`share-page-cache-usage.test.ts`** (new) — 4 invariant tests asserting the share page imports from the shared module, calls `readBadgeSvgCache(...)` before `renderBadgeSvg(...)`, writes back on miss, and uses `buildBadgeSvgCacheKey` (no duplicated key format).
- All existing tests still pass: typecheck ✓ lint ✓ 7,323/7,323 tests ✓

## Test plan

- [x] `pnpm run test` (one pre-existing flake in `BadgeToolbar.render.test.tsx > strips @keyframes` clears on re-run; unrelated)
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [ ] CI green
- [ ] Manual: warm visit to `/u/<handle>` (cache hit) → badge renders identical to fresh visit (cache miss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)