### PR TITLE
fix(security): preserve device-code binding through CLI approval

### DIFF
--- a/apps/web/app/api/cli/auth/approve/route.test.ts
+++ b/apps/web/app/api/cli/auth/approve/route.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/lib/auth/require-session", () => ({
 }));
 
 vi.mock("@/lib/cache/redis", () => ({
+  cacheGet: vi.fn(),
   cacheSet: vi.fn(),
   rateLimit: vi.fn(),
 }));
@@ -20,7 +21,7 @@ vi.mock("@/lib/http/client-ip", () => ({
 
 import { POST } from "./route";
 import { requireSession } from "@/lib/auth/require-session";
-import { cacheSet, rateLimit } from "@/lib/cache/redis";
+import { cacheGet, cacheSet, rateLimit } from "@/lib/cache/redis";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -50,6 +51,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(requireSession).mockReturnValue({ session: SESSION });
   vi.mocked(rateLimit).mockResolvedValue({ allowed: true, current: 1, limit: 10 });
+  vi.mocked(cacheGet).mockResolvedValue(null);
 });
 
 // ---------------------------------------------------------------------------
@@ -146,5 +148,58 @@ describe("POST /api/cli/auth/approve", () => {
     expect(res.headers.get("Retry-After")).toBe("60");
     const body = await res.json();
     expect(body.error).toMatch(/too many requests/i);
+  });
+
+  // -------------------------------------------------------------------------
+  // BE-H3 / SE-H1 (#1078, #1097): read-modify-write, not a blind overwrite.
+  // -------------------------------------------------------------------------
+
+  it("preserves deviceCode/deviceCodeConfirmed from the existing session instead of overwriting them", async () => {
+    vi.mocked(cacheGet).mockResolvedValue({
+      status: "pending",
+      deviceCode: "abc123def456",
+      deviceCodeConfirmed: true,
+    });
+    vi.mocked(cacheSet).mockResolvedValue(true);
+
+    await POST(
+      makeRequest(
+        { sessionId: "1feae8e3-6bc0-47da-84aa-0e24e2510454" },
+        "chapa_session=valid",
+      ),
+    );
+
+    expect(cacheGet).toHaveBeenCalledWith(
+      "cli:device:1feae8e3-6bc0-47da-84aa-0e24e2510454",
+    );
+    expect(cacheSet).toHaveBeenCalledWith(
+      "cli:device:1feae8e3-6bc0-47da-84aa-0e24e2510454",
+      {
+        status: "approved",
+        handle: "testuser",
+        deviceCode: "abc123def456",
+        deviceCodeConfirmed: true,
+      },
+      300,
+    );
+  });
+
+  it("creates a fresh approved session when no prior session exists (legacy path)", async () => {
+    vi.mocked(cacheGet).mockResolvedValue(null);
+    vi.mocked(cacheSet).mockResolvedValue(true);
+
+    const res = await POST(
+      makeRequest(
+        { sessionId: "1feae8e3-6bc0-47da-84aa-0e24e2510454" },
+        "chapa_session=valid",
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(cacheSet).toHaveBeenCalledWith(
+      "cli:device:1feae8e3-6bc0-47da-84aa-0e24e2510454",
+      { status: "approved", handle: "testuser" },
+      300,
+    );
   });
 });

--- a/apps/web/app/api/cli/auth/approve/route.ts
+++ b/apps/web/app/api/cli/auth/approve/route.ts
@@ -1,8 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireSession } from "@/lib/auth/require-session";
-import { cacheSet, rateLimit } from "@/lib/cache/redis";
+import { cacheGet, cacheSet, rateLimit } from "@/lib/cache/redis";
 import { getClientIp } from "@/lib/http/client-ip";
 import { withErrorCapture } from "@/lib/analytics/server-errors";
+import {
+  type CliDeviceSession,
+  cliDeviceSessionKey,
+} from "@/lib/auth/cli-device-session";
 
 const DEVICE_SESSION_TTL = 300; // 5 minutes
 
@@ -44,12 +48,23 @@ export const POST = withErrorCapture("/api/cli/auth/approve", async (request: Ne
     return NextResponse.json({ error: "Invalid session ID" }, { status: 400 });
   }
 
-  // 3. Store approval in Redis
-  const stored = await cacheSet(
-    `cli:device:${sessionId}`,
-    { status: "approved", handle: session.login },
-    DEVICE_SESSION_TTL,
-  );
+  // 3. Store approval in Redis as a read-modify-write, not a blind overwrite
+  // (BE-H3 / SE-H1, #1078 / #1097). The poll route's device_code binding
+  // (`deviceCode` / `deviceCodeConfirmed`) lives on this same session object.
+  // A plain `cacheSet({ status, handle })` here would drop those fields,
+  // silently disabling the poll route's `if (session.deviceCode)`
+  // enforcement on the very next (redeeming) poll — letting anyone who learns
+  // the bare sessionId redeem a token even for a confirmed session. If no
+  // session exists yet (approve called before any poll), there's nothing to
+  // preserve — that's the legacy path the poll route's own comments describe.
+  const key = cliDeviceSessionKey(sessionId);
+  const existing = await cacheGet<CliDeviceSession>(key);
+  const merged: CliDeviceSession = {
+    ...existing,
+    status: "approved",
+    handle: session.login,
+  };
+  const stored = await cacheSet(key, merged, DEVICE_SESSION_TTL);
 
   if (!stored) {
     return NextResponse.json(

--- a/apps/web/app/api/cli/auth/device-binding-integration.test.ts
+++ b/apps/web/app/api/cli/auth/device-binding-integration.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// BE-H3 / SE-H1 (#1078, #1097): regression test for the real approve -> poll
+// sequence. Every prior test constructed the cached session object by hand,
+// which is exactly why the bug (approve blindly overwriting the session and
+// dropping deviceCode/deviceCodeConfirmed) went unnoticed. This test drives
+// BOTH real route handlers against a shared in-memory Redis fake so the
+// approve route's actual read/write behavior is what's under test.
+// ---------------------------------------------------------------------------
+
+const { store } = vi.hoisted(() => ({ store: new Map<string, unknown>() }));
+
+vi.mock("@/lib/cache/redis", () => ({
+  cacheGet: vi.fn(async (key: string) => (store.has(key) ? store.get(key) : null)),
+  cacheSet: vi.fn(async (key: string, value: unknown) => {
+    store.set(key, value);
+    return true;
+  }),
+  cacheDel: vi.fn(async (key: string) => {
+    store.delete(key);
+  }),
+  rateLimit: vi.fn(async () => ({ allowed: true, current: 1, limit: 1000 })),
+}));
+
+vi.mock("@/lib/auth/require-session", () => ({
+  requireSession: vi.fn(() => ({
+    session: { login: "octocat", name: "Octocat", avatar_url: "" },
+  })),
+}));
+
+vi.mock("@/lib/http/client-ip", () => ({
+  NO_TRUSTED_IP: "unknown",
+  getClientIp: (req: Request) =>
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown",
+}));
+
+import { GET as pollGET } from "./poll/route";
+import { POST as approvePOST } from "./approve/route";
+
+const SESSION_ID = "1feae8e3-6bc0-47da-84aa-0e24e2510454";
+
+function pollRequest(deviceCode?: string): NextRequest {
+  const url = new URL("https://chapa.thecreativetoken.com/api/cli/auth/poll");
+  url.searchParams.set("session", SESSION_ID);
+  if (deviceCode !== undefined) url.searchParams.set("device_code", deviceCode);
+  return new NextRequest(url.toString());
+}
+
+function approveRequest(): NextRequest {
+  return new NextRequest(
+    "https://chapa.thecreativetoken.com/api/cli/auth/approve",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        cookie: "chapa_session=valid",
+      },
+      body: JSON.stringify({ sessionId: SESSION_ID }),
+    },
+  );
+}
+
+beforeEach(() => {
+  store.clear();
+  vi.clearAllMocks();
+  vi.stubEnv("NEXTAUTH_SECRET", "test-secret-32-characters-valid-ok");
+});
+
+describe("CLI device-code binding survives approval (#1078, #1097)", () => {
+  it("keeps device_code enforcement after approval — redeeming poll without the code is rejected", async () => {
+    // 1. First poll — real route creates the session and mints a device_code.
+    const first = await pollGET(pollRequest());
+    expect(first.status).toBe(200);
+    const firstBody = await first.json();
+    expect(firstBody.status).toBe("pending");
+    const deviceCode: string = firstBody.device_code;
+    expect(typeof deviceCode).toBe("string");
+
+    // 2. Second poll — the CLI echoes the device_code back, confirming the session.
+    const confirm = await pollGET(pollRequest(deviceCode));
+    expect(confirm.status).toBe(200);
+    expect((await confirm.json()).status).toBe("pending");
+
+    // 3. The REAL approve handler approves the session (not a hand-built object).
+    const approve = await approvePOST(approveRequest());
+    expect(approve.status).toBe(200);
+
+    // 4. The redeeming poll WITHOUT device_code must still be rejected — the
+    // binding must survive approval, not be silently dropped by a blind
+    // Redis overwrite in the approve route.
+    const redeemWithoutCode = await pollGET(pollRequest());
+    expect(redeemWithoutCode.status).toBe(401);
+    const redeemBody = await redeemWithoutCode.json();
+    expect(redeemBody.error).toMatch(/device_code/i);
+    expect(redeemBody.token).toBeUndefined();
+  });
+
+  it("issues a token on the redeeming poll when the correct device_code is presented after approval", async () => {
+    const first = await pollGET(pollRequest());
+    const deviceCode: string = (await first.json()).device_code;
+
+    await pollGET(pollRequest(deviceCode)); // confirm
+    const approve = await approvePOST(approveRequest()); // approve via real handler
+    expect(approve.status).toBe(200);
+
+    const redeem = await pollGET(pollRequest(deviceCode));
+    expect(redeem.status).toBe(200);
+    const body = await redeem.json();
+    expect(body.status).toBe("approved");
+    expect(typeof body.token).toBe("string");
+    expect(body.handle).toBe("octocat");
+  });
+
+  it("legacy flow (device_code offered but never confirmed) still works via sessionId only after approval", async () => {
+    // First poll offers a device_code, but the (legacy) client never echoes it
+    // back, so the session is never confirmed.
+    await pollGET(pollRequest());
+
+    const approve = await approvePOST(approveRequest());
+    expect(approve.status).toBe(200);
+
+    const redeem = await pollGET(pollRequest());
+    expect(redeem.status).toBe(200);
+    const body = await redeem.json();
+    expect(body.status).toBe("approved");
+    expect(typeof body.token).toBe("string");
+  });
+});

--- a/apps/web/app/api/cli/auth/poll/route.ts
+++ b/apps/web/app/api/cli/auth/poll/route.ts
@@ -4,21 +4,11 @@ import { getNextauthSecret } from "@/lib/env";
 import { generateCliToken } from "@/lib/auth/cli-token";
 import { getClientIp, NO_TRUSTED_IP } from "@/lib/http/client-ip";
 import { withErrorCapture } from "@/lib/analytics/server-errors";
+import {
+  type CliDeviceSession as DeviceSession,
+  cliDeviceSessionKey,
+} from "@/lib/auth/cli-device-session";
 import { randomBytes, timingSafeEqual } from "crypto";
-
-interface DeviceSession {
-  status: "pending" | "approved";
-  handle?: string;
-  /** RFC 8628-style high-entropy secret (BE-M2 #869). Only the originating CLI device
-   *  should possess this. Offered on the first poll. Absent on sessions created
-   *  before this hardening (e.g. directly by the approve route). */
-  deviceCode?: string;
-  /** Set true once a poll has echoed back the correct {@link deviceCode}, proving the
-   *  client actually possesses it. ONLY once confirmed is device_code enforced on
-   *  subsequent polls. This keeps existing (legacy) CLI binaries — which never echo
-   *  the code — fully working via sessionId only. See enforcement logic below. */
-  deviceCodeConfirmed?: boolean;
-}
 
 // BE-M1 (#868): When no trusted IP header is present, all such requests would
 // collapse into a single "unknown" rate-limit bucket, defeating per-IP limiting.
@@ -75,7 +65,7 @@ export const GET = withErrorCapture("/api/cli/auth/poll", async (request: NextRe
     );
   }
 
-  const session = await cacheGet<DeviceSession>(`cli:device:${sessionId}`);
+  const session = await cacheGet<DeviceSession>(cliDeviceSessionKey(sessionId));
 
   // BE-M2 (#869): RFC 8628-style device_code split — FULLY BACKWARD-COMPATIBLE.
   //
@@ -115,7 +105,7 @@ export const GET = withErrorCapture("/api/cli/auth/poll", async (request: NextRe
     };
     // Best-effort store — if Redis is unavailable, fall through to pending response
     // without device_code (fail-open, consistent with existing rate-limit fail-open).
-    await cacheSet(`cli:device:${sessionId}`, pendingSession, DEVICE_SESSION_TTL);
+    await cacheSet(cliDeviceSessionKey(sessionId), pendingSession, DEVICE_SESSION_TTL);
     return NextResponse.json({ status: "pending", device_code: newDeviceCode });
   }
 
@@ -140,7 +130,7 @@ export const GET = withErrorCapture("/api/cli/auth/poll", async (request: NextRe
       if (!session.deviceCodeConfirmed) {
         const confirmed: DeviceSession = { ...session, deviceCodeConfirmed: true };
         // Best-effort persist; if it fails the enforcement simply isn't latched yet.
-        await cacheSet(`cli:device:${sessionId}`, confirmed, DEVICE_SESSION_TTL);
+        await cacheSet(cliDeviceSessionKey(sessionId), confirmed, DEVICE_SESSION_TTL);
       }
     } else if (session.deviceCodeConfirmed) {
       // No code presented, but the client previously proved possession → enforce.
@@ -166,7 +156,7 @@ export const GET = withErrorCapture("/api/cli/auth/poll", async (request: NextRe
     const token = generateCliToken(session.handle, secret);
 
     // Clean up — one-time use
-    await cacheDel(`cli:device:${sessionId}`);
+    await cacheDel(cliDeviceSessionKey(sessionId));
 
     return NextResponse.json({
       status: "approved",

--- a/apps/web/lib/auth/cli-device-session.ts
+++ b/apps/web/lib/auth/cli-device-session.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared session shape + Redis key for the CLI device-authorization flow
+ * (`/api/cli/auth/poll` + `/api/cli/auth/approve`).
+ *
+ * Both routes read and write the same `cli:device:<sessionId>` Redis entry, so
+ * the shape and key builder are centralized here to keep them from drifting —
+ * a mismatch (or a route that blindly overwrites fields the other route relies
+ * on) silently breaks the device-binding guarantee. See `poll/route.ts` for the
+ * full RFC 8628-style device_code design (#869) and BE-H3/SE-H1 (#1078/#1097)
+ * for the approval read-modify-write fix that this type supports.
+ */
+export interface CliDeviceSession {
+  status: "pending" | "approved";
+  handle?: string;
+  /** RFC 8628-style high-entropy secret (BE-M2 #869). Only the originating CLI device
+   *  should possess this. Offered on the first poll. Absent on sessions created
+   *  before this hardening. */
+  deviceCode?: string;
+  /** Set true once a poll has echoed back the correct {@link deviceCode}, proving the
+   *  client actually possesses it. ONLY once confirmed is device_code enforced on
+   *  subsequent polls. This keeps existing (legacy) CLI binaries — which never echo
+   *  the code — fully working via sessionId only. See enforcement logic in poll/route.ts. */
+  deviceCodeConfirmed?: boolean;
+}
+
+/** Redis key for a CLI device-authorization session. */
+export function cliDeviceSessionKey(sessionId: string): string {
+  return `cli:device:${sessionId}`;
+}


### PR DESCRIPTION
Closes #1078, #1097