### PR TITLE
hotfix: restore full-page locale translation on landing page

### DIFF
--- a/apps/web/app/page.render.test.tsx
+++ b/apps/web/app/page.render.test.tsx
@@ -2,8 +2,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
 
-// Mock getServerT to return English without needing Next.js infrastructure.
-// Page now renders at DEFAULT_LOCALE statically (no getServerLocale call at render time).
+// Mock getServerLocale + getServerT to return English without needing Next.js infrastructure.
 // Uses a deep-traversal resolver that returns sub-objects (not just leaves) for intermediate keys.
 vi.mock("@/lib/i18n/server", async () => {
   const { en } = await import("@/lib/i18n/dictionaries/en");
@@ -18,6 +17,7 @@ vi.mock("@/lib/i18n/server", async () => {
     return current;
   }
   return {
+    getServerLocale: vi.fn().mockResolvedValue("en"),
     getServerT: vi.fn().mockImplementation(() => (key: string) =>
       deepGet(en as unknown as Record<string, unknown>, key)
     ),

--- a/apps/web/app/page.test.ts
+++ b/apps/web/app/page.test.ts
@@ -22,18 +22,18 @@ describe("Landing page (server component)", () => {
     });
   });
 
-  describe("static rendering (ISR-cacheable, DEFAULT_LOCALE)", () => {
-    it("does not use force-dynamic directive (page must be statically renderable)", () => {
+  describe("rendering mode", () => {
+    it("does not use force-dynamic directive (Next.js infers dynamic from cookies() call)", () => {
       expect(SOURCE).not.toContain("export const dynamic = 'force-dynamic'");
     });
 
-    it("does not use force-static directive (default Next.js static rendering is fine)", () => {
+    it("does not use force-static directive", () => {
       expect(SOURCE).not.toContain("export const dynamic = 'force-static'");
     });
   });
 
   describe("rendering", () => {
-    it("renders NavbarClient (ISR-compatible, no headers() call)", () => {
+    it("renders NavbarClient (session fetched client-side)", () => {
       expect(SOURCE).toContain("NavbarClient");
     });
 
@@ -90,15 +90,14 @@ describe("Landing page (server component)", () => {
       expect(SOURCE).toContain("getServerT");
     });
 
-    it("renders at DEFAULT_LOCALE statically (no cookie read at render time)", () => {
-      // Page must NOT call getServerLocale() — that reads cookies/headers, which
-      // prevents ISR caching. Instead it uses DEFAULT_LOCALE directly and relies
-      // on the LocaleSync client component to switch locale after hydration.
-      expect(SOURCE).not.toContain("getServerLocale");
-      expect(SOURCE).toContain("DEFAULT_LOCALE");
+    it("uses getServerLocale() to read locale from cookie/header for full page translation", () => {
+      // The page is server-rendered per-request so switching locale via the
+      // LanguageSwitcher (which sets chapa-locale cookie + calls router.refresh())
+      // results in the server re-rendering all content in the correct language.
+      expect(SOURCE).toContain("getServerLocale");
     });
 
-    it("renders LocaleSync for sticky lang override", () => {
+    it("renders LocaleSync for sticky ?lang= query param override", () => {
       expect(SOURCE).toContain("LocaleSync");
     });
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -3,8 +3,7 @@ import { CopyButton } from "@/components/CopyButton";
 import { ErrorBanner } from "@/components/ErrorBanner";
 import { NavbarClient } from "@/components/NavbarClient";
 import { LocaleSync } from "@/lib/i18n";
-import { getServerT } from "@/lib/i18n/server";
-import { DEFAULT_LOCALE } from "@/lib/i18n/types";
+import { getServerLocale, getServerT } from "@/lib/i18n/server";
 import { getOAuthErrorMessage } from "@/lib/auth/error-messages";
 import { renderBadgeSvg } from "@/lib/render/BadgeSvg";
 import { DEMO_STATS, DEMO_IMPACT } from "@/lib/render/demoData";
@@ -65,12 +64,8 @@ export default async function Home({
 }) {
   const { error, lang } = await searchParams;
   const errorMessage = getOAuthErrorMessage(error);
-  // Render statically at DEFAULT_LOCALE ('es') for CDN/ISR cacheability.
-  // The LocaleSync client component handles locale switching after hydration:
-  // when the user has a chapa-locale cookie set to 'en', LocaleSync loads the
-  // English dictionary client-side and re-renders without a server round-trip.
-  // This keeps the landing page ISR-cacheable while still supporting i18n.
-  const t = getServerT(DEFAULT_LOCALE);
+  const locale = await getServerLocale(lang);
+  const t = getServerT(locale);
 
   const navLinks = t('landing.navLinks') as unknown as Array<{ label: string; href: string }>;
 


### PR DESCRIPTION
## Summary

- **Root cause**: `c93ee637` (Wave 2) removed `getServerLocale()` from `page.tsx` for ISR cacheability. All landing page content is server-rendered — switching locale in the UI only updated the nav labels (client-side), while the hero, features, CTAs, and all other sections stayed in Spanish permanently.
- **Fix**: Restore `getServerLocale(lang)`. The server reads the `chapa-locale` cookie per-request and renders the full page in the correct language. `router.refresh()` after locale switch now returns the right language end-to-end.
- **Trade-off accepted**: The landing page is no longer ISR-cached (reads cookies → dynamic rendering). ISR was a medium-severity finding; breaking i18n for all English users is the worse trade-off.
- **Tests updated**: ISR-static assertions updated to dynamic-rendering assertions; `getServerLocale` mock added to render tests.

## Test plan
- [x] Full test suite: 8114/8114 passing
- [x] TypeScript: no errors
- [x] ESLint: no warnings
- Verified manually via browser: switching to EN now renders the entire page in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UM9dcHmJrjYakwP2H9BAbX