### PR TITLE
fix: release Resend webhook dedup key on delivery failure

### DIFF
--- a/apps/web/app/api/webhooks/resend/route.test.ts
+++ b/apps/web/app/api/webhooks/resend/route.test.ts
@@ -12,6 +12,7 @@ const {
   mockForwardEmail,
   mockRateLimit,
   mockCacheSetNxStatus,
+  mockCacheDel,
 } = vi.hoisted(() => ({
   mockVerifyWebhookSignature: vi.fn(),
   mockFetchReceivedEmail: vi.fn(),
@@ -19,6 +20,8 @@ const {
   mockRateLimit: vi.fn(),
   // BE-L2: route now uses cacheSetNxStatus (not cacheSetNx + cacheGet)
   mockCacheSetNxStatus: vi.fn(),
+  // BE-H2: route releases the dedupe key on the 502 failure branches
+  mockCacheDel: vi.fn(),
 }));
 
 vi.mock("@/lib/email/resend", () => ({
@@ -30,6 +33,7 @@ vi.mock("@/lib/email/resend", () => ({
 vi.mock("@/lib/cache/redis", () => ({
   rateLimit: mockRateLimit,
   cacheSetNxStatus: mockCacheSetNxStatus,
+  cacheDel: mockCacheDel,
 }));
 
 vi.mock("@/lib/http/client-ip", () => ({
@@ -93,6 +97,7 @@ beforeEach(() => {
   mockRateLimit.mockResolvedValue({ allowed: true, current: 1, limit: 20 });
   // Default: key newly acquired — first delivery
   mockCacheSetNxStatus.mockResolvedValue("acquired");
+  mockCacheDel.mockResolvedValue(undefined);
 });
 
 // ---------------------------------------------------------------------------
@@ -340,6 +345,134 @@ describe("POST /api/webhooks/resend", () => {
     expect(entry.count).toBe(1);
 
     errorSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BE-H2: dedupe key must be released on the 502 failure branches so a real
+// Resend retry can actually re-attempt the fetch/forward instead of being
+// short-circuited as "already_processed".
+// ---------------------------------------------------------------------------
+
+describe("POST /api/webhooks/resend — dedupe key release on failure (BE-H2)", () => {
+  beforeEach(() => {
+    // Guard against cross-test pollution from queued mockResolvedValueOnce
+    // values: vi.clearAllMocks() (outer beforeEach) clears call records but
+    // NOT any unconsumed queued implementations, and a dedup short-circuit
+    // (the exact bug under test) can leave a queued value unconsumed.
+    mockFetchReceivedEmail.mockReset();
+    mockForwardEmail.mockReset();
+  });
+
+  it("releases the dedupe key when fetchReceivedEmail fails (502)", async () => {
+    mockVerifyWebhookSignature.mockReturnValueOnce(true);
+    mockFetchReceivedEmail.mockResolvedValueOnce(null);
+
+    const req = makeRequest(emailReceivedPayload, validHeaders);
+    const res = await POST(req);
+
+    expect(res.status).toBe(502);
+    expect(mockCacheDel).toHaveBeenCalledWith("webhook:resend:svix:msg_123");
+  });
+
+  it("releases the dedupe key when forwardEmail fails (502)", async () => {
+    mockVerifyWebhookSignature.mockReturnValueOnce(true);
+    mockFetchReceivedEmail.mockResolvedValueOnce(sampleEmail);
+    mockForwardEmail.mockResolvedValueOnce(null);
+
+    const req = makeRequest(emailReceivedPayload, validHeaders);
+    const res = await POST(req);
+
+    expect(res.status).toBe(502);
+    expect(mockCacheDel).toHaveBeenCalledWith("webhook:resend:svix:msg_123");
+  });
+
+  it("does NOT release the dedupe key on a genuine success", async () => {
+    mockVerifyWebhookSignature.mockReturnValueOnce(true);
+    mockFetchReceivedEmail.mockResolvedValueOnce(sampleEmail);
+    mockForwardEmail.mockResolvedValueOnce({ id: "fwd_123" });
+
+    const req = makeRequest(emailReceivedPayload, validHeaders);
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    expect(mockCacheDel).not.toHaveBeenCalled();
+  });
+
+  // Integration-style tests below use a small in-memory fake for the Redis
+  // dedupe primitives so a second POST() call with the same svix-id genuinely
+  // observes the effect of the first call's cacheSetNxStatus/cacheDel calls —
+  // this is what actually proves a Resend retry recovers instead of being
+  // short-circuited as "already_processed".
+  function useFakeDedupeStore() {
+    const store = new Set<string>();
+    mockCacheSetNxStatus.mockImplementation(async (key: string) => {
+      if (store.has(key)) return "exists";
+      store.add(key);
+      return "acquired";
+    });
+    mockCacheDel.mockImplementation(async (key: string) => {
+      store.delete(key);
+    });
+    return store;
+  }
+
+  it("allows a retried delivery to actually re-fetch after fetchReceivedEmail failed on the first attempt", async () => {
+    useFakeDedupeStore();
+    mockVerifyWebhookSignature.mockReturnValue(true);
+    mockFetchReceivedEmail.mockResolvedValueOnce(null); // first attempt: transient failure
+    mockFetchReceivedEmail.mockResolvedValueOnce(sampleEmail); // Resend retry: succeeds
+    mockForwardEmail.mockResolvedValueOnce({ id: "fwd_retry_fetch" });
+
+    const first = await POST(makeRequest(emailReceivedPayload, validHeaders));
+    expect(first.status).toBe(502);
+
+    // Resend retries the same delivery (same svix-id)
+    const second = await POST(makeRequest(emailReceivedPayload, validHeaders));
+    expect(second.status).toBe(200);
+    const body = await second.json();
+    expect(body.status).toBe("forwarded");
+    expect(body.status).not.toBe("already_processed");
+    expect(mockFetchReceivedEmail).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows a retried delivery to actually re-forward after forwardEmail failed on the first attempt", async () => {
+    useFakeDedupeStore();
+    mockVerifyWebhookSignature.mockReturnValue(true);
+    mockFetchReceivedEmail.mockResolvedValue(sampleEmail);
+    mockForwardEmail.mockResolvedValueOnce(null); // first attempt: transient failure
+    mockForwardEmail.mockResolvedValueOnce({ id: "fwd_retry_forward" }); // Resend retry: succeeds
+
+    const first = await POST(makeRequest(emailReceivedPayload, validHeaders));
+    expect(first.status).toBe(502);
+
+    const second = await POST(makeRequest(emailReceivedPayload, validHeaders));
+    expect(second.status).toBe(200);
+    const body = await second.json();
+    expect(body.status).toBe("forwarded");
+    expect(body.status).not.toBe("already_processed");
+    expect(mockForwardEmail).toHaveBeenCalledTimes(2);
+  });
+
+  it("still deduplicates a retried delivery after a genuine success (no duplicate forward)", async () => {
+    useFakeDedupeStore();
+    mockVerifyWebhookSignature.mockReturnValue(true);
+    mockFetchReceivedEmail.mockResolvedValue(sampleEmail);
+    mockForwardEmail.mockResolvedValueOnce({ id: "fwd_once" });
+
+    const first = await POST(makeRequest(emailReceivedPayload, validHeaders));
+    expect(first.status).toBe(200);
+    const firstBody = await first.json();
+    expect(firstBody.status).toBe("forwarded");
+
+    // Resend retries even though the first attempt already succeeded
+    const second = await POST(makeRequest(emailReceivedPayload, validHeaders));
+    expect(second.status).toBe(200);
+    const secondBody = await second.json();
+    expect(secondBody.status).toBe("already_processed");
+
+    expect(mockFetchReceivedEmail).toHaveBeenCalledTimes(1);
+    expect(mockForwardEmail).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/app/api/webhooks/resend/route.ts
+++ b/apps/web/app/api/webhooks/resend/route.ts
@@ -5,7 +5,7 @@ import {
   fetchReceivedEmail,
   forwardEmail,
 } from "@/lib/email/resend";
-import { cacheSetNxStatus, rateLimit } from "@/lib/cache/redis";
+import { cacheDel, cacheSetNxStatus, rateLimit } from "@/lib/cache/redis";
 import { getClientIp } from "@/lib/http/client-ip";
 import { withErrorCapture } from "@/lib/analytics/server-errors";
 import { log } from "@/lib/log";
@@ -119,6 +119,12 @@ export const POST = withErrorCapture("/api/webhooks/resend", async (request: Nex
   // 5. Fetch full email
   const email = await fetchReceivedEmail(emailId);
   if (!email) {
+    // BE-H2: this 502 exists specifically so Resend retries the delivery.
+    // The dedupe key must be released, or the retry short-circuits as
+    // "already_processed" (200) instead of actually re-attempting — silently
+    // dropping the email for the full 7-day TTL despite Resend reporting a
+    // successful delivery.
+    await cacheDel(dedupeKey);
     return NextResponse.json(
       { error: "Failed to fetch received email" },
       { status: 502 },
@@ -142,6 +148,10 @@ export const POST = withErrorCapture("/api/webhooks/resend", async (request: Nex
   });
 
   if (!result) {
+    // BE-H2: same rationale as the fetch failure branch above — release the
+    // dedupe key so a genuine Resend retry can actually re-attempt the
+    // forward.
+    await cacheDel(dedupeKey);
     return NextResponse.json(
       { error: "Failed to forward email" },
       { status: 502 },


### PR DESCRIPTION
Closes #1077