### PR TITLE
fix(share-page): dynamic rendering, confidence redaction, OAuth error banner

### DIFF
--- a/apps/web/app/u/[handle]/page.test.ts
+++ b/apps/web/app/u/[handle]/page.test.ts
@@ -66,7 +66,9 @@ describe("SharePage", () => {
 
     it("passes stats, impact, and handle to SharePageOwnerContent", () => {
       expect(SOURCE).toContain("stats={stats}");
-      expect(SOURCE).toContain("impact={impact}");
+      // #1067 — impactForClient is the redacted-for-visitors projection of
+      // impact (see redactImpactForVisitor); the raw impact stays server-only.
+      expect(SOURCE).toContain("impact={impactForClient}");
       expect(SOURCE).toContain("handle={handle}");
     });
   });
@@ -137,6 +139,11 @@ describe("SharePage", () => {
 
     it("resolves locale via getServerLocale (cookie/header fallback), not a hardcoded default", () => {
       expect(SOURCE).toContain("getServerLocale");
+    });
+
+    it("imports headers from next/headers to resolve the requester's session", () => {
+      expect(SOURCE).toMatch(/from ["']next\/headers["']/);
+      expect(SOURCE).toMatch(/\bheaders\(\)/);
     });
 
     it("uses NavbarClient (unaffected by the dynamic-rendering change)", () => {

--- a/apps/web/app/u/[handle]/page.test.ts
+++ b/apps/web/app/u/[handle]/page.test.ts
@@ -124,32 +124,27 @@ describe("SharePage", () => {
     });
   });
 
-  // #555 — ISR revalidation for share pages (cuts serverless invocations 80-90%)
-  describe("ISR revalidation", () => {
-    it("exports revalidate = 3600 for Incremental Static Regeneration", () => {
-      expect(SOURCE).toContain("export const revalidate = 3600");
+  // #1066 (FE-H2) — the route was declaring `revalidate = 3600` (ISR) while
+  // both generateMetadata and the page component unconditionally awaited
+  // searchParams, which already opted the route out of static rendering
+  // entirely (confirmed via .next/prerender-manifest.json: no ISR entry).
+  // The route now commits to dynamic rendering instead of paying every ISR
+  // trade-off for a route that was never actually static.
+  describe("dynamic rendering (#1066)", () => {
+    it("does NOT export revalidate (the route is genuinely dynamic, not ISR)", () => {
+      expect(SOURCE).not.toContain("export const revalidate");
     });
 
-    it("does NOT import headers from next/headers (ISR incompatible)", () => {
-      expect(SOURCE).not.toContain('from "next/headers"');
-      expect(SOURCE).not.toContain("from 'next/headers'");
+    it("resolves locale via getServerLocale (cookie/header fallback), not a hardcoded default", () => {
+      expect(SOURCE).toContain("getServerLocale");
     });
 
-    it("does NOT call headers() anywhere (ISR incompatible)", () => {
-      // Ensure no headers() call that would force dynamic rendering
-      expect(SOURCE).not.toMatch(/\bheaders\(\)/);
-    });
-
-    it("does NOT import readSessionCookie (session is client-side)", () => {
-      expect(SOURCE).not.toContain("readSessionCookie");
-    });
-
-    it("uses NavbarClient instead of server-side Navbar", () => {
+    it("uses NavbarClient (unaffected by the dynamic-rendering change)", () => {
       expect(SOURCE).toContain("NavbarClient");
       expect(SOURCE).not.toMatch(/from ["']@\/components\/Navbar["']/);
     });
 
-    it("uses SharePageOwnerContent for client-side owner detection", () => {
+    it("uses SharePageOwnerContent for client-side display gating", () => {
       expect(SOURCE).toContain("SharePageOwnerContent");
     });
   });

--- a/apps/web/app/u/[handle]/page.test.tsx
+++ b/apps/web/app/u/[handle]/page.test.tsx
@@ -109,6 +109,10 @@ vi.mock("@/lib/i18n", () => ({
   LanguageProvider: (props: { children?: unknown }) => props.children,
 }));
 
+vi.mock("@/components/ErrorBanner", () => ({
+  ErrorBanner: () => null,
+}));
+
 vi.mock("@/components/CommandBarHint", () => ({
   CommandBarHint: () => null,
 }));
@@ -130,6 +134,7 @@ vi.mock("@/components/BadgeSkeleton", () => ({
 
 import SharePage, { SharePageContent, generateMetadata } from "./page";
 import { SharePageOwnerContentLazy } from "@/components/SharePageOwnerContentLazy";
+import { ErrorBanner } from "@/components/ErrorBanner";
 
 /**
  * Recursively walk a rendered React element tree (as returned by an async
@@ -335,6 +340,56 @@ describe("SharePage /u/[handle]", () => {
         (el) => !!el.props && "initialLocale" in el.props,
       );
       expect(provider!.props.initialLocale).toBe("en");
+    });
+  });
+
+  // #1107 (UX-H1) — every platform OAuth (Bitbucket/Codeberg/GitLab)
+  // connect/callback failure branch in lib/auth/platform-oauth.ts redirects
+  // back to this exact page as `?error=<platform>_<code>`. Read server-side
+  // (the route is already dynamic per #1066), not via the client
+  // useSyncExternalStore leaf the landing page uses — that pattern exists
+  // solely to avoid opting a static page out of ISR, which is moot here.
+  describe("platform OAuth error banner (#1107)", () => {
+    it("renders an ErrorBanner with a platform-aware message when ?error=<platform>_<code> is present", async () => {
+      const result = await SharePage({
+        params: Promise.resolve({ handle: "testuser" }),
+        searchParams: Promise.resolve({ error: "gitlab_token_exchange" }),
+      });
+
+      const banner = findElement(result, (el) => el.type === ErrorBanner);
+      expect(banner).not.toBeNull();
+      expect(banner!.props.message as string).toContain("GitLab");
+    });
+
+    it("renders no ErrorBanner when there is no error query param", async () => {
+      const result = await SharePage({
+        params: Promise.resolve({ handle: "testuser" }),
+        searchParams: Promise.resolve({}),
+      });
+
+      const banner = findElement(result, (el) => el.type === ErrorBanner);
+      expect(banner).toBeNull();
+    });
+
+    it("renders no ErrorBanner for an unrelated query string", async () => {
+      const result = await SharePage({
+        params: Promise.resolve({ handle: "testuser" }),
+        searchParams: Promise.resolve({ lang: "en" }),
+      });
+
+      const banner = findElement(result, (el) => el.type === ErrorBanner);
+      expect(banner).toBeNull();
+    });
+
+    it("recognizes the base GitHub session_storage code too (#1107 gap fix)", async () => {
+      const result = await SharePage({
+        params: Promise.resolve({ handle: "testuser" }),
+        searchParams: Promise.resolve({ error: "session_storage" }),
+      });
+
+      const banner = findElement(result, (el) => el.type === ErrorBanner);
+      expect(banner).not.toBeNull();
+      expect(typeof banner!.props.message).toBe("string");
     });
   });
 

--- a/apps/web/app/u/[handle]/page.test.tsx
+++ b/apps/web/app/u/[handle]/page.test.tsx
@@ -6,24 +6,30 @@ const {
   mockRunPublicProfileSideEffects,
   mockPersistProfileSnapshot,
   mockDeferProfileCacheWork,
+  mockRedactImpactForVisitor,
   mockIsValidHandle,
   mockGetAvatarBase64,
   mockRenderBadgeSvg,
   mockAfter,
   mockGetServerLocale,
   mockGetTrendData,
+  mockHeaders,
+  mockGetOptionalServerSessionFromHeaders,
 } = vi.hoisted(() => ({
   mockMaterializePublicProfile: vi.fn(),
   mockGetPublicProfileVerification: vi.fn(),
   mockRunPublicProfileSideEffects: vi.fn(),
   mockPersistProfileSnapshot: vi.fn(),
   mockDeferProfileCacheWork: vi.fn(),
+  mockRedactImpactForVisitor: vi.fn(),
   mockIsValidHandle: vi.fn(),
   mockGetAvatarBase64: vi.fn(),
   mockRenderBadgeSvg: vi.fn(),
   mockAfter: vi.fn(),
   mockGetServerLocale: vi.fn(),
   mockGetTrendData: vi.fn(),
+  mockHeaders: vi.fn(),
+  mockGetOptionalServerSessionFromHeaders: vi.fn(),
 }));
 
 vi.mock("@/lib/profile/public-profile", () => ({
@@ -36,6 +42,17 @@ vi.mock("@/lib/profile/public-profile", () => ({
     mockPersistProfileSnapshot(...args),
   deferProfileCacheWork: (...args: unknown[]) =>
     mockDeferProfileCacheWork(...args),
+  redactImpactForVisitor: (...args: unknown[]) =>
+    mockRedactImpactForVisitor(...args),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: (...args: unknown[]) => mockHeaders(...args),
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  getOptionalServerSessionFromHeaders: (...args: unknown[]) =>
+    mockGetOptionalServerSessionFromHeaders(...args),
 }));
 
 vi.mock("@/lib/history/get-trend-data", () => ({
@@ -191,6 +208,15 @@ describe("SharePage /u/[handle]", () => {
     mockRenderBadgeSvg.mockReturnValue(FAKE_SVG);
     mockGetServerLocale.mockResolvedValue("en");
     mockGetTrendData.mockResolvedValue({ trend: null, diff: null });
+    mockHeaders.mockResolvedValue({ get: () => null });
+    // No session by default — most tests exercise the visitor path. Tests
+    // that need owner behavior override this per-test.
+    mockGetOptionalServerSessionFromHeaders.mockReturnValue(null);
+    mockRedactImpactForVisitor.mockImplementation((impact: Record<string, unknown>) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { confidence: _confidence, confidencePenalties: _confidencePenalties, ...rest } = impact;
+      return rest;
+    });
   });
 
   it("generates metadata with the daily OG cache buster", async () => {
@@ -309,6 +335,66 @@ describe("SharePage /u/[handle]", () => {
         (el) => !!el.props && "initialLocale" in el.props,
       );
       expect(provider!.props.initialLocale).toBe("en");
+    });
+  });
+
+  // #1067 (FE-M1) — confidence/confidencePenalties must never reach the
+  // client-serialized props for a non-owner request. Ownership is resolved
+  // server-side (via the session cookie), not client-side, so it can gate
+  // what data is SENT, not just what is displayed.
+  describe("owner-only confidence redaction (#1067)", () => {
+    it("resolves the session via headers() + getOptionalServerSessionFromHeaders", async () => {
+      const fakeHeaderStore = { get: () => null };
+      mockHeaders.mockResolvedValue(fakeHeaderStore);
+
+      await renderPage("testuser");
+
+      expect(mockGetOptionalServerSessionFromHeaders).toHaveBeenCalledWith(fakeHeaderStore);
+    });
+
+    it("passes the redacted impact when there is no session (anonymous visitor)", async () => {
+      mockGetOptionalServerSessionFromHeaders.mockReturnValue(null);
+
+      const result = await renderPage("testuser");
+
+      expect(mockRedactImpactForVisitor).toHaveBeenCalledWith(FAKE_MATERIALIZED.displayImpact);
+      const ownerEl = findElement(result, (el) => el.type === SharePageOwnerContentLazy);
+      const impactProp = ownerEl!.props.impact as Record<string, unknown>;
+      expect("confidence" in impactProp).toBe(false);
+      expect("confidencePenalties" in impactProp).toBe(false);
+    });
+
+    it("passes the redacted impact when a different user's session is present", async () => {
+      mockGetOptionalServerSessionFromHeaders.mockReturnValue({ login: "someone-else" });
+
+      const result = await renderPage("testuser");
+
+      expect(mockRedactImpactForVisitor).toHaveBeenCalledWith(FAKE_MATERIALIZED.displayImpact);
+      const ownerEl = findElement(result, (el) => el.type === SharePageOwnerContentLazy);
+      const impactProp = ownerEl!.props.impact as Record<string, unknown>;
+      expect("confidence" in impactProp).toBe(false);
+    });
+
+    it("passes the FULL impact (including confidence) when the session matches the handle", async () => {
+      mockGetOptionalServerSessionFromHeaders.mockReturnValue({ login: "testuser" });
+
+      const result = await renderPage("testuser");
+
+      expect(mockRedactImpactForVisitor).not.toHaveBeenCalled();
+      const ownerEl = findElement(result, (el) => el.type === SharePageOwnerContentLazy);
+      expect(ownerEl!.props.impact).toEqual(FAKE_MATERIALIZED.displayImpact);
+    });
+
+    it("never redacts the impact used to render the inline badge SVG (server-only, not client-serialized)", async () => {
+      mockGetOptionalServerSessionFromHeaders.mockReturnValue(null);
+
+      await renderPage("testuser");
+
+      expect(mockRenderBadgeSvg).toHaveBeenCalledWith(
+        FAKE_MATERIALIZED.stats,
+        FAKE_MATERIALIZED.displayImpact,
+        expect.anything(),
+      );
     });
   });
 
@@ -458,7 +544,17 @@ describe("SharePage /u/[handle]", () => {
       // Impact/stats sections are still present — the page doesn't omit the
       // dashboard just because history is missing.
       expect(ownerEl!.props.stats).toEqual(FAKE_MATERIALIZED.stats);
-      expect(ownerEl!.props.impact).toEqual(FAKE_MATERIALIZED.displayImpact);
+      // #1067 — the default test session is a visitor (no session), so the
+      // page redacts confidence/confidencePenalties before this crosses
+      // into the client component tree. See "owner-only confidence
+      // redaction (#1067)" below for dedicated coverage of that behavior.
+      expect(ownerEl!.props.impact).toEqual({
+        adjustedComposite: 65,
+        tier: "Solid",
+        archetype: "Builder",
+        dimensions: { delivery: 70, quality: 60, consistency: 65, breadth: 55 },
+        profileType: "collaborative",
+      });
     });
 
     it("degrades gracefully (renders, does not throw) when getTrendData itself rejects", async () => {

--- a/apps/web/app/u/[handle]/page.test.tsx
+++ b/apps/web/app/u/[handle]/page.test.tsx
@@ -89,6 +89,7 @@ vi.mock("@/lib/i18n/server", async () => {
 vi.mock("@/lib/i18n", () => ({
   DEFAULT_LOCALE: "es",
   LocaleSync: () => null,
+  LanguageProvider: (props: { children?: unknown }) => props.children,
 }));
 
 vi.mock("@/components/CommandBarHint", () => ({
@@ -193,6 +194,12 @@ describe("SharePage /u/[handle]", () => {
   });
 
   it("generates metadata with the daily OG cache buster", async () => {
+    // #1066 — locale now resolves via getServerLocale (mocked here to the
+    // "es" cookie/header-fallback default) rather than a hardcoded literal;
+    // this test is about the OG cache-buster URL, not locale resolution
+    // itself (see the "locale resolution (#1066)" describe block for that).
+    mockGetServerLocale.mockResolvedValue("es");
+
     const metadata = await generateMetadata({
       params: Promise.resolve({ handle: "testuser" }),
     });
@@ -214,6 +221,95 @@ describe("SharePage /u/[handle]", () => {
       SharePage({ params: Promise.resolve({ handle: "bad!!handle" }) }),
     ).rejects.toThrow("NOT_FOUND");
     expect(mockNotFound).toHaveBeenCalled();
+  });
+
+  // #1066 (FE-H2) — the route now commits to dynamic rendering and resolves
+  // locale via getServerLocale (query override > chapa-locale cookie >
+  // Accept-Language > DEFAULT_LOCALE — see lib/i18n/server.ts, already
+  // covered by its own unit tests). These tests assert page.tsx wires the
+  // query param through correctly and that generateMetadata/body agree.
+  describe("locale resolution (#1066)", () => {
+    it("generateMetadata resolves locale via getServerLocale using the ?lang= override", async () => {
+      mockGetServerLocale.mockResolvedValue("en");
+
+      await generateMetadata({
+        params: Promise.resolve({ handle: "testuser" }),
+        searchParams: Promise.resolve({ lang: "en" }),
+      });
+
+      // #1020 contract: an explicit ?lang= must win over any cookie —
+      // asserting the literal value is forwarded (not dropped) is what
+      // guarantees that precedence downstream in getServerLocale.
+      expect(mockGetServerLocale).toHaveBeenCalledWith("en");
+    });
+
+    it("generateMetadata falls through to cookie/header resolution when ?lang= is absent", async () => {
+      mockGetServerLocale.mockResolvedValue("es");
+
+      await generateMetadata({
+        params: Promise.resolve({ handle: "testuser" }),
+      });
+
+      expect(mockGetServerLocale).toHaveBeenCalledWith(null);
+    });
+
+    it("SharePage's LanguageProvider uses the ?lang= override for the body locale", async () => {
+      mockGetServerLocale.mockResolvedValue("en");
+
+      const result = await SharePage({
+        params: Promise.resolve({ handle: "testuser" }),
+        searchParams: Promise.resolve({ lang: "en" }),
+      });
+
+      expect(mockGetServerLocale).toHaveBeenCalledWith("en");
+      const provider = findElement(
+        result,
+        (el) => !!el.props && "initialLocale" in el.props,
+      );
+      expect(provider).not.toBeNull();
+      expect(provider!.props.initialLocale).toBe("en");
+    });
+
+    it("SharePage's LanguageProvider falls back to the cookie-resolved locale when ?lang= is absent", async () => {
+      // getServerLocale is mocked here to stand in for a real cookie read
+      // (its own precedence order is covered by lib/i18n/server.test.ts) —
+      // this test only asserts page.tsx defers to it rather than
+      // hardcoding "es".
+      mockGetServerLocale.mockResolvedValue("es");
+
+      const result = await SharePage({
+        params: Promise.resolve({ handle: "testuser" }),
+        searchParams: Promise.resolve({}),
+      });
+
+      expect(mockGetServerLocale).toHaveBeenCalledWith(null);
+      const provider = findElement(
+        result,
+        (el) => !!el.props && "initialLocale" in el.props,
+      );
+      expect(provider!.props.initialLocale).toBe("es");
+    });
+
+    it("generateMetadata and the body resolve to the same locale for an identical request", async () => {
+      mockGetServerLocale.mockResolvedValue("en");
+
+      await generateMetadata({
+        params: Promise.resolve({ handle: "testuser" }),
+        searchParams: Promise.resolve({ lang: "en" }),
+      });
+      const bodyResult = await SharePage({
+        params: Promise.resolve({ handle: "testuser" }),
+        searchParams: Promise.resolve({ lang: "en" }),
+      });
+
+      const forwardedValues = mockGetServerLocale.mock.calls.map((args) => args[0]);
+      expect(forwardedValues.every((value) => value === "en")).toBe(true);
+      const provider = findElement(
+        bodyResult,
+        (el) => !!el.props && "initialLocale" in el.props,
+      );
+      expect(provider!.props.initialLocale).toBe("en");
+    });
   });
 
   it("renders the inline badge from displayImpact, not rawImpact", async () => {

--- a/apps/web/app/u/[handle]/page.tsx
+++ b/apps/web/app/u/[handle]/page.tsx
@@ -28,6 +28,8 @@ import {
   redactImpactForVisitor,
 } from "@/lib/profile/public-profile";
 import { getOptionalServerSessionFromHeaders } from "@/lib/auth/session";
+import { getOAuthErrorMessage } from "@/lib/auth/error-messages";
+import { ErrorBanner } from "@/components/ErrorBanner";
 import { getTrendData } from "@/lib/history/get-trend-data";
 import { getServerLocale, getServerT } from "@/lib/i18n/server";
 import { LanguageProvider, LocaleSync } from "@/lib/i18n";
@@ -101,6 +103,18 @@ export default async function SharePage({ params, searchParams }: SharePageProps
   const locale = await getServerLocale(queryLang);
   const readOnly = resolvedSearch[READ_ONLY_SMOKE_PARAM] === "1";
 
+  // #1107 — every platform OAuth (Bitbucket/Codeberg/GitLab) connect/
+  // callback failure branch in lib/auth/platform-oauth.ts redirects back to
+  // this exact page as `?error=<platform>_<code>`, but nothing here read
+  // that param — a failed "Connect GitLab" click left the user with zero
+  // feedback. Read server-side (not via a client useSyncExternalStore leaf
+  // like the landing page's #982 pattern): that pattern exists solely to
+  // avoid opting a static/ISR page out of static rendering, and this route
+  // is already dynamic (#1066 above already awaits searchParams and reads
+  // the session), so there is no static-rendering cost left to avoid here.
+  const errorCode = typeof resolvedSearch.error === "string" ? resolvedSearch.error : null;
+  const errorMessage = getOAuthErrorMessage(errorCode);
+
   if (!isValidHandle(handle)) {
     notFound();
   }
@@ -113,6 +127,7 @@ export default async function SharePage({ params, searchParams }: SharePageProps
       {/* Establish query ownership in the hydrated shell. The streamed client
           subtree then starts with the same dictionary as its server markup. */}
       <LocaleSync queryLang={queryLang} />
+      {errorMessage && <ErrorBanner message={errorMessage} />}
       <main id="main-content" className="min-h-screen bg-bg">
         <Suspense fallback={<BadgeSkeleton />}>
           <SharePageContent handle={handle} readOnly={readOnly} />

--- a/apps/web/app/u/[handle]/page.tsx
+++ b/apps/web/app/u/[handle]/page.tsx
@@ -1,5 +1,3 @@
-export const revalidate = 3600;
-
 import { Suspense } from "react";
 import { after } from "next/server";
 import { BadgeToolbar } from "@/components/BadgeToolbar";
@@ -28,11 +26,10 @@ import {
   persistProfileSnapshot,
 } from "@/lib/profile/public-profile";
 import { getTrendData } from "@/lib/history/get-trend-data";
-import { getServerT } from "@/lib/i18n/server";
+import { getServerLocale, getServerT } from "@/lib/i18n/server";
 import { LanguageProvider, LocaleSync } from "@/lib/i18n";
 import { en } from "@/lib/i18n/dictionaries/en";
 import { es } from "@/lib/i18n/dictionaries/es";
-import { isSupportedLocale } from "@/lib/i18n/types";
 import { interpolate } from "@/lib/i18n/interpolate";
 import { SharePageH2 } from "./SharePageH2";
 import { SharePageLocaleContent } from "./SharePageLocaleContent";
@@ -54,13 +51,16 @@ export async function generateMetadata({
     return { title: "Not Found" };
   }
 
-  // Avoid request-only locale APIs so the page stays ISR-compatible. Spanish
-  // remains the social-card default, while an explicit deep-link locale must
-  // also select matching metadata so streamed metadata cannot overwrite the
-  // client title with a different language after hydration.
+  // #1066 — the route is dynamic (see SharePage below), so locale resolves
+  // via getServerLocale: an explicit ?lang= deep-link override first (#1020
+  // contract — must win over the cookie), then the chapa-locale cookie,
+  // then Accept-Language, falling back to DEFAULT_LOCALE ('es'). This must
+  // resolve to the SAME locale as the body below, or streamed metadata
+  // could disagree with the client title after hydration.
   const resolvedSearch = searchParams ? await searchParams : {};
-  const requestedLocale = resolvedSearch.lang;
-  const locale = isSupportedLocale(requestedLocale) ? requestedLocale : "es";
+  const requestedLocale =
+    typeof resolvedSearch.lang === "string" ? resolvedSearch.lang : null;
+  const locale = await getServerLocale(requestedLocale);
   const t = getServerT(locale);
 
   const pageUrl = `${BASE_URL}/u/${handle}`;
@@ -93,7 +93,9 @@ export default async function SharePage({ params, searchParams }: SharePageProps
   const { handle } = await params;
   const resolvedSearch = searchParams ? await searchParams : {};
   const queryLang = typeof resolvedSearch.lang === "string" ? resolvedSearch.lang : null;
-  const locale = isSupportedLocale(queryLang) ? queryLang : "es";
+  // #1066 — same resolution as generateMetadata above (query > cookie >
+  // header > default), so the body never disagrees with streamed metadata.
+  const locale = await getServerLocale(queryLang);
   const readOnly = resolvedSearch[READ_ONLY_SMOKE_PARAM] === "1";
 
   if (!isValidHandle(handle)) {

--- a/apps/web/app/u/[handle]/page.tsx
+++ b/apps/web/app/u/[handle]/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import { after } from "next/server";
+import { headers } from "next/headers";
 import { BadgeToolbar } from "@/components/BadgeToolbar";
 import { isValidHandle } from "@/lib/validation";
 import { NavbarClient } from "@/components/NavbarClient";
@@ -24,7 +25,9 @@ import {
   deferProfileCacheWork,
   materializePublicProfile,
   persistProfileSnapshot,
+  redactImpactForVisitor,
 } from "@/lib/profile/public-profile";
+import { getOptionalServerSessionFromHeaders } from "@/lib/auth/session";
 import { getTrendData } from "@/lib/history/get-trend-data";
 import { getServerLocale, getServerT } from "@/lib/i18n/server";
 import { LanguageProvider, LocaleSync } from "@/lib/i18n";
@@ -132,22 +135,37 @@ export async function SharePageContent({
   handle: string;
   readOnly?: boolean;
 }) {
-  // ISR: No dynamic request APIs (next headers/cookies) are called.
-  // Session is checked client-side via SharePageOwnerContent and NavbarClient.
   // Stats fetch uses env GITHUB_TOKEN fallback (no per-user OAuth token).
 
-  // #1034 — fetch trend/diff history alongside profile materialization
+  // #1067 — resolve the requester's session server-side (the route is
+  // dynamic per #1066) so owner-only confidence data can be redacted below
+  // BEFORE it crosses into the "use client" component tree. A client-side
+  // isOwner check (still used for display gating in SharePageOwnerContent)
+  // only hides the UI — the data would already be in a visitor's
+  // view-source via the RSC payload.
+  //
+  // #1034 — trend/diff history is fetched alongside profile materialization
   // (rather than in a client `useEffect` post-hydration) so the dashboard
   // renders with this data on first paint instead of a client fetch waterfall.
   // getTrendData() already degrades gracefully (returns nulls) on any
   // history-store failure; the `.catch()` here is a belt-and-suspenders
   // guard so a future regression in that contract still can't fail the
   // whole share page render — a 500 here would be a bug (CLAUDE.md).
-  const [materialized, trendData] = await Promise.all([
+  //
+  // Session resolution has no data dependency on the other two, so all
+  // three run concurrently rather than awaiting headers() up front.
+  const [session, materialized, trendData] = await Promise.all([
+    headers().then((h) => getOptionalServerSessionFromHeaders(h)),
     materializePublicProfile(handle, { readOnly }),
     getTrendData(handle).catch(() => ({ trend: null, diff: null })),
   ]);
+  const isOwner = session?.login === handle;
   const stats = materialized?.stats ?? null;
+  // `impact` stays the FULL, unredacted result — it feeds renderBadgeSvg and
+  // personJsonLd below (and, via `materialized` itself, the snapshot/HMAC
+  // record in the deferred work further down). Only the copy handed to the
+  // client component tree is redacted, via `impactForClient` near the
+  // bottom of this function.
   const impact = materialized?.displayImpact ?? null;
   const craftResult = materialized?.craftResult ?? null;
   const verification = materialized
@@ -237,6 +255,13 @@ export async function SharePageContent({
 
   const badgeLabelId = `share-badge-label-${handle}`;
 
+  // #1067 — this is the ONE place `impact` crosses into a "use client"
+  // component tree. A projection, not a mutation: `impact` (and, more
+  // importantly, `materialized.displayImpact` it's aliased from) must stay
+  // fully intact above for the badge render, JSON-LD, and the deferred
+  // snapshot/HMAC verification-record work in `after()`.
+  const impactForClient = impact && !isOwner ? redactImpactForVisitor(impact) : impact;
+
   return (
     <>
       <SharePageShortcuts
@@ -301,7 +326,7 @@ export async function SharePageContent({
         <SharePageOwnerContentLazy
           handle={handle}
           stats={stats}
-          impact={impact}
+          impact={impactForClient}
           craftResult={craftResult}
           trend={trendData.trend}
           diff={trendData.diff}

--- a/apps/web/app/u/[handle]/share-page.render.test.tsx
+++ b/apps/web/app/u/[handle]/share-page.render.test.tsx
@@ -233,6 +233,12 @@ describe("Phase 4d — Share page i18n", () => {
 
   describe("generateMetadata — es locale (social cards use primary locale)", () => {
     it("uses interpolated handle in OG image alt (Spanish)", async () => {
+      // #1066 — locale now resolves via getServerLocale (cookie/header
+      // fallback), mocked here to "es" to preserve this test's original
+      // intent (its own precedence is covered by lib/i18n/server.test.ts
+      // and the "locale resolution (#1066)" tests in page.test.tsx).
+      mockGetServerLocale.mockResolvedValue("es");
+
       const metadata = await generateMetadata({
         params: Promise.resolve({ handle: "testuser" }),
       });
@@ -382,8 +388,13 @@ describe("Phase 4d — Share page i18n", () => {
       expect(SOURCE).toContain("@/lib/i18n/server");
     });
 
-    it("still exports revalidate = 3600", () => {
-      expect(SOURCE).toContain("export const revalidate = 3600");
+    // #1066 (FE-H2) — revalidate = 3600 was inert: both generateMetadata
+    // and the page component already unconditionally awaited searchParams,
+    // opting the route out of static rendering entirely. The route now
+    // commits to dynamic rendering instead (see page.test.ts's "dynamic
+    // rendering (#1066)" describe block for the replacement coverage).
+    it("does NOT export revalidate (genuinely dynamic, not ISR)", () => {
+      expect(SOURCE).not.toContain("export const revalidate");
     });
 
     it("delegates locale-sensitive title and labels to a client component", () => {

--- a/apps/web/app/u/[handle]/share-page.render.test.tsx
+++ b/apps/web/app/u/[handle]/share-page.render.test.tsx
@@ -12,6 +12,7 @@ const {
   mockRunPublicProfileSideEffects,
   mockPersistProfileSnapshot,
   mockDeferProfileCacheWork,
+  mockRedactImpactForVisitor,
   mockIsValidHandle,
   mockGetAvatarBase64,
   mockRenderBadgeSvg,
@@ -20,12 +21,15 @@ const {
   mockReadBadgeSvgCache,
   mockWriteBadgeSvgCache,
   mockGetTrendData,
+  mockHeaders,
+  mockGetOptionalServerSessionFromHeaders,
 } = vi.hoisted(() => ({
   mockMaterializePublicProfile: vi.fn(),
   mockGetPublicProfileVerification: vi.fn(),
   mockRunPublicProfileSideEffects: vi.fn(),
   mockPersistProfileSnapshot: vi.fn(),
   mockDeferProfileCacheWork: vi.fn(),
+  mockRedactImpactForVisitor: vi.fn(),
   mockIsValidHandle: vi.fn(),
   mockGetAvatarBase64: vi.fn(),
   mockRenderBadgeSvg: vi.fn(),
@@ -34,6 +38,17 @@ const {
   mockReadBadgeSvgCache: vi.fn(),
   mockWriteBadgeSvgCache: vi.fn(),
   mockGetTrendData: vi.fn(),
+  mockHeaders: vi.fn(),
+  mockGetOptionalServerSessionFromHeaders: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: (...args: unknown[]) => mockHeaders(...args),
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  getOptionalServerSessionFromHeaders: (...args: unknown[]) =>
+    mockGetOptionalServerSessionFromHeaders(...args),
 }));
 
 vi.mock("@/lib/profile/public-profile", () => ({
@@ -47,6 +62,8 @@ vi.mock("@/lib/profile/public-profile", () => ({
     mockPersistProfileSnapshot(...args),
   deferProfileCacheWork: (...args: unknown[]) =>
     mockDeferProfileCacheWork(...args),
+  redactImpactForVisitor: (...args: unknown[]) =>
+    mockRedactImpactForVisitor(...args),
 }));
 
 vi.mock("@/lib/validation", () => ({
@@ -182,6 +199,13 @@ beforeEach(() => {
   mockReadBadgeSvgCache.mockResolvedValue(null);
   mockWriteBadgeSvgCache.mockResolvedValue(undefined);
   mockGetTrendData.mockResolvedValue({ trend: null, diff: null });
+  mockHeaders.mockResolvedValue({ get: () => null });
+  mockGetOptionalServerSessionFromHeaders.mockReturnValue(null);
+  mockRedactImpactForVisitor.mockImplementation((impact: Record<string, unknown>) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { confidence: _confidence, confidencePenalties: _confidencePenalties, ...rest } = impact;
+    return rest;
+  });
 });
 
 describe("Phase 4d — Share page i18n", () => {

--- a/apps/web/components/ImpactBreakdown.tsx
+++ b/apps/web/components/ImpactBreakdown.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import type { ImpactV6Result, StatsData, Platform, DimensionScores } from "@chapa/shared";
+import type {
+  ClientImpactV6Result,
+  ImpactV6Result,
+  StatsData,
+  Platform,
+  DimensionScores,
+} from "@chapa/shared";
 import { formatCompact } from "@chapa/shared";
 import { InfoTooltip } from "./InfoTooltip";
 import { useTranslation } from "@/lib/i18n";
@@ -155,7 +161,9 @@ function toArchetypeKey(archetype: string): string {
  * actionable tip for the developer's weakest dimension.
  */
 export function getArchetypeProfile(
-  impact: ImpactV6Result,
+  // #1067 — may be a redacted PublicImpactV6Result for a non-owner
+  // share-page visitor; this function never reads confidence.
+  impact: ClientImpactV6Result,
   t: (key: string) => string | string[] | Record<string, unknown>[],
 ): string {
   const profile = t(`archetypeProfiles.${toArchetypeKey(impact.archetype)}`) as string;

--- a/apps/web/components/SharePageOwnerContent.tsx
+++ b/apps/web/components/SharePageOwnerContent.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import type { CraftResult, ImpactV6Result, StatsData } from "@chapa/shared";
+import type { ClientImpactV6Result, CraftResult, StatsData } from "@chapa/shared";
 import type { TrendSummary } from "@/lib/history/trend";
 import type { SnapshotDiff } from "@/lib/history/diff";
 import { DataSources } from "@/components/ImpactBreakdown";
@@ -89,7 +89,9 @@ function EmptyImpactState({ handle }: { handle: string }) {
 interface SharePageOwnerContentProps {
   handle: string;
   stats: StatsData | null;
-  impact: ImpactV6Result | null;
+  // #1067 — redacted PublicImpactV6Result for a non-owner visitor, full
+  // ImpactV6Result for the owner (see SharePageOwnerContentLazy).
+  impact: ClientImpactV6Result | null;
   craftResult?: CraftResult | null;
   trend?: TrendSummary | null;
   diff?: SnapshotDiff | null;

--- a/apps/web/components/SharePageOwnerContentLazy.tsx
+++ b/apps/web/components/SharePageOwnerContentLazy.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import type { CraftResult, ImpactV6Result, StatsData } from "@chapa/shared";
+import type { ClientImpactV6Result, CraftResult, StatsData } from "@chapa/shared";
 import type { TrendSummary } from "@/lib/history/trend";
 import type { SnapshotDiff } from "@/lib/history/diff";
 import { BadgeSkeleton } from "./BadgeSkeleton";
@@ -14,7 +14,10 @@ const SharePageOwnerContent = dynamic(
 interface Props {
   handle: string;
   stats: StatsData | null;
-  impact: ImpactV6Result | null;
+  // #1067 — the server passes a redacted PublicImpactV6Result (no
+  // confidence/confidencePenalties keys) for non-owner visitors, and the
+  // full ImpactV6Result for the owner.
+  impact: ClientImpactV6Result | null;
   craftResult?: CraftResult | null;
   trend?: TrendSummary | null;
   diff?: SnapshotDiff | null;

--- a/apps/web/components/dashboard/CoachingInsights.tsx
+++ b/apps/web/components/dashboard/CoachingInsights.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import type { ImpactV6Result } from "@chapa/shared";
+import type { ClientImpactV6Result } from "@chapa/shared";
 import type { TrendSummary } from "@/lib/history/trend";
 import type { SnapshotDiff } from "@/lib/history/diff";
 import { generateInsights } from "@/lib/dashboard/generate-insights";
@@ -13,7 +13,9 @@ import { useTranslation } from "@/lib/i18n";
 // ---------------------------------------------------------------------------
 
 interface CoachingInsightsProps {
-  impact: ImpactV6Result;
+  // #1067 — redacted PublicImpactV6Result for a non-owner visitor, full
+  // ImpactV6Result for the owner. generateInsights() never reads confidence.
+  impact: ClientImpactV6Result;
   trend: TrendSummary | null;
   diff: SnapshotDiff | null;
   className?: string;

--- a/apps/web/components/dashboard/DimensionCardsRow.tsx
+++ b/apps/web/components/dashboard/DimensionCardsRow.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import type { CraftResult, ImpactV6Result, StatsData, DimensionScores } from "@chapa/shared";
+import type {
+  ClientImpactV6Result,
+  CraftResult,
+  StatsData,
+  DimensionScores,
+} from "@chapa/shared";
 import type { TrendSummary } from "@/lib/history/trend";
 import type { SnapshotDiff } from "@/lib/history/diff";
 import { DimensionCard } from "./DimensionCard";
@@ -10,7 +15,9 @@ import { useTranslation } from "@/lib/i18n";
 const CORE_DIMENSIONS = ["delivery", "quality", "consistency", "breadth"] as const;
 
 export interface DimensionCardsRowProps {
-  impact: ImpactV6Result;
+  // #1067 — redacted PublicImpactV6Result for a non-owner visitor, full
+  // ImpactV6Result for the owner. This component never reads confidence.
+  impact: ClientImpactV6Result;
   stats: StatsData;
   trend?: TrendSummary | null;
   diff?: SnapshotDiff | null;

--- a/apps/web/components/dashboard/ImpactDashboard.tsx
+++ b/apps/web/components/dashboard/ImpactDashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { CraftResult, ImpactV6Result, StatsData } from "@chapa/shared";
+import type { ClientImpactV6Result, CraftResult, StatsData } from "@chapa/shared";
 import type { TrendSummary } from "@/lib/history/trend";
 import type { SnapshotDiff } from "@/lib/history/diff";
 import { getArchetypeProfile } from "@/components/ImpactBreakdown";
@@ -15,7 +15,10 @@ import { useTranslation } from "@/lib/i18n";
 // ---------------------------------------------------------------------------
 
 interface ImpactDashboardProps {
-  impact: ImpactV6Result;
+  // #1067 — redacted PublicImpactV6Result for a non-owner visitor, full
+  // ImpactV6Result for the owner. Nothing in this component or its children
+  // reads confidence/confidencePenalties.
+  impact: ClientImpactV6Result;
   stats: StatsData;
   handle: string;
   craftResult?: CraftResult | null;

--- a/apps/web/components/dashboard/ScoreExplanationPanel.test.tsx
+++ b/apps/web/components/dashboard/ScoreExplanationPanel.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { CraftResult } from "@chapa/shared";
 import { makeImpact, makeStats } from "@/lib/test-helpers/fixtures";
+import { redactImpactForVisitor } from "@/lib/profile/public-profile";
 import { ScoreExplanationPanel } from "./ScoreExplanationPanel";
 
 afterEach(cleanup);
@@ -118,6 +119,25 @@ describe("ScoreExplanationPanel", () => {
     expect(screen.getByText("GitLab does not expose PR-description, branch, or issue-link signals, so your Quality dimension is based on limited data here.")).toBeTruthy();
     expect(screen.queryByText("Confidence")).toBeNull();
     expect(screen.queryByText("Confidence: 95%")).toBeNull();
+  });
+
+  // #1067 (FE-M1) — the share page now passes a structurally-redacted
+  // PublicImpactV6Result (no confidence/confidencePenalties keys at all,
+  // not just hidden values) for non-owner requests. The panel must accept
+  // that shape without throwing and still never surface confidence copy.
+  it("renders correctly when given a redacted (visitor) impact payload with no confidence fields", () => {
+    const redacted = redactImpactForVisitor(soloImpact);
+    expect("confidence" in redacted).toBe(false);
+    expect("confidencePenalties" in redacted).toBe(false);
+
+    render(
+      <ScoreExplanationPanel impact={redacted} stats={soloStats} isOwner={false} />,
+    );
+    expandPanel();
+
+    expect(screen.getByText("52 (Solid)")).toBeTruthy();
+    expect(screen.queryByText("Confidence")).toBeNull();
+    expect(screen.queryByText(/Confidence:/)).toBeNull();
   });
 
   it("shows confidence details only to the owner", () => {

--- a/apps/web/components/dashboard/ScoreExplanationPanel.tsx
+++ b/apps/web/components/dashboard/ScoreExplanationPanel.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { useCallback, useId, useMemo, useState } from "react";
-import type { CraftResult, DimensionScores, ImpactV6Result, Platform, StatsData } from "@chapa/shared";
+import type {
+  ClientImpactV6Result,
+  CraftResult,
+  DimensionScores,
+  Platform,
+  StatsData,
+} from "@chapa/shared";
 import {
   buildScoreExplanation,
   type DimensionExplanation,
@@ -14,7 +20,11 @@ import { ChallengeForm } from "./ChallengeForm";
 type TranslateFn = (key: string) => string | string[] | Record<string, unknown>[];
 
 interface ScoreExplanationPanelProps {
-  impact: ImpactV6Result;
+  // #1067 — the share page passes a structurally-redacted
+  // PublicImpactV6Result (confidence/confidencePenalties keys entirely
+  // absent) for non-owner visitors, and the full ImpactV6Result only for
+  // the owner. buildScoreExplanation() below narrows on field presence.
+  impact: ClientImpactV6Result;
   stats: StatsData;
   craftResult?: CraftResult | null;
   isOwner: boolean;

--- a/apps/web/lib/auth/error-messages.test.ts
+++ b/apps/web/lib/auth/error-messages.test.ts
@@ -63,4 +63,67 @@ describe("getOAuthErrorMessage", () => {
       expect(msg.length).toBeGreaterThan(10);
     }
   });
+
+  // #1107 (UX-H1) — the GitHub callback route
+  // (app/api/auth/callback/route.ts:158) has redirected to
+  // `/?error=session_storage` since it was added, but the code was never
+  // registered here, so it silently fell through to the generic fallback
+  // message instead of its own copy.
+  describe("'session_storage' code", () => {
+    it("is a known OAUTH_ERROR_CODES entry", () => {
+      expect(OAUTH_ERROR_CODES).toContain("session_storage");
+    });
+
+    it("returns a user-friendly, non-technical message", () => {
+      const result = getOAuthErrorMessage("session_storage");
+      expect(result).toBeTruthy();
+      expect(result).not.toContain("session_storage");
+    });
+  });
+
+  // #1107 (UX-H1) — platform OAuth (Bitbucket/Codeberg/GitLab) connect and
+  // callback failures redirect to the user's own share page as
+  // `?error=<platform>_<suffix>` (lib/auth/platform-oauth.ts). These codes
+  // are never a bare OAUTH_ERROR_CODES member, so getOAuthErrorMessage must
+  // recognize the `<platform>_<suffix>` shape and return copy that names the
+  // platform rather than generic GitHub sign-in wording.
+  describe("platform OAuth error codes", () => {
+    const platforms = ["bitbucket", "codeberg", "gitlab"] as const;
+    const suffixes = [
+      "no_code",
+      "invalid_state",
+      "config",
+      "token_exchange",
+      "user_fetch",
+      "storage",
+    ] as const;
+
+    for (const platform of platforms) {
+      for (const suffix of suffixes) {
+        it(`returns a truthy message for '${platform}_${suffix}'`, () => {
+          const result = getOAuthErrorMessage(`${platform}_${suffix}`);
+          expect(result).toBeTruthy();
+          expect(typeof result).toBe("string");
+        });
+      }
+    }
+
+    it("names the platform for connection failures instead of using generic GitHub wording", () => {
+      expect(getOAuthErrorMessage("gitlab_token_exchange")).toContain("GitLab");
+      expect(getOAuthErrorMessage("bitbucket_token_exchange")).toContain("Bitbucket");
+      expect(getOAuthErrorMessage("codeberg_token_exchange")).toContain("Codeberg");
+    });
+
+    it("does not fall back to GitHub sign-in copy for a platform failure", () => {
+      const msg = getOAuthErrorMessage("gitlab_token_exchange")!;
+      expect(msg).not.toContain("GitHub");
+      expect(msg).not.toContain("sign-in");
+    });
+
+    it("distinguishes platform connect failures from each other by platform name", () => {
+      const gitlab = getOAuthErrorMessage("gitlab_user_fetch")!;
+      const bitbucket = getOAuthErrorMessage("bitbucket_user_fetch")!;
+      expect(gitlab).not.toBe(bitbucket);
+    });
+  });
 });

--- a/apps/web/lib/auth/error-messages.ts
+++ b/apps/web/lib/auth/error-messages.ts
@@ -13,6 +13,10 @@ export const OAUTH_ERROR_CODES = [
   "config",
   "token_exchange",
   "user_fetch",
+  // #1107 \u2014 emitted by app/api/auth/callback/route.ts:158 since it was
+  // added, but never registered here; it silently fell through to the
+  // generic FALLBACK_MESSAGE instead of getting its own copy.
+  "session_storage",
 ] as const;
 
 type OAuthErrorCode = (typeof OAUTH_ERROR_CODES)[number];
@@ -28,13 +32,73 @@ const ERROR_MESSAGES: Record<OAuthErrorCode, string> = {
     "We couldn\u2019t complete sign-in with GitHub. Please try again.",
   user_fetch:
     "We couldn\u2019t retrieve your GitHub profile. Please try again.",
+  session_storage:
+    "We couldn\u2019t start your session. Please try again.",
 };
 
 const FALLBACK_MESSAGE = "Something went wrong during sign-in. Please try again.";
 
 /**
+ * Platform identifiers used by the linked-account OAuth flows
+ * (`lib/auth/platform-oauth.ts`). Every Bitbucket/Codeberg/GitLab connect and
+ * callback failure branch redirects back to the user's own share page as
+ * `?error=<platform>_<suffix>` (#1107 / UX-H1) \u2014 a shape the base
+ * `OAUTH_ERROR_CODES` above never covers.
+ */
+const PLATFORM_OAUTH_PLATFORMS = ["bitbucket", "codeberg", "gitlab"] as const;
+type PlatformOAuthPlatform = (typeof PLATFORM_OAUTH_PLATFORMS)[number];
+
+const PLATFORM_LABELS: Record<PlatformOAuthPlatform, string> = {
+  bitbucket: "Bitbucket",
+  codeberg: "Codeberg",
+  gitlab: "GitLab",
+};
+
+type PlatformOAuthSuffix =
+  | "no_code"
+  | "invalid_state"
+  | "config"
+  | "token_exchange"
+  | "user_fetch"
+  | "storage";
+
+const PLATFORM_SUFFIX_MESSAGES: Record<
+  PlatformOAuthSuffix,
+  (platform: string) => string
+> = {
+  no_code: (platform) =>
+    `Connecting your ${platform} account was interrupted before completing. Please try again.`,
+  invalid_state: (platform) =>
+    `Your ${platform} connection request expired or was invalid. Please try again.`,
+  config: () => "Something went wrong on our end. Please try again later.",
+  token_exchange: (platform) =>
+    `We couldn\u2019t connect your ${platform} account. Please try again.`,
+  user_fetch: (platform) =>
+    `We couldn\u2019t retrieve your ${platform} profile. Please try again.`,
+  storage: (platform) =>
+    `We couldn\u2019t save your ${platform} connection. Please try again.`,
+};
+
+/**
+ * Matches a `<platform>_<suffix>` code and builds platform-aware copy, or
+ * returns `null` when `code` isn't one of the recognized platform codes.
+ */
+function getPlatformOAuthErrorMessage(code: string): string | null {
+  for (const platform of PLATFORM_OAUTH_PLATFORMS) {
+    const prefix = `${platform}_`;
+    if (!code.startsWith(prefix)) continue;
+    const suffix = code.slice(prefix.length) as PlatformOAuthSuffix;
+    const buildMessage = PLATFORM_SUFFIX_MESSAGES[suffix];
+    return buildMessage ? buildMessage(PLATFORM_LABELS[platform]) : null;
+  }
+  return null;
+}
+
+/**
  * Maps an OAuth error code (from the URL `?error=` param) to a
- * user-friendly message string.
+ * user-friendly message string. Recognizes both the base GitHub sign-in
+ * codes and the platform-prefixed `<platform>_<suffix>` codes emitted by the
+ * Bitbucket/Codeberg/GitLab linked-account flows (#1107).
  *
  * Returns `null` when the input is falsy (undefined, null, empty string),
  * meaning there is no error to display.
@@ -43,6 +107,9 @@ export function getOAuthErrorMessage(
   code: string | null | undefined,
 ): string | null {
   if (!code) return null;
+
+  const platformMessage = getPlatformOAuthErrorMessage(code);
+  if (platformMessage) return platformMessage;
 
   const known = ERROR_MESSAGES[code as OAuthErrorCode];
   return known ?? FALLBACK_MESSAGE;

--- a/apps/web/lib/dashboard/generate-insights.ts
+++ b/apps/web/lib/dashboard/generate-insights.ts
@@ -1,6 +1,6 @@
 import type {
+  ClientImpactV6Result,
   DimensionScores,
-  ImpactV6Result,
   ImpactTier,
 } from "@chapa/shared";
 import type { TrendSummary } from "@/lib/history/trend";
@@ -108,14 +108,16 @@ function findWorstDimension(trend: TrendSummary): string {
  * weakest-dimension tip, next-tier guidance, and archetype context. Results are
  * sorted by priority and capped at 5. Used by the share page insights panel.
  *
- * @param impact - Current impact profile (dimensions, archetype, tier, composite)
+ * @param impact - Current impact profile (dimensions, archetype, tier, composite).
+ *   May be a redacted PublicImpactV6Result for a non-owner share-page visitor
+ *   (#1067) — this function never reads confidence/confidencePenalties.
  * @param trend  - Optional trend summary (direction, avgDelta, dimension trends)
  * @param diff   - Optional snapshot diff (tier/dimension changes since last snapshot)
  * @param t      - Translation function for locale-aware strings
  * @returns Up to 5 insights sorted by priority (1 = highest)
  */
 export function generateInsights(
-  impact: ImpactV6Result,
+  impact: ClientImpactV6Result,
   trend: TrendSummary | null,
   diff: SnapshotDiff | null,
   t: (key: string) => string | string[] | Record<string, unknown>[] = (key) => key,

--- a/apps/web/lib/dashboard/score-explanation.ts
+++ b/apps/web/lib/dashboard/score-explanation.ts
@@ -1,9 +1,9 @@
 import type {
+  ClientImpactV6Result,
   ConfidenceFlag,
   CraftResult,
   DimensionScores,
   ImpactTier,
-  ImpactV6Result,
   Platform,
   StatsData,
 } from "@chapa/shared";
@@ -127,7 +127,10 @@ function buildPlatformProvenance(platform: Platform, stats: StatsData): Platform
 }
 
 export function buildScoreExplanation(
-  impact: ImpactV6Result,
+  // #1067 — impact may be a redacted PublicImpactV6Result (no
+  // confidence/confidencePenalties keys at all) for a non-owner share-page
+  // visitor. Narrow with "in" below rather than assuming the field exists.
+  impact: ClientImpactV6Result,
   stats: StatsData,
   craftResult: CraftResult | null = null,
 ): ScoreExplanation {
@@ -158,9 +161,15 @@ export function buildScoreExplanation(
     },
     dimensions,
     dataSources: platforms.map((platform) => buildPlatformProvenance(platform, stats)),
+    // #1067 — a redacted (visitor) impact has neither key at all. This
+    // section is never rendered to a visitor (ScoreExplanationPanel gates
+    // it on isOwner), so the 0/[] defaults below are never displayed —
+    // they only keep this function total over both impact shapes.
     confidence: {
-      value: impact.confidence,
-      penalties: (impact.confidencePenalties ?? []).map(({ flag, penalty }) => ({ flag, penalty })),
+      value: "confidence" in impact ? impact.confidence : 0,
+      penalties: (
+        "confidencePenalties" in impact ? impact.confidencePenalties ?? [] : []
+      ).map(({ flag, penalty }) => ({ flag, penalty })),
     },
   };
 }

--- a/apps/web/lib/profile/public-profile.test.ts
+++ b/apps/web/lib/profile/public-profile.test.ts
@@ -1,11 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { makeFullStats, makeSnapshot } from "../test-helpers/fixtures";
+import { makeFullStats, makeImpact, makeSnapshot } from "../test-helpers/fixtures";
 import type { MaterializedProfile } from "./materialize-profile";
 import {
   deferProfileCacheWork,
   getPublicProfileVerification,
   materializePublicProfile,
   persistProfileSnapshot,
+  redactImpactForVisitor,
   runPublicProfileSideEffects,
 } from "./public-profile";
 
@@ -569,5 +570,66 @@ describe("runPublicProfileSideEffects", () => {
       expect(mockStoreVerificationRecord).not.toHaveBeenCalled();
       expect(mockTrackBadgeGenerated).toHaveBeenCalledWith("testuser");
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// redactImpactForVisitor (#1067 FE-M1)
+// ---------------------------------------------------------------------------
+//
+// The share page (apps/web/app/u/[handle]/page.tsx) crosses `impact` into a
+// "use client" component tree. Whatever crosses that boundary is serialized
+// into the RSC payload a visitor's browser downloads, regardless of whether
+// any component actually renders it. Confidence/confidencePenalties are
+// owner-only (CLAUDE.md), so a non-owner request must never receive them —
+// not just have them hidden from display.
+describe("redactImpactForVisitor", () => {
+  it("strips confidence and confidencePenalties from the result", () => {
+    const impact = makeImpact({
+      confidence: 62,
+      confidencePenalties: [
+        { flag: "low_activity_signal", penalty: 10, reason: "Low recent activity." },
+      ],
+    });
+
+    const redacted = redactImpactForVisitor(impact);
+
+    expect("confidence" in redacted).toBe(false);
+    expect("confidencePenalties" in redacted).toBe(false);
+    expect(JSON.stringify(redacted)).not.toContain("confidence");
+  });
+
+  it("preserves every other field, including the public headline score", () => {
+    const impact = makeImpact({
+      handle: "octocat",
+      adjustedComposite: 73,
+      compositeScore: 70,
+      tier: "High",
+      archetype: "Builder",
+      profileType: "collaborative",
+    });
+
+    const redacted = redactImpactForVisitor(impact);
+
+    expect(redacted).toEqual({
+      handle: "octocat",
+      profileType: "collaborative",
+      dimensions: impact.dimensions,
+      archetype: "Builder",
+      compositeScore: 70,
+      adjustedComposite: 73,
+      tier: "High",
+      computedAt: impact.computedAt,
+    });
+  });
+
+  it("returns a new object rather than mutating the input (snapshot/HMAC record safety)", () => {
+    const impact = makeImpact({ confidence: 91 });
+
+    const redacted = redactImpactForVisitor(impact);
+
+    expect(redacted).not.toBe(impact);
+    expect(impact.confidence).toBe(91);
+    expect(impact.confidencePenalties).toEqual([]);
   });
 });

--- a/apps/web/lib/profile/public-profile.ts
+++ b/apps/web/lib/profile/public-profile.ts
@@ -1,3 +1,4 @@
+import type { ImpactV6Result, PublicImpactV6Result } from "@chapa/shared";
 import { captureServerError, captureServerEvent } from "@/lib/analytics/server-errors";
 import { fireAndForget } from "@/lib/async/fire-and-forget";
 import { cacheSetNxStatus, trackBadgeGenerated } from "@/lib/cache/redis";
@@ -16,6 +17,28 @@ import { reconcileSnapshotWrite } from "./snapshot-write";
 export interface PublicVerificationCode {
   hash: string;
   date: string;
+}
+
+/**
+ * Strip owner-only confidence data before an `ImpactV6Result` crosses into a
+ * "use client" component's serialized props for a non-owner share-page
+ * visitor (#1067 FE-M1). Whatever is passed as a client-component prop is
+ * serialized into the RSC payload the browser downloads regardless of
+ * whether any component renders it — a client-side `isOwner` display gate is
+ * not sufficient on its own.
+ *
+ * Returns a NEW object; never mutates `impact`. The same
+ * `MaterializedProfile.displayImpact` reference this is called on also feeds
+ * the persisted snapshot and the HMAC verification record in the same
+ * request (see `runPublicProfileSideEffects` / `buildVerificationRecord`
+ * above), both of which require the real confidence value.
+ */
+export function redactImpactForVisitor(
+  impact: ImpactV6Result,
+): PublicImpactV6Result {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { confidence: _confidence, confidencePenalties: _confidencePenalties, ...publicImpact } = impact;
+  return publicImpact;
 }
 
 export async function materializePublicProfile(

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,6 +9,8 @@ export type {
   DimensionScores,
   DeveloperArchetype,
   ImpactV6Result,
+  PublicImpactV6Result,
+  ClientImpactV6Result,
   SupplementalStats,
   SnapshotPenalty,
   MetricsSnapshot,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -99,6 +99,29 @@ export interface ImpactV6Result {
   computedAt: string; // ISO timestamp
 }
 
+/**
+ * `ImpactV6Result` without `confidence`/`confidencePenalties` — the shape
+ * served into the client-serialized share-page payload for a non-owner
+ * visitor (#1067). Confidence and its penalty flags are owner-only data
+ * (see CLAUDE.md acceptance criteria); this projection keeps those two
+ * fields out of the RSC payload entirely rather than merely hiding them in
+ * the UI, so a visitor's view-source never contains them.
+ */
+export type PublicImpactV6Result = Omit<
+  ImpactV6Result,
+  "confidence" | "confidencePenalties"
+>;
+
+/**
+ * The impact shape a share-page client component may receive: the full
+ * `ImpactV6Result` for the owner, or the redacted `PublicImpactV6Result` for
+ * a visitor (#1067). Every "use client" component downstream of the share
+ * page that accepts `impact` as a prop but doesn't itself branch on
+ * ownership should type that prop as `ClientImpactV6Result` — one named
+ * alias instead of re-deriving the same union per file.
+ */
+export type ClientImpactV6Result = ImpactV6Result | PublicImpactV6Result;
+
 /** Raw data shape returned by the GitHub GraphQL contribution query */
 export interface RawContributionData {
   login: string;


### PR DESCRIPTION
Closes #1066, #1067, #1107