### PR TITLE
fix: enforce stats-completeness gate on all snapshot writers

### DIFF
--- a/apps/web/app/api/admin/bulk-recalculate/route.test.ts
+++ b/apps/web/app/api/admin/bulk-recalculate/route.test.ts
@@ -80,6 +80,7 @@ const FAKE_MATERIALIZED = {
     computedAt: "2026-04-17T12:00:00.000Z",
   },
   snapshot: { date: "2026-04-17", adjustedComposite: 42, tier: "Solid" },
+  statsComplete: true,
 };
 
 const VALID_SECRET = "test-admin-secret";
@@ -304,6 +305,31 @@ describe("POST /api/admin/bulk-recalculate", () => {
     expect(body.errors[0]).toEqual({
       handle: "alice",
       error: "Snapshot replace failed",
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // #1076 — persistOrchestratedSnapshot's #1003 gate intentionally skips
+  // persistence when materialized.statsComplete is false. Distinguish that
+  // from a genuine write failure in the per-handle error message so an
+  // operator scanning bulk-recalculate output can tell them apart.
+  // ---------------------------------------------------------------------------
+
+  it("#1076: reports an incomplete-stats skip distinctly from a genuine snapshot replace failure", async () => {
+    mockMaterializeOrchestratedProfile.mockResolvedValue({
+      ...FAKE_MATERIALIZED,
+      statsComplete: false,
+    });
+    mockPersistOrchestratedSnapshot.mockResolvedValue(false);
+
+    const res = await POST(makeRequest(VALID_SECRET, { handles: ["alice"] }));
+    const body = await res.json();
+
+    expect(body.recalculated).toBe(0);
+    expect(body.failed).toBe(1);
+    expect(body.errors[0]).toEqual({
+      handle: "alice",
+      error: "Snapshot skipped: stats incomplete",
     });
   });
 

--- a/apps/web/app/api/admin/bulk-recalculate/route.ts
+++ b/apps/web/app/api/admin/bulk-recalculate/route.ts
@@ -160,7 +160,16 @@ export const POST = withErrorCapture("/api/admin/bulk-recalculate", async (reque
             revalidatePath(`/u/${handle}`);
             recalculated++;
           } else {
-            errors.push({ handle, error: "Snapshot replace failed" });
+            // #1076 — persistOrchestratedSnapshot's #1003 gate intentionally
+            // skips persistence when the fetched stats look incomplete/
+            // poisoned. Distinguish that from a genuine write failure so an
+            // operator scanning this batch's errors can tell them apart.
+            errors.push({
+              handle,
+              error: materialized.statsComplete
+                ? "Snapshot replace failed"
+                : "Snapshot skipped: stats incomplete",
+            });
           }
         } catch (err) {
           errors.push({

--- a/apps/web/app/api/recalculate/route.test.ts
+++ b/apps/web/app/api/recalculate/route.test.ts
@@ -93,6 +93,7 @@ const FAKE_MATERIALIZED = {
     computedAt: "2026-04-17T12:00:00.000Z",
   },
   snapshot: { date: "2026-04-17", adjustedComposite: 58, tier: "Solid" },
+  statsComplete: true,
 };
 
 function makeRequest(): NextRequest {
@@ -223,6 +224,29 @@ describe("POST /api/recalculate", () => {
     const resp = await POST(makeRequest());
 
     expect(resp.status).toBe(500);
+    expect(mockInvalidateProfileReadModels).not.toHaveBeenCalled();
+    expect(mockRevalidatePath).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // #1076 — the route checks materialized.statsComplete up front (the #1003
+  // persist-boundary gate) so an intentional skip is distinguishable from a
+  // genuine write failure, not a bare 500, and persistOrchestratedSnapshot is
+  // never even called.
+  // ---------------------------------------------------------------------------
+
+  it("#1076: returns 422 with reason stats_incomplete without attempting to persist", async () => {
+    mockMaterializeOrchestratedProfile.mockResolvedValue({
+      ...FAKE_MATERIALIZED,
+      statsComplete: false,
+    });
+
+    const resp = await POST(makeRequest());
+    const body = await resp.json();
+
+    expect(resp.status).toBe(422);
+    expect(body.reason).toBe("stats_incomplete");
+    expect(mockPersistOrchestratedSnapshot).not.toHaveBeenCalled();
     expect(mockInvalidateProfileReadModels).not.toHaveBeenCalled();
     expect(mockRevalidatePath).not.toHaveBeenCalled();
   });

--- a/apps/web/app/api/recalculate/route.ts
+++ b/apps/web/app/api/recalculate/route.ts
@@ -64,6 +64,20 @@ export const POST = withErrorCapture("/api/recalculate", async (request: NextReq
     );
   }
 
+  // #1076 — persistOrchestratedSnapshot's #1003 gate would refuse to persist
+  // stats that look incomplete/poisoned anyway; check it here so the
+  // intentional skip (422) is distinguishable from a genuine write failure
+  // (500) up front, rather than inferring the reason from a bare `!persisted`.
+  if (!materialized.statsComplete) {
+    return NextResponse.json(
+      {
+        error: "Recalculated data looks incomplete and was not saved. Try again later.",
+        reason: "stats_incomplete",
+      },
+      { status: 422 },
+    );
+  }
+
   const persisted = await persistOrchestratedSnapshot(handle, materialized, {
     mode: "replace",
   });

--- a/apps/web/app/api/refresh/route.test.ts
+++ b/apps/web/app/api/refresh/route.test.ts
@@ -113,6 +113,7 @@ const FAKE_MATERIALIZED = {
     computedAt: "2026-04-17T12:00:00.000Z",
   },
   snapshot: { date: "2026-04-17", adjustedComposite: 72, tier: "Solid" },
+  statsComplete: true,
 };
 
 function makeRequest(handle?: string): NextRequest {
@@ -337,6 +338,37 @@ describe("POST /api/refresh", () => {
     expect(res.status).toBe(500);
     // The pre-fetch `{stats}` invalidation has already run by this point; what
     // must NOT run is the post-persist artifact invalidation.
+    expect(mockInvalidateProfileReadModels).not.toHaveBeenCalledWith(
+      "testuser",
+      expect.objectContaining({ badgeSvg: true }),
+    );
+    expect(mockRevalidatePath).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // #1076 — the route checks materialized.statsComplete up front (the #1003
+  // persist-boundary gate) so an intentional skip is distinguishable from a
+  // genuine write failure: no 500, no captureServerError escalation (the
+  // shared guard already emits snapshot_skipped_incomplete_stats telemetry),
+  // and persistOrchestratedSnapshot is never even called.
+  // ---------------------------------------------------------------------------
+
+  it("#1076: returns 422 with reason stats_incomplete without attempting to persist, and without escalating as a genuine failure", async () => {
+    mockMaterializeOrchestratedProfile.mockResolvedValue({
+      ...FAKE_MATERIALIZED,
+      statsComplete: false,
+    });
+
+    const res = await POST(makeRequest("testuser"));
+    const body = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(body.reason).toBe("stats_incomplete");
+    expect(mockPersistOrchestratedSnapshot).not.toHaveBeenCalled();
+    // Not a genuine failure — the shared guard already reports this via
+    // snapshot_skipped_incomplete_stats telemetry, so this must not also
+    // fire captureServerError (would double-report the same skip).
+    expect(mockCaptureServerError).not.toHaveBeenCalled();
     expect(mockInvalidateProfileReadModels).not.toHaveBeenCalledWith(
       "testuser",
       expect.objectContaining({ badgeSvg: true }),

--- a/apps/web/app/api/refresh/route.ts
+++ b/apps/web/app/api/refresh/route.ts
@@ -85,6 +85,21 @@ export const POST = withErrorCapture("/api/refresh", async (request: NextRequest
     );
   }
 
+  // #1076 — persistOrchestratedSnapshot's #1003 gate would refuse to persist
+  // stats that look incomplete/poisoned anyway (and already emits its own
+  // snapshot_skipped_incomplete_stats telemetry); check it here so the
+  // intentional skip (422) is distinguishable from a genuine write failure
+  // (500) up front, rather than inferring the reason from a bare `!persisted`.
+  if (!materialized.statsComplete) {
+    return NextResponse.json(
+      {
+        error: "Refreshed data looks incomplete and was not saved. Try again later.",
+        reason: "stats_incomplete",
+      },
+      { status: 422 },
+    );
+  }
+
   const persisted = await persistOrchestratedSnapshot(handle, materialized, {
     mode: "replace",
   });

--- a/apps/web/lib/profile/orchestrated-profile.test.ts
+++ b/apps/web/lib/profile/orchestrated-profile.test.ts
@@ -13,6 +13,8 @@ const mockMaterializeProfile = vi.fn();
 const mockDbInsertSnapshot = vi.fn();
 const mockDbReplaceSnapshot = vi.fn();
 const mockUpdateSnapshotCache = vi.fn();
+const mockCaptureServerEvent =
+  vi.fn<(...args: unknown[]) => Promise<void>>(() => Promise.resolve());
 
 vi.mock("./materialize-profile", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./materialize-profile")>();
@@ -29,6 +31,10 @@ vi.mock("@/lib/db/snapshots", () => ({
 
 vi.mock("@/lib/cache/snapshot-cache", () => ({
   updateSnapshotCache: (...args: unknown[]) => mockUpdateSnapshotCache(...args),
+}));
+
+vi.mock("@/lib/analytics/server-errors", () => ({
+  captureServerEvent: (...args: unknown[]) => mockCaptureServerEvent(...args),
 }));
 
 function makeMaterializedProfile(): MaterializedProfile {
@@ -140,5 +146,52 @@ describe("persistOrchestratedSnapshot", () => {
     expect(sameDayPublicRead.snapshot.adjustedComposite).toBe(
       replaced.snapshot.adjustedComposite,
     );
+  });
+
+  // ---------------------------------------------------------------------------
+  // #1076 — the orchestrated writer (warm-cache, /api/refresh, /api/recalculate,
+  // /api/admin/bulk-recalculate) must refuse to persist incomplete/poisoned
+  // stats, mirroring the badge path's existing #1003 gate in
+  // lib/profile/public-profile.ts's persistProfileSnapshot.
+  // ---------------------------------------------------------------------------
+
+  it("#1076: returns false and writes nothing when stats are incomplete (corrupt shape)", async () => {
+    const materialized = { ...makeMaterializedProfile(), statsComplete: false };
+
+    const persisted = await persistOrchestratedSnapshot("testuser", materialized, {
+      mode: "insert",
+    });
+
+    expect(persisted).toBe(false);
+    expect(mockDbInsertSnapshot).not.toHaveBeenCalled();
+    expect(mockDbReplaceSnapshot).not.toHaveBeenCalled();
+    expect(mockUpdateSnapshotCache).not.toHaveBeenCalled();
+  });
+
+  it("#1076: emits snapshot_skipped_incomplete_stats telemetry when stats are incomplete", async () => {
+    const materialized = { ...makeMaterializedProfile(), statsComplete: false };
+
+    await persistOrchestratedSnapshot("testuser", materialized, { mode: "replace" });
+
+    expect(mockCaptureServerEvent).toHaveBeenCalledWith(
+      "snapshot_skipped_incomplete_stats",
+      expect.objectContaining({
+        handle: "testuser",
+        prsMergedCount: materialized.stats.prsMergedCount,
+        commitsTotal: materialized.stats.commitsTotal,
+      }),
+    );
+  });
+
+  it("#1076: still persists normally when stats are complete (no regression)", async () => {
+    const materialized = { ...makeMaterializedProfile(), statsComplete: true };
+
+    const persisted = await persistOrchestratedSnapshot("testuser", materialized, {
+      mode: "insert",
+    });
+
+    expect(persisted).toBe(true);
+    expect(mockDbInsertSnapshot).toHaveBeenCalledWith("testuser", materialized.snapshot);
+    expect(mockCaptureServerEvent).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/profile/orchestrated-profile.ts
+++ b/apps/web/lib/profile/orchestrated-profile.ts
@@ -2,6 +2,7 @@ import {
   materializeProfile,
   type MaterializedProfile,
 } from "./materialize-profile";
+import { guardStatsComplete } from "./persist-guard";
 import {
   reconcileSnapshotWrite,
   type SnapshotPersistenceMode,
@@ -31,6 +32,14 @@ export async function persistOrchestratedSnapshot(
   materialized: MaterializedProfile,
   options: { mode: SnapshotPersistenceMode },
 ): Promise<boolean> {
+  // #1076 — This orchestrated writer backs warm-cache, /api/refresh,
+  // /api/recalculate, and /api/admin/bulk-recalculate, and previously
+  // bypassed the shared persist-boundary gate entirely (only
+  // lib/profile/public-profile.ts's persistProfileSnapshot enforced it).
+  if (!guardStatsComplete(handle, materialized)) {
+    return false;
+  }
+
   // The durable Supabase write and the Redis cache mirror are reconciled as
   // one envelope: a partial failure (durable ok, cache stale) emits an
   // operational alert rather than being swallowed (#975). Callers branch on

--- a/apps/web/lib/profile/persist-guard.ts
+++ b/apps/web/lib/profile/persist-guard.ts
@@ -1,0 +1,30 @@
+import { captureServerEvent } from "@/lib/analytics/server-errors";
+import { fireAndForget } from "@/lib/async/fire-and-forget";
+import type { MaterializedProfile } from "./materialize-profile";
+
+/**
+ * #1003, extended to every writer by #1076 — the shared persist-boundary
+ * gate: refuse to build a permanent snapshot row (or verification record)
+ * from stats that look incomplete/poisoned (e.g. served from an old
+ * poisoned `stats:stale` entry). Every snapshot writer must call this before
+ * persisting — `persistProfileSnapshot` (badge path) and
+ * `persistOrchestratedSnapshot` (warm-cache, /api/refresh, /api/recalculate,
+ * /api/admin/bulk-recalculate) both do.
+ */
+export function guardStatsComplete(
+  handle: string,
+  materialized: MaterializedProfile,
+): boolean {
+  if (materialized.statsComplete) return true;
+
+  fireAndForget(
+    () =>
+      captureServerEvent("snapshot_skipped_incomplete_stats", {
+        handle,
+        prsMergedCount: materialized.stats.prsMergedCount,
+        commitsTotal: materialized.stats.commitsTotal,
+      }),
+    () => undefined,
+  );
+  return false;
+}

--- a/apps/web/lib/profile/public-profile.ts
+++ b/apps/web/lib/profile/public-profile.ts
@@ -1,5 +1,4 @@
-import { captureServerError, captureServerEvent } from "@/lib/analytics/server-errors";
-import { fireAndForget } from "@/lib/async/fire-and-forget";
+import { captureServerError } from "@/lib/analytics/server-errors";
 import { cacheSetNxStatus, trackBadgeGenerated } from "@/lib/cache/redis";
 import { clearStatsDirty } from "@/lib/cache/dirty-stats";
 import { dbUpsertUser } from "@/lib/db/users";
@@ -11,6 +10,7 @@ import {
   materializeProfile,
   type MaterializedProfile,
 } from "./materialize-profile";
+import { guardStatsComplete } from "./persist-guard";
 import { reconcileSnapshotWrite } from "./snapshot-write";
 
 export interface PublicVerificationCode {
@@ -99,18 +99,7 @@ export async function persistProfileSnapshot(
 ): Promise<boolean> {
   if (options.readOnly) return false;
 
-  // #1003 — Never build a permanent snapshot row from stats that look
-  // incomplete (e.g. served from an old poisoned `stats:stale` entry).
-  if (!materialized.statsComplete) {
-    fireAndForget(
-      () =>
-        captureServerEvent("snapshot_skipped_incomplete_stats", {
-          handle,
-          prsMergedCount: materialized.stats.prsMergedCount,
-          commitsTotal: materialized.stats.commitsTotal,
-        }),
-      () => undefined,
-    );
+  if (!guardStatsComplete(handle, materialized)) {
     return false;
   }
 


### PR DESCRIPTION
Closes #1076