### PR TITLE
perf(ttfb): parallelize profile lookups, tighten avatar deadline (#800)

### DIFF
--- a/apps/web/app/u/[handle]/page.tsx
+++ b/apps/web/app/u/[handle]/page.tsx
@@ -108,20 +108,25 @@ export async function SharePageContent({ handle }: { handle: string }) {
 
   let inlineSvg: string | null = cachedSvg;
   let renderedFresh = false;
+  let avatarResolved = false;
 
   if (!cachedSvg && stats && impact) {
-    // Cache miss — render inline. Avatar fetch is best-effort with a 500ms
-    // deadline so a slow external image server can't block TTFB.
+    // Cache miss — render inline. Avatar fetch is best-effort with a tight
+    // 250ms deadline (#800) so a slow external image server can't block
+    // TTFB. The /u/[handle]/badge.svg route awaits the avatar fully on its
+    // own first render and writes the avatar-bearing SVG to the same
+    // cache, so warm visits to the share page get the real avatar.
     const avatarPromise = stats.avatarUrl
       ? getAvatarBase64(handle, stats.avatarUrl).catch(() => undefined)
       : Promise.resolve(undefined);
-    const AVATAR_DEADLINE_MS = 500;
+    const AVATAR_DEADLINE_MS = 250;
     const avatarDataUri = await Promise.race([
       avatarPromise,
       new Promise<undefined>((resolve) =>
         setTimeout(() => resolve(undefined), AVATAR_DEADLINE_MS),
       ),
     ]);
+    avatarResolved = avatarDataUri !== undefined;
     inlineSvg = renderBadgeSvg(stats, impact, {
       avatarDataUri,
       verificationHash: verification?.hash,
@@ -130,11 +135,13 @@ export async function SharePageContent({ handle }: { handle: string }) {
     renderedFresh = true;
   }
 
-  // Deferred work: verification storage, tracking, snapshots, and (on
-  // fresh render) cache write so future requests / the badge.svg route
-  // can hit the cache.
+  // Deferred work: verification storage, tracking, snapshots, and (on a
+  // fresh render where the avatar resolved) cache write so future requests
+  // and the badge.svg route can hit the cache. We deliberately do NOT
+  // cache renders that fell back to a placeholder avatar — that would
+  // poison the shared cache with a degraded SVG for up to 24h. (#800)
   if (materialized && inlineSvg) {
-    const svgToCache = renderedFresh ? inlineSvg : null;
+    const svgToCache = renderedFresh && avatarResolved ? inlineSvg : null;
     after(() => {
       if (svgToCache) {
         void writeBadgeSvgCache(svgCacheKey, svgToCache);

--- a/apps/web/app/u/[handle]/share-page-ttfb.test.ts
+++ b/apps/web/app/u/[handle]/share-page-ttfb.test.ts
@@ -1,0 +1,41 @@
+/**
+ * #800 — share-page TTFB invariants:
+ *  - Avatar deadline must be 250ms or less (not the original 500ms).
+ *  - When the avatar fetch times out, the rendered (degraded) SVG must NOT
+ *    be written to the shared cache. Otherwise badge.svg later reads a
+ *    placeholder version and visitors see a missing avatar for up to 24h.
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const SHARE_PAGE = fs.readFileSync(
+  path.resolve(__dirname, "page.tsx"),
+  "utf-8",
+);
+
+describe("share page TTFB (#800)", () => {
+  it("avatar deadline is at most 250ms", () => {
+    const match = SHARE_PAGE.match(
+      /AVATAR_DEADLINE_MS\s*=\s*(\d+)/,
+    );
+    expect(match).not.toBeNull();
+    const deadline = Number(match![1]);
+    expect(deadline).toBeGreaterThan(0);
+    expect(deadline).toBeLessThanOrEqual(250);
+  });
+
+  it("only writes to badge SVG cache when avatar fetch resolved (no degraded caching)", () => {
+    // The cache write must be guarded by a flag that's set only when avatar
+    // resolved (not on timeout). Otherwise a slow avatar fetch poisons the
+    // shared cache with a placeholder version for up to 24h.
+    expect(SHARE_PAGE).toMatch(/avatarResolved/);
+
+    // The writeBadgeSvgCache call must be inside an avatarResolved-gated branch.
+    const writeIdx = SHARE_PAGE.indexOf("writeBadgeSvgCache(");
+    expect(writeIdx).toBeGreaterThan(-1);
+    // Look back a reasonable window from the write call for the gate.
+    const window = SHARE_PAGE.slice(Math.max(0, writeIdx - 600), writeIdx);
+    expect(window).toMatch(/avatarResolved/);
+  });
+});

--- a/apps/web/lib/profile/materialize-profile-parallel.test.ts
+++ b/apps/web/lib/profile/materialize-profile-parallel.test.ts
@@ -1,0 +1,103 @@
+/**
+ * #800 — materializeProfile must run getStats concurrently with the
+ * craft / snapshot / dirty cache lookups. The cache lookups only need
+ * the handle, so blocking them behind getStats adds an extra RTT to
+ * every share-page / badge.svg cache miss.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { materializeProfile } from "./materialize-profile";
+import { makeFullStats } from "../test-helpers/fixtures";
+
+const mockGetStats = vi.fn();
+const mockGetCachedCraftScore = vi.fn();
+const mockGetCachedLatestSnapshot = vi.fn();
+const mockIsStatsDirty = vi.fn();
+
+vi.mock("@/lib/github/client", () => ({
+  getStats: (...args: unknown[]) => mockGetStats(...args),
+}));
+vi.mock("@/lib/cache/craft-cache", () => ({
+  getCachedCraftScore: (...args: unknown[]) => mockGetCachedCraftScore(...args),
+}));
+vi.mock("@/lib/cache/snapshot-cache", () => ({
+  getCachedLatestSnapshot: (...args: unknown[]) =>
+    mockGetCachedLatestSnapshot(...args),
+}));
+vi.mock("@/lib/cache/dirty-stats", () => ({
+  isStatsDirty: (...args: unknown[]) => mockIsStatsDirty(...args),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("materializeProfile parallelism (#800)", () => {
+  it("starts the cache lookups before getStats resolves", async () => {
+    const callOrder: string[] = [];
+
+    let resolveStats: (v: unknown) => void = () => {};
+    mockGetStats.mockImplementation(() => {
+      callOrder.push("getStats:start");
+      return new Promise((resolve) => {
+        resolveStats = (v) => {
+          callOrder.push("getStats:end");
+          resolve(v);
+        };
+      });
+    });
+    mockGetCachedCraftScore.mockImplementation(async () => {
+      callOrder.push("craft:start");
+      await new Promise((r) => setTimeout(r, 0));
+      callOrder.push("craft:end");
+      return null;
+    });
+    mockGetCachedLatestSnapshot.mockImplementation(async () => {
+      callOrder.push("snapshot:start");
+      await new Promise((r) => setTimeout(r, 0));
+      callOrder.push("snapshot:end");
+      return null;
+    });
+    mockIsStatsDirty.mockImplementation(async () => {
+      callOrder.push("dirty:start");
+      await new Promise((r) => setTimeout(r, 0));
+      callOrder.push("dirty:end");
+      return false;
+    });
+
+    const promise = materializeProfile("octocat");
+    // Yield once so all synchronously-started promises can record their start.
+    await new Promise((r) => setTimeout(r, 0));
+
+    // The cache lookups must have started before getStats resolved.
+    expect(callOrder).toContain("craft:start");
+    expect(callOrder).toContain("snapshot:start");
+    expect(callOrder).toContain("dirty:start");
+    expect(callOrder).not.toContain("getStats:end");
+
+    resolveStats(makeFullStats());
+    await promise;
+  });
+
+  it("returns null when getStats fails, even if cache lookups succeed", async () => {
+    mockGetStats.mockResolvedValue(null);
+    mockGetCachedCraftScore.mockResolvedValue(null);
+    mockGetCachedLatestSnapshot.mockResolvedValue(null);
+    mockIsStatsDirty.mockResolvedValue(false);
+
+    const result = await materializeProfile("nope");
+    expect(result).toBeNull();
+  });
+
+  it("survives cache lookup rejections (fail open to defaults)", async () => {
+    mockGetStats.mockResolvedValue(makeFullStats());
+    mockGetCachedCraftScore.mockRejectedValue(new Error("redis"));
+    mockGetCachedLatestSnapshot.mockRejectedValue(new Error("redis"));
+    mockIsStatsDirty.mockRejectedValue(new Error("redis"));
+
+    const result = await materializeProfile("octocat");
+    expect(result).not.toBeNull();
+    expect(result!.craftResult).toBeNull();
+    expect(result!.latestSnapshot).toBeNull();
+    expect(result!.inputsChanged).toBe(false);
+  });
+});

--- a/apps/web/lib/profile/materialize-profile.ts
+++ b/apps/web/lib/profile/materialize-profile.ts
@@ -73,17 +73,23 @@ export async function materializeProfile(
   handle: string,
   options: MaterializeProfileOptions = {},
 ): Promise<MaterializedProfile | null> {
-  const stats = await getStats(handle, options.token);
+  // #800 — getStats and the three cache lookups all only need the handle, so
+  // they run concurrently. On cache miss for stats, GitHub's GraphQL still
+  // dominates; on cache hit, this saves a round-trip vs the previous serial
+  // shape. Cache lookup failures fail open to defaults rather than rejecting
+  // the whole profile fetch.
+  const [statsSettled, craftSettled, snapshotSettled, dirtySettled] =
+    await Promise.allSettled([
+      getStats(handle, options.token),
+      getCachedCraftScore(handle),
+      getCachedLatestSnapshot(handle),
+      isStatsDirty(handle),
+    ]);
 
+  const stats = statsSettled.status === "fulfilled" ? statsSettled.value : null;
   if (!stats) {
     return null;
   }
-
-  const [craftSettled, snapshotSettled, dirtySettled] = await Promise.allSettled([
-    getCachedCraftScore(handle),
-    getCachedLatestSnapshot(handle),
-    isStatsDirty(handle),
-  ]);
 
   const craftResult = craftSettled.status === "fulfilled"
     ? craftSettled.value
@@ -94,7 +100,8 @@ export async function materializeProfile(
   // Dirty-signal lookup failures fail open — defaulting to false preserves
   // the existing same-day-lock behavior rather than introducing surprise
   // refreshes when Redis hiccups.
-  const dirtyFromCache = dirtySettled.status === "fulfilled" && dirtySettled.value === true;
+  const dirtyFromCache =
+    dirtySettled.status === "fulfilled" && dirtySettled.value === true;
   const inputsChanged = options.inputsChanged ?? dirtyFromCache;
 
   return {


### PR DESCRIPTION
## Summary

Closes #800. Three changes that reduce TTFB on share-page / badge cache misses.

### 1. `materializeProfile` runs all four lookups in parallel

`getStats(handle)` and the three cache lookups (`getCachedCraftScore`, `getCachedLatestSnapshot`, `isStatsDirty`) all only depend on the handle. Previously the cache lookups waited for `getStats` to finish — adding a wasted round-trip on every share-page / badge.svg cache miss. Now all four run via `Promise.allSettled` concurrently.

- On stats cache hit: saves the round-trip outright (cache lookups in flight while stats is read from Redis).
- On stats cache miss: GitHub's GraphQL still dominates, but the cache lookups no longer pile on top of it.
- Cache lookup failures still fail open to defaults (preserves the existing `inputsChanged` semantics).

### 2. Tighten the share page's avatar deadline from 500ms → 250ms

The `/u/[handle]/badge.svg` route awaits the avatar fully on its own first render and writes the avatar-bearing SVG to the same cache key (#720). Warm visits to the share page therefore read the real avatar via cache hit. The share page's own avatar deadline only matters on its own first render — and at 250ms it's high enough for cached avatars to land but low enough that a slow GitHub CDN can't stall TTFB.

### 3. Fix a regression introduced in #720

The share page used to write its freshly rendered SVG to the shared cache regardless of whether the avatar fetch resolved. If the avatar deadline fired first, the cached SVG had a placeholder — and badge.svg would later read that same placeholder version for up to 24h.

The cache write is now gated on `avatarResolved` (the avatar promise returned a real data URI before the deadline). Degraded renders are returned to the visitor but never poison the shared cache.

## Files

- `apps/web/lib/profile/materialize-profile.ts` — single `Promise.allSettled` for all four lookups
- `apps/web/app/u/[handle]/page.tsx` — 250ms avatar deadline + `avatarResolved`-gated cache write
- `apps/web/lib/profile/materialize-profile-parallel.test.ts` (new) — 3 tests covering parallel kickoff, stats failure, and cache-lookup rejection fallback
- `apps/web/app/u/[handle]/share-page-ttfb.test.ts` (new) — 2 invariants on the deadline and the cache-write gate

## Test plan

- [x] `pnpm run test` — 7,328/7,328 pass
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [ ] CI green
- [ ] Manual: cold visit to `/u/<handle>` returns within p95 budget; warm visit hits cache as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)