### PR TITLE
hotfix: oauth state — accept Upstash deserialized 1 (v2.9.1)

### DIFF
--- a/apps/web/lib/auth/oauth-state.test.ts
+++ b/apps/web/lib/auth/oauth-state.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { consumeOauthState, issueOauthState } from "./oauth-state";
 
 describe("oauth-state store", () => {
   beforeEach(() => {
+    vi.resetModules();
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-22T00:00:00.000Z"));
     vi.stubEnv("UPSTASH_REDIS_REST_URL", undefined);
@@ -12,20 +12,90 @@ describe("oauth-state store", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllEnvs();
+    vi.doUnmock("@upstash/redis");
   });
 
-  it("consume returns true on first call and false on subsequent calls", async () => {
-    await issueOauthState("s1");
+  describe("in-memory fallback (no Redis configured)", () => {
+    it("consume returns true on first call and false on subsequent calls", async () => {
+      const { issueOauthState, consumeOauthState } = await import("./oauth-state");
+      await issueOauthState("s1");
 
-    await expect(consumeOauthState("s1")).resolves.toBe(true);
-    await expect(consumeOauthState("s1")).resolves.toBe(false);
+      await expect(consumeOauthState("s1")).resolves.toBe(true);
+      await expect(consumeOauthState("s1")).resolves.toBe(false);
+    });
+
+    it("expires state entries after 10 minutes", async () => {
+      const { issueOauthState, consumeOauthState } = await import("./oauth-state");
+      await issueOauthState("s2");
+
+      await vi.advanceTimersByTimeAsync(11 * 60 * 1000);
+
+      await expect(consumeOauthState("s2")).resolves.toBe(false);
+    });
   });
 
-  it("expires state entries after 10 minutes", async () => {
-    await issueOauthState("s2");
+  // Regression for production incident 2026-05-01:
+  // Upstash Redis client auto-deserializes the stored literal `"1"` as the
+  // JSON number `1`, so the previous strict equality (`existed === "1"`) was
+  // always false on the first consume → every fresh login returned 400
+  // state_already_used. The fix disables auto-deserialization for the OAuth
+  // state client (or accepts both shapes). This test pins down both behaviours.
+  describe("Upstash deserializes stored \"1\" — accept what the client returns", () => {
+    beforeEach(() => {
+      vi.useRealTimers();
+    });
 
-    await vi.advanceTimersByTimeAsync(11 * 60 * 1000);
+    it("consume returns true when getdel returns the string \"1\"", async () => {
+      vi.stubEnv("UPSTASH_REDIS_REST_URL", "https://example.upstash.io");
+      vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "test-token");
 
-    await expect(consumeOauthState("s2")).resolves.toBe(false);
+      const setMock = vi.fn().mockResolvedValue("OK");
+      const getdelMock = vi.fn().mockResolvedValueOnce("1");
+      class FakeRedis {
+        set = setMock;
+        getdel = getdelMock;
+      }
+      vi.doMock("@upstash/redis", () => ({ Redis: FakeRedis }));
+
+      const { issueOauthState, consumeOauthState } = await import("./oauth-state");
+      await issueOauthState("string-state");
+      await expect(consumeOauthState("string-state")).resolves.toBe(true);
+    });
+
+    it("consume returns true when getdel returns the number 1 (real Upstash behaviour)", async () => {
+      vi.stubEnv("UPSTASH_REDIS_REST_URL", "https://example.upstash.io");
+      vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "test-token");
+
+      const setMock = vi.fn().mockResolvedValue("OK");
+      // Upstash auto-parses the JSON-shaped string "1" into the number 1.
+      // This was confirmed against production Redis on 2026-05-01.
+      const getdelMock = vi.fn().mockResolvedValueOnce(1);
+      class FakeRedis {
+        set = setMock;
+        getdel = getdelMock;
+      }
+      vi.doMock("@upstash/redis", () => ({ Redis: FakeRedis }));
+
+      const { issueOauthState, consumeOauthState } = await import("./oauth-state");
+      await issueOauthState("number-state");
+      await expect(consumeOauthState("number-state")).resolves.toBe(true);
+    });
+
+    it("consume returns false when getdel returns null (genuine miss / replay)", async () => {
+      vi.stubEnv("UPSTASH_REDIS_REST_URL", "https://example.upstash.io");
+      vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "test-token");
+
+      const setMock = vi.fn().mockResolvedValue("OK");
+      const getdelMock = vi.fn().mockResolvedValue(null);
+      class FakeRedis {
+        set = setMock;
+        getdel = getdelMock;
+      }
+      vi.doMock("@upstash/redis", () => ({ Redis: FakeRedis }));
+
+      const { issueOauthState, consumeOauthState } = await import("./oauth-state");
+      await issueOauthState("missing-state");
+      await expect(consumeOauthState("missing-state")).resolves.toBe(false);
+    });
   });
 });

--- a/apps/web/lib/auth/oauth-state.ts
+++ b/apps/web/lib/auth/oauth-state.ts
@@ -37,6 +37,12 @@ function getRedis(): Redis | null {
     // Without read-your-writes consistency, the callback can briefly miss the
     // fresh nonce and incorrectly reject a first-time login as a replay.
     readYourWrites: true,
+    // We store the literal string "1" as a flag and check `existed === "1"`
+    // on consume. Upstash's default JSON-shaped deserialization parses "1"
+    // back as the number 1, breaking the equality check and rejecting every
+    // first login with state_already_used (production incident 2026-05-01).
+    // Disabling auto-deserialization keeps responses as raw strings.
+    automaticDeserialization: false,
   });
   return _redis;
 }
@@ -78,9 +84,15 @@ export async function consumeOauthState(state: string): Promise<boolean> {
     try {
       const key = getKey(state);
       const existed = await (
-        redis as unknown as { getdel<T>(key: string): Promise<T | null> }
-      ).getdel<string>(key);
-      if (existed === "1") return true;
+        redis as unknown as {
+          getdel<T>(key: string): Promise<T | null>;
+        }
+      ).getdel<string | number>(key);
+      // Accept both the raw string "1" and the JSON-parsed number 1. With
+      // automaticDeserialization disabled (above) we should always see the
+      // string, but staying defensive avoids the same outage if a future
+      // Upstash version flips the default back on.
+      if (existed === "1" || existed === 1) return true;
 
       // Upstash read-your-writes consistency is client-scoped. In dev and
       // serverless environments, /login and /callback may hit distinct Redis
@@ -90,9 +102,11 @@ export async function consumeOauthState(state: string): Promise<boolean> {
       for (const delayMs of REDIS_READ_RETRY_DELAYS_MS) {
         await sleep(delayMs);
         const retried = await (
-          redis as unknown as { getdel<T>(key: string): Promise<T | null> }
-        ).getdel<string>(key);
-        if (retried === "1") return true;
+          redis as unknown as {
+            getdel<T>(key: string): Promise<T | null>;
+          }
+        ).getdel<string | number>(key);
+        if (retried === "1" || retried === 1) return true;
       }
       return false;
     } catch {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chapa/web",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## P0 incident — login broken in production

Every fresh GitHub login on chapa.thecreativetoken.com returned 400 {"error":"state_already_used"}. Reproduced via curl against prod (clean cookies, captured fresh state, immediate callback → 400).

## Root cause

Upstash's REST client auto-deserializes JSON-shaped responses. The OAuth state code stores the literal string "1" and checks existed === "1" after getdel. But getdel returns the JSON-parsed value — for "1", that is the **number** 1. Strict equality fails, every legitimate first login is rejected as a replay.

Verified live against production Redis:

```
SET oauth-state:diag-… "1"  →  "OK"
getdel                       →  1 (number, not "1")
existed === "1"              →  false  ← BUG
```

This bug was latent in v2.8.0 too. v2.9.0 didn't introduce it — usage exposed it.

## Fix

Two complementary changes:

1. automaticDeserialization: false on the OAuth state Redis client so responses come back as raw strings. Root-cause fix.
2. Defensive comparison: accept both "1" and 1 in the consume check. Belt-and-suspenders so a future Upstash default flip can't reproduce the outage.

## Tests

Three new regression tests in apps/web/lib/auth/oauth-state.test.ts:
- consume returns true when getdel returns the string "1"
- consume returns true when getdel returns the number 1 ← was failing on v2.9.0, passes now
- consume returns false when getdel returns null (genuine miss / replay still works)

pnpm run test — 7,331 / 7,331 pass; typecheck and lint clean.

## Direct to main (hotfix path)

This PR targets main directly to recover production faster. After merge:
1. Tag v2.9.1, push tag.
2. Merge main back into develop so the fix lives there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)