### PR TITLE
fix: make smoke materialization fully read-only

### DIFF
--- a/apps/web/app/u/[handle]/badge.svg/route.test.ts
+++ b/apps/web/app/u/[handle]/badge.svg/route.test.ts
@@ -184,6 +184,7 @@ describe("GET /u/[handle]/badge.svg", () => {
 
     expect(mockMaterializePublicProfile).toHaveBeenCalledWith("testuser", {
       token: "oauth-token",
+      readOnly: false,
     });
   });
 
@@ -239,6 +240,10 @@ describe("GET /u/[handle]/badge.svg", () => {
     );
     await GET(req, ctx);
 
+    expect(mockMaterializePublicProfile).toHaveBeenCalledWith("testuser", {
+      token: undefined,
+      readOnly: true,
+    });
     expect(mockRunPublicProfileSideEffects).toHaveBeenCalledWith(
       "testuser",
       FAKE_MATERIALIZED,
@@ -248,6 +253,7 @@ describe("GET /u/[handle]/badge.svg", () => {
       },
     );
     expect(mockCacheSet).not.toHaveBeenCalled();
+    expect(mockGetAvatarBase64).not.toHaveBeenCalled();
   });
 
   it("falls back to an undefined avatar when avatar fetch fails", async () => {

--- a/apps/web/app/u/[handle]/badge.svg/route.ts
+++ b/apps/web/app/u/[handle]/badge.svg/route.ts
@@ -225,7 +225,10 @@ export async function GET(
       }
     }
 
-    const materialized = await materializePublicProfile(handle, { token });
+    const materialized = await materializePublicProfile(handle, {
+      token,
+      readOnly,
+    });
     if (!materialized) {
       const fallbackResult = {
         svg: fallbackSvg(handle, "Could not load data — try again later."),
@@ -238,7 +241,7 @@ export async function GET(
       return new NextResponse(fallbackResult.svg, { headers: fallbackResult.headers });
     }
 
-    const avatarDataUri = materialized.stats.avatarUrl
+    const avatarDataUri = !readOnly && materialized.stats.avatarUrl
       ? await getAvatarBase64(handle, materialized.stats.avatarUrl).catch(() => undefined)
       : undefined;
     const verification = getPublicProfileVerification(materialized);

--- a/apps/web/app/u/[handle]/page.test.ts
+++ b/apps/web/app/u/[handle]/page.test.ts
@@ -75,9 +75,10 @@ describe("SharePage", () => {
   // #230 — badge img must have fetchpriority="high" (LCP element)
   describe("badge img fetchpriority", () => {
     it("has fetchpriority=\"high\" on the badge img tag", () => {
-      // Find the JSX <img that contains badge.svg (multi-line JSX with \n between attrs)
-      // Use \n after <img to distinguish from the single-line embed HTML string
-      const imgMatch = SOURCE.match(/<img\n[\s\S]*?badge\.svg[\s\S]*?\/>/);
+      expect(SOURCE).toContain("badgeImageSrc");
+      expect(SOURCE).toContain("badge.svg?");
+      // Find the fallback badge JSX <img (multi-line JSX with \n between attrs).
+      const imgMatch = SOURCE.match(/<img\n[\s\S]*?src=\{badgeImageSrc\}[\s\S]*?\/>/);
       expect(imgMatch).not.toBeNull();
       expect(imgMatch![0]).toContain('fetchPriority="high"');
     });

--- a/apps/web/app/u/[handle]/page.test.tsx
+++ b/apps/web/app/u/[handle]/page.test.tsx
@@ -173,7 +173,9 @@ describe("SharePage /u/[handle]", () => {
   it("renders the inline badge from displayImpact, not rawImpact", async () => {
     await renderPage();
 
-    expect(mockMaterializePublicProfile).toHaveBeenCalledWith("testuser");
+    expect(mockMaterializePublicProfile).toHaveBeenCalledWith("testuser", {
+      readOnly: false,
+    });
     expect(mockRenderBadgeSvg).toHaveBeenCalledWith(
       FAKE_MATERIALIZED.stats,
       FAKE_MATERIALIZED.displayImpact,
@@ -202,7 +204,11 @@ describe("SharePage /u/[handle]", () => {
   it("does not register side effects in read-only smoke mode", async () => {
     await SharePageContent({ handle: "testuser", readOnly: true });
 
+    expect(mockMaterializePublicProfile).toHaveBeenCalledWith("testuser", {
+      readOnly: true,
+    });
     expect(mockRenderBadgeSvg).toHaveBeenCalled();
+    expect(mockGetAvatarBase64).not.toHaveBeenCalled();
     expect(mockAfter).not.toHaveBeenCalled();
     expect(mockRunPublicProfileSideEffects).not.toHaveBeenCalled();
   });

--- a/apps/web/app/u/[handle]/page.tsx
+++ b/apps/web/app/u/[handle]/page.tsx
@@ -114,7 +114,7 @@ export async function SharePageContent({
   // Session is checked client-side via SharePageOwnerContent and NavbarClient.
   // Stats fetch uses env GITHUB_TOKEN fallback (no per-user OAuth token).
 
-  const materialized = await materializePublicProfile(handle);
+  const materialized = await materializePublicProfile(handle, { readOnly });
   const stats = materialized?.stats ?? null;
   const impact = materialized?.displayImpact ?? null;
   const verification = materialized
@@ -138,7 +138,7 @@ export async function SharePageContent({
     // TTFB. The /u/[handle]/badge.svg route awaits the avatar fully on its
     // own first render and writes the avatar-bearing SVG to the same
     // cache, so warm visits to the share page get the real avatar.
-    const avatarPromise = stats.avatarUrl
+    const avatarPromise = !readOnly && stats.avatarUrl
       ? getAvatarBase64(handle, stats.avatarUrl).catch(() => undefined)
       : Promise.resolve(undefined);
     const AVATAR_DEADLINE_MS = 250;
@@ -173,6 +173,11 @@ export async function SharePageContent({
   }
 
   const badgeCacheBuster = stats?.fetchedAt ?? new Date().toISOString();
+  const badgeSrcParams = new URLSearchParams({
+    v: badgeCacheBuster,
+    ...(readOnly ? { [READ_ONLY_SMOKE_PARAM]: "1" } : {}),
+  });
+  const badgeImageSrc = `/u/${encodeURIComponent(handle)}/badge.svg?${badgeSrcParams.toString()}`;
 
   const embedMarkdown = `![Chapa Badge](https://chapa.thecreativetoken.com/u/${handle}/badge.svg)`;
 
@@ -238,7 +243,7 @@ export async function SharePageContent({
                 <BadgeSkeleton />
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
-                  src={`/u/${encodeURIComponent(handle)}/badge.svg?v=${encodeURIComponent(badgeCacheBuster)}`}
+                  src={badgeImageSrc}
                   alt={interpolate(t("sharePage.badgeAlt") as string, { handle })}
                   width={1200}
                   height={630}

--- a/apps/web/app/u/[handle]/share-page.render.test.tsx
+++ b/apps/web/app/u/[handle]/share-page.render.test.tsx
@@ -261,6 +261,22 @@ describe("Phase 4d — Share page i18n", () => {
       const jsxString = JSON.stringify(result);
       expect(jsxString).toContain("Tu Impacto, Decodificado");
     });
+
+    it("keeps fallback badge image requests read-only in smoke mode", async () => {
+      mockRenderBadgeSvg.mockReturnValue("");
+
+      const result = await SharePageContent({
+        handle: "testuser",
+        readOnly: true,
+      });
+      const jsxString = JSON.stringify(result);
+
+      expect(jsxString).toContain("/u/testuser/badge.svg?");
+      expect(jsxString).toContain("__chapa_smoke=1");
+      expect(mockGetAvatarBase64).not.toHaveBeenCalled();
+      expect(mockAfter).not.toHaveBeenCalled();
+      expect(mockWriteBadgeSvgCache).not.toHaveBeenCalled();
+    });
   });
 
   describe("page.tsx source — LocaleSync mount", () => {

--- a/apps/web/lib/github/client.test.ts
+++ b/apps/web/lib/github/client.test.ts
@@ -132,6 +132,21 @@ describe("getStats", () => {
     expect(mockFetchStatsData).not.toHaveBeenCalled();
   });
 
+  it("does not write caches or user registry in read-only mode", async () => {
+    const githubStats = makeStats();
+    setupCacheMiss(githubStats);
+
+    const result = await getStats("test-user", undefined, { readOnly: true });
+
+    expect(result).toEqual(githubStats);
+    expect(mockFetchStatsData).toHaveBeenCalledWith("test-user", undefined);
+    expect(mockFetchBitbucketIfLinked).not.toHaveBeenCalled();
+    expect(mockFetchCodebergIfLinked).not.toHaveBeenCalled();
+    expect(mockFetchGitlabIfLinked).not.toHaveBeenCalled();
+    expect(mockCacheSet).not.toHaveBeenCalled();
+    expect(mockDbUpsertUser).not.toHaveBeenCalled();
+  });
+
   it("enriches cached stats with linkedPlatformLogins when missing", async () => {
     // Simulate pre-deploy cached data: has linkedPlatforms but no linkedPlatformLogins
     const cached = makeStats({
@@ -184,6 +199,22 @@ describe("getStats", () => {
       expect.objectContaining({ linkedPlatformLogins: { bitbucket: "bb-user" } }),
       expect.any(Number),
     );
+  });
+
+  it("PE-L2: does not backfill enriched stats in read-only mode", async () => {
+    const cached = makeStats({
+      linkedPlatforms: ["bitbucket"],
+    });
+    mockCacheGet.mockResolvedValue(cached);
+    mockDbGetLinkedPlatform.mockResolvedValue({
+      remoteLogin: "bb-user",
+      tokens: { accessToken: "t", refreshToken: null, expiresAt: null },
+    });
+
+    const result = await getStats("test-user", undefined, { readOnly: true });
+
+    expect(result!.linkedPlatformLogins).toEqual({ bitbucket: "bb-user" });
+    expect(mockCacheSet).not.toHaveBeenCalled();
   });
 
   it("PE-L2: does not backfill the cache when no logins are found", async () => {

--- a/apps/web/lib/github/client.ts
+++ b/apps/web/lib/github/client.ts
@@ -47,16 +47,24 @@ export function _resetInflight(): void {
 export async function getStats(
   handle: string,
   token?: string,
+  options: { readOnly?: boolean } = {},
 ): Promise<StatsData | null> {
   const lowerHandle = handle.toLowerCase();
   const cacheKey = `stats:v2:merged:${lowerHandle}`;
-  const publicInflightKey = `${lowerHandle}:public`;
-  const authenticatedInflightKey = `${lowerHandle}:authenticated`;
+  const mode = options.readOnly ? "readonly" : "write";
+  const publicInflightKey = `${lowerHandle}:public:${mode}`;
+  const authenticatedInflightKey = `${lowerHandle}:authenticated:${mode}`;
   const inflightKey = token ? authenticatedInflightKey : publicInflightKey;
 
   // Try primary cache first (no dedup needed for cache hits)
   const cached = await cacheGet<StatsData>(cacheKey);
-  if (cached) return _enrichWithLogins(cached, handle, cacheKey);
+  if (cached) {
+    return _enrichWithLogins(
+      cached,
+      handle,
+      options.readOnly ? undefined : cacheKey,
+    );
+  }
 
   // Public callers can share an authenticated fetch. Authenticated callers
   // must not reuse a weaker public fetch.
@@ -70,7 +78,9 @@ export async function getStats(
   // even if the underlying fetch hangs indefinitely (e.g. GitHub never responds).
   // A timed-out promise resolves to null via the catch below, which causes the
   // caller to fall back to stale cache exactly as a failed API call would.
-  const rawPromise = _fetchAndCache(handle, lowerHandle, cacheKey, token);
+  const rawPromise = _fetchAndCache(handle, lowerHandle, cacheKey, token, {
+    readOnly: options.readOnly,
+  });
   const promise = withTimeout(rawPromise, INFLIGHT_TIMEOUT_MS, `getStats(${handle})`).catch(
     (err) => {
       console.error(`[github] inflight fetch timed out for ${handle}:`, err);
@@ -139,6 +149,7 @@ async function _fetchAndCache(
   lowerHandle: string,
   cacheKey: string,
   token?: string,
+  options: { readOnly?: boolean } = {},
 ): Promise<StatsData | null> {
   const staleKey = `stats:stale:${lowerHandle}`;
 
@@ -157,11 +168,17 @@ async function _fetchAndCache(
   }
 
   // Fetch Bitbucket + Codeberg + GitLab in parallel — error in one must not block the others
-  const [bbResult, cbResult, glResult] = await Promise.allSettled([
-    fetchBitbucketIfLinked(handle, lowerHandle),
-    fetchCodebergIfLinked(handle, lowerHandle),
-    fetchGitlabIfLinked(handle, lowerHandle),
-  ]);
+  const [bbResult, cbResult, glResult] = options.readOnly
+    ? [
+        { status: "fulfilled", value: null },
+        { status: "fulfilled", value: null },
+        { status: "fulfilled", value: null },
+      ] as const
+    : await Promise.allSettled([
+        fetchBitbucketIfLinked(handle, lowerHandle),
+        fetchCodebergIfLinked(handle, lowerHandle),
+        fetchGitlabIfLinked(handle, lowerHandle),
+      ]);
 
   const bbStats = bbResult.status === "fulfilled" ? bbResult.value : null;
   const cbStats = cbResult.status === "fulfilled" ? cbResult.value : null;
@@ -193,10 +210,12 @@ async function _fetchAndCache(
     const persisted = await dbGetSupplemental(lowerHandle);
     if (persisted) {
       supplemental = persisted;
-      fireAndForget(
-        () => cacheSet(supplementalKey, persisted, SUPPLEMENTAL_TTL),
-        () => undefined,
-      );
+      if (!options.readOnly) {
+        fireAndForget(
+          () => cacheSet(supplementalKey, persisted, SUPPLEMENTAL_TTL),
+          () => undefined,
+        );
+      }
     }
   }
   if (supplemental) {
@@ -240,6 +259,10 @@ async function _fetchAndCache(
       linkedPlatforms,
       ...(Object.keys(linkedPlatformLogins).length > 0 && { linkedPlatformLogins }),
     };
+  }
+
+  if (options.readOnly) {
+    return stats;
   }
 
   // Cache the final (possibly merged) result — both primary and stale fallback

--- a/apps/web/lib/profile/materialize-profile.test.ts
+++ b/apps/web/lib/profile/materialize-profile.test.ts
@@ -188,11 +188,27 @@ describe("materializeProfile", () => {
       today: "2026-04-17",
     });
 
-    expect(mockGetStats).toHaveBeenCalledWith("testuser", "oauth-token");
+    expect(mockGetStats).toHaveBeenCalledWith("testuser", "oauth-token", {
+      readOnly: undefined,
+    });
     expect(mockGetCachedCraftScore).toHaveBeenCalledWith("testuser");
     expect(result?.craftResult).toEqual(craftResult);
     // Regression: stored craft must not be mutated by a refresh/read.
     // (No dbRecomputeCraft path exists anymore.)
+  });
+
+  it("passes read-only mode to the stats loader", async () => {
+    const stats = makeFullStats({ handle: "testuser" });
+    mockGetStats.mockResolvedValue(stats);
+    mockGetCachedCraftScore.mockResolvedValue(null);
+    mockGetCachedLatestSnapshot.mockResolvedValue(null);
+    mockIsStatsDirty.mockResolvedValue(false);
+
+    await materializeProfile("testuser", { readOnly: true });
+
+    expect(mockGetStats).toHaveBeenCalledWith("testuser", undefined, {
+      readOnly: true,
+    });
   });
 
   it("tolerates craft and snapshot loader failures for public consumers", async () => {

--- a/apps/web/lib/profile/materialize-profile.ts
+++ b/apps/web/lib/profile/materialize-profile.ts
@@ -39,6 +39,7 @@ export interface MaterializedImpactState {
 export interface MaterializeProfileOptions
   extends Omit<MaterializeImpactStateOptions, "craftResult" | "latestSnapshot"> {
   token?: string;
+  readOnly?: boolean;
 }
 
 export interface MaterializedProfile extends MaterializedImpactState {
@@ -80,7 +81,7 @@ export async function materializeProfile(
   // the whole profile fetch.
   const [statsSettled, craftSettled, snapshotSettled, dirtySettled] =
     await Promise.allSettled([
-      getStats(handle, options.token),
+      getStats(handle, options.token, { readOnly: options.readOnly }),
       getCachedCraftScore(handle),
       getCachedLatestSnapshot(handle),
       isStatsDirty(handle),

--- a/apps/web/lib/profile/public-profile.test.ts
+++ b/apps/web/lib/profile/public-profile.test.ts
@@ -116,9 +116,24 @@ describe("materializePublicProfile", () => {
     expect(mockMaterializeProfile).toHaveBeenCalledWith("testuser", {
       token: "oauth-token",
       today: undefined,
+      readOnly: undefined,
       policy: "public-display",
     });
     expect(result).toBe(materialized);
+  });
+
+  it("passes read-only mode to the shared materializer", async () => {
+    const materialized = makeMaterializedProfile();
+    mockMaterializeProfile.mockResolvedValue(materialized);
+
+    await materializePublicProfile("testuser", { readOnly: true });
+
+    expect(mockMaterializeProfile).toHaveBeenCalledWith("testuser", {
+      token: undefined,
+      today: undefined,
+      readOnly: true,
+      policy: "public-display",
+    });
   });
 });
 

--- a/apps/web/lib/profile/public-profile.ts
+++ b/apps/web/lib/profile/public-profile.ts
@@ -19,11 +19,12 @@ export interface PublicVerificationCode {
 
 export async function materializePublicProfile(
   handle: string,
-  options: { token?: string; today?: string } = {},
+  options: { token?: string; today?: string; readOnly?: boolean } = {},
 ): Promise<MaterializedProfile | null> {
   return materializeProfile(handle, {
     token: options.token,
     today: options.today,
+    readOnly: options.readOnly,
     policy: "public-display",
   });
 }


### PR DESCRIPTION
Follow-up to #922. The first patch skipped deferred public-profile side effects, but smoke reads could still write through lower-level materialization: stats/stale cache, user registry upsert, platform negative caches, supplemental cache hydration, and avatar cache.\n\nThis patch threads readOnly through materializePublicProfile -> materializeProfile -> getStats, skips write-through cache/registry/platform probes in smoke mode, skips avatar cache fetches, and preserves __chapa_smoke=1 on fallback badge image URLs.\n\nVerification:\n- pnpm vitest run apps/web/lib/github/client.test.ts apps/web/lib/profile/materialize-profile.test.ts apps/web/lib/profile/public-profile.test.ts 'apps/web/app/u/[handle]/badge.svg/route.test.ts' 'apps/web/app/u/[handle]/page.test.tsx' 'apps/web/app/u/[handle]/share-page.render.test.tsx'\n- pnpm run typecheck\n- pnpm run lint\n- pnpm run test