### PR TITLE
Hotfix: NEXT_PUBLIC flags inline client-side — restore platform link/unlink rows (#918)

### DIFF
--- a/apps/web/lib/env.test.ts
+++ b/apps/web/lib/env.test.ts
@@ -1,5 +1,33 @@
+import { readFileSync } from "node:fs";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { getBaseUrl, getAdminHandles } from "./env";
+
+// Next.js only inlines NEXT_PUBLIC_* env vars into the client bundle when they
+// are referenced as a STATIC LITERAL member expression (process.env.NEXT_PUBLIC_X).
+// Dynamic access (process.env[name]) is never substituted, so any NEXT_PUBLIC_*
+// reader routed through readTrimmed(name) returns undefined in the browser — which
+// silently disabled client-side feature flags (platform link/unlink rows). See #918.
+// Runtime tests run in Node where process.env[name] works, so this regression can
+// only be guarded at the source level.
+describe("env.ts NEXT_PUBLIC readers use static literal access (#918)", () => {
+  const source = readFileSync(new URL("./env.ts", import.meta.url), "utf8");
+  const publicVars = [
+    ...new Set(source.match(/NEXT_PUBLIC_[A-Z0-9_]+/g) ?? []),
+  ];
+
+  it("finds NEXT_PUBLIC vars to check", () => {
+    expect(publicVars.length).toBeGreaterThan(0);
+  });
+
+  for (const name of publicVars) {
+    it(`reads ${name} via static literal, not dynamic readTrimmed`, () => {
+      // Must be referenced literally so the bundler can inline it client-side.
+      expect(source).toContain(`process.env.${name}`);
+      // Must NOT be read via the dynamic helper (won't inline on the client).
+      expect(source).not.toContain(`readTrimmed("${name}")`);
+    });
+  }
+});
 
 describe("getBaseUrl", () => {
   afterEach(() => {

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -19,6 +19,20 @@ function readTrimmed(name: string): string | undefined {
   return v ? v : undefined;
 }
 
+/**
+ * Trim a raw env value, collapsing empty strings to `undefined`.
+ *
+ * Used for `NEXT_PUBLIC_*` readers, which MUST reference `process.env.X` as a
+ * static literal at the call site. Next.js only inlines public env vars into the
+ * client bundle for literal member expressions — dynamic access (the `name`
+ * argument to {@link readTrimmed}) is never substituted and returns `undefined`
+ * in the browser, silently disabling client-side feature flags (#918).
+ */
+function clean(value: string | undefined): string | undefined {
+  const v = value?.trim();
+  return v ? v : undefined;
+}
+
 function readBool(name: string): boolean {
   return readTrimmed(name) === "true";
 }
@@ -62,12 +76,12 @@ export function getChapaAlertWebhookUrl(): string | undefined {
 
 /** PostHog host URL (e.g. `https://app.posthog.com`). */
 export function getPosthogHost(): string | undefined {
-  return readTrimmed("NEXT_PUBLIC_POSTHOG_HOST");
+  return clean(process.env.NEXT_PUBLIC_POSTHOG_HOST);
 }
 
 /** PostHog project API key. */
 export function getPosthogKey(): string | undefined {
-  return readTrimmed("NEXT_PUBLIC_POSTHOG_KEY");
+  return clean(process.env.NEXT_PUBLIC_POSTHOG_KEY);
 }
 
 // ---------------------------------------------------------------------------
@@ -116,7 +130,8 @@ export function getNextauthSecret(): string | undefined {
  */
 export function getBaseUrl(): string {
   return (
-    readTrimmed("NEXT_PUBLIC_BASE_URL") ?? "https://chapa.thecreativetoken.com"
+    clean(process.env.NEXT_PUBLIC_BASE_URL) ??
+    "https://chapa.thecreativetoken.com"
   );
 }
 
@@ -136,7 +151,7 @@ export function getBitbucketClientSecret(): string | undefined {
 
 /** Raw `NEXT_PUBLIC_BITBUCKET_ENABLED` value — `"true"` when Bitbucket integration is on. */
 export function getBitbucketEnabledEnv(): string | undefined {
-  return readTrimmed("NEXT_PUBLIC_BITBUCKET_ENABLED");
+  return clean(process.env.NEXT_PUBLIC_BITBUCKET_ENABLED);
 }
 
 // ---------------------------------------------------------------------------
@@ -169,7 +184,7 @@ export function getCodebergClientSecret(): string | undefined {
 
 /** Raw `NEXT_PUBLIC_CODEBERG_ENABLED` value — `"true"` when Codeberg integration is on. */
 export function getCodebergEnabledEnv(): string | undefined {
-  return readTrimmed("NEXT_PUBLIC_CODEBERG_ENABLED");
+  return clean(process.env.NEXT_PUBLIC_CODEBERG_ENABLED);
 }
 
 // ---------------------------------------------------------------------------
@@ -188,7 +203,7 @@ export function getGitlabClientSecret(): string | undefined {
 
 /** Raw `NEXT_PUBLIC_GITLAB_ENABLED` value — `"true"` when GitLab integration is on. */
 export function getGitlabEnabledEnv(): string | undefined {
-  return readTrimmed("NEXT_PUBLIC_GITLAB_ENABLED");
+  return clean(process.env.NEXT_PUBLIC_GITLAB_ENABLED);
 }
 
 // ---------------------------------------------------------------------------
@@ -239,17 +254,17 @@ export function getSupportForwardEmail(): string | undefined {
 
 /** Raw `NEXT_PUBLIC_EXPERIMENTS_ENABLED` value — `"true"` when experiments page is on. */
 export function getExperimentsEnabledEnv(): string | undefined {
-  return readTrimmed("NEXT_PUBLIC_EXPERIMENTS_ENABLED");
+  return clean(process.env.NEXT_PUBLIC_EXPERIMENTS_ENABLED);
 }
 
 /** Raw `NEXT_PUBLIC_INSIGHTS_ENABLED` value — `"true"` when AI Insights integration is on. */
 export function getInsightsEnabledEnv(): string | undefined {
-  return readTrimmed("NEXT_PUBLIC_INSIGHTS_ENABLED");
+  return clean(process.env.NEXT_PUBLIC_INSIGHTS_ENABLED);
 }
 
 /** Raw `NEXT_PUBLIC_STUDIO_ENABLED` value — `"true"` when Creator Studio is on. */
 export function getStudioEnabledEnv(): string | undefined {
-  return readTrimmed("NEXT_PUBLIC_STUDIO_ENABLED");
+  return clean(process.env.NEXT_PUBLIC_STUDIO_ENABLED);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Hotfix (cherry-pick onto main)

Single-commit hotfix. Restores the Bitbucket/Codeberg/GitLab data-source link/unlink rows in the User Menu, which silently disappeared for all users in production.

This is cherry-picked directly onto `main` (not a develop→main merge) to keep the production change minimal — `develop` has diverged with substantial unreleased work that is **not** part of this hotfix.

### Root cause
`env.ts` read `NEXT_PUBLIC_*` vars via dynamic `process.env[name]`. Next.js only inlines public env vars into the **client** bundle for static literal references, so every `NEXT_PUBLIC_*` reader returned `undefined` in the browser. The client-side `isBitbucketEnabledSync()` gate in `UserMenu.tsx` always evaluated false → status fetch skipped → rows never rendered. Also affected `isInsightsEnabledSync` / `isStudioEnabledSync`.

### Fix
Reference each `NEXT_PUBLIC_*` var as a static literal via a new `clean()` helper. Server-only readers keep `readTrimmed`. Added a source-level guard test.

### Verification
- env test 16/16, typecheck clean (verified on a main-based worktree)
- Full suite (7,928 tests), lint, typecheck green on `develop` for the same commit

Fixes #918

🤖 Generated with [Claude Code](https://claude.com/claude-code)