### PR TITLE
fix(badge): cache SVG when avatar is absent, not just when it resolves

### DIFF
--- a/apps/web/app/u/[handle]/badge.svg/route.test.ts
+++ b/apps/web/app/u/[handle]/badge.svg/route.test.ts
@@ -472,6 +472,60 @@ describe("GET /u/[handle]/badge.svg", () => {
         expect.any(Number),
       );
     });
+
+    // #1080 — `avatarResolved` used to conflate "nothing to fetch" and "a hard
+    // failure settled before the deadline" with "the deadline actually fired".
+    // Both of the first two cases will never resolve differently on a retry,
+    // so the SVG cache must still be written for them; only a genuine timeout
+    // should withhold the write (a retry might succeed there).
+    it("#1080: writes the SVG cache when the handle has no avatarUrl at all (nothing to fetch)", async () => {
+      mockMaterializePublicProfile.mockResolvedValue({
+        ...FAKE_MATERIALIZED,
+        stats: { ...FAKE_MATERIALIZED.stats, avatarUrl: undefined },
+      });
+
+      const [req, ctx] = makeRequest("testuser", { "x-forwarded-for": "1.2.3.4" });
+      await GET(req, ctx);
+
+      expect(mockGetAvatarBase64).not.toHaveBeenCalled();
+      expect(mockCacheSet).toHaveBeenCalledWith(
+        expect.stringMatching(new RegExp(`^badge:${CACHE_VERSION}:testuser:${BADGE_RENDER_VARIANT}:`)),
+        FAKE_SVG,
+        expect.any(Number),
+      );
+    });
+
+    it("#1080: still writes the SVG cache when the avatar fetch fails outright before the deadline (not a timeout)", async () => {
+      mockGetAvatarBase64.mockRejectedValue(new Error("404 from CDN"));
+
+      const [req, ctx] = makeRequest("testuser", { "x-forwarded-for": "1.2.3.4" });
+      await GET(req, ctx);
+
+      expect(mockCacheSet).toHaveBeenCalledWith(
+        expect.stringMatching(new RegExp(`^badge:${CACHE_VERSION}:testuser:${BADGE_RENDER_VARIANT}:`)),
+        FAKE_SVG,
+        expect.any(Number),
+      );
+    });
+
+    it("#1080: still withholds the SVG cache write when the avatar fetch genuinely times out against the deadline", async () => {
+      vi.useFakeTimers();
+      mockGetAvatarBase64.mockImplementation(
+        () => new Promise<string | undefined>(() => undefined),
+      );
+
+      try {
+        const [req, ctx] = makeRequest("testuser", { "x-forwarded-for": "1.2.3.4" });
+        const responsePromise = GET(req, ctx);
+
+        await vi.advanceTimersByTimeAsync(1000);
+        await responsePromise;
+
+        expect(mockCacheSet).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe("SVG full-response cache (#717)", () => {

--- a/apps/web/app/u/[handle]/badge.svg/route.ts
+++ b/apps/web/app/u/[handle]/badge.svg/route.ts
@@ -189,18 +189,32 @@ async function finalizeMaterializedBadge(
   renderMs: number;
 }> {
   let avatarDataUri: string | undefined;
-  let avatarResolved = false;
+  // #1080 — whether the avatar step reached a definitive outcome (resolved,
+  // either with data or a hard failure/404, or there was no `avatarUrl` to
+  // fetch in the first place) vs. genuinely hitting the race deadline before
+  // settling. Only the latter should withhold the SVG cache write — a retry
+  // might succeed once the CDN responds. A missing `avatarUrl` or a fetch
+  // that already failed will never resolve differently on retry either, so
+  // those are safe to cache normally instead of being permanently stuck on
+  // the cache-miss side of the latency SLO.
+  let avatarFetchTimedOut = false;
   if (!options.readOnly) {
     const avatarPromise = materialized.stats.avatarUrl
       ? getAvatarBase64(handle, materialized.stats.avatarUrl).catch(() => undefined)
       : Promise.resolve(undefined);
-    avatarDataUri = await Promise.race([
+    const AVATAR_TIMEOUT = Symbol("avatar-race-timeout");
+    const raceResult = await Promise.race([
       avatarPromise,
-      new Promise<undefined>((resolve) =>
-        setTimeout(() => resolve(undefined), AVATAR_RACE_DEADLINE_MS),
+      new Promise<typeof AVATAR_TIMEOUT>((resolve) =>
+        setTimeout(() => resolve(AVATAR_TIMEOUT), AVATAR_RACE_DEADLINE_MS),
       ),
     ]);
-    avatarResolved = avatarDataUri !== undefined;
+    if (raceResult === AVATAR_TIMEOUT) {
+      avatarFetchTimedOut = true;
+      avatarDataUri = undefined;
+    } else {
+      avatarDataUri = raceResult;
+    }
   }
   const verification = getPublicProfileVerification(materialized);
 
@@ -218,7 +232,7 @@ async function finalizeMaterializedBadge(
   // A missing verification record can be temporary when the first public
   // fetch is incomplete. Do not make that unverified render the terminal
   // 24-hour cache value; a later complete fetch must be able to heal it.
-  if (!options.readOnly && avatarResolved && verification) {
+  if (!options.readOnly && !avatarFetchTimedOut && verification) {
     await writeBadgeSvgCache(options.svgCacheKey, svg, handle);
   }
 


### PR DESCRIPTION
## Summary

Fixes #1080 (BE-M2). The badge SVG cache write in `finalizeMaterializedBadge` (`apps/web/app/u/[handle]/badge.svg/route.ts`) was gated on `avatarResolved` — `avatarDataUri !== undefined`. That conflated three distinct outcomes into one boolean, all of which permanently left the gate `false`:

1. **No `avatarUrl` at all** — `getAvatarBase64` never runs; `avatarPromise` resolves immediately to `undefined`.
2. **Fetch settled with a hard failure** (network error, 404 — caught in `getAvatarBase64`/`fetchAvatarBase64`) — also resolves to `undefined`, but *before* the race deadline.
3. **Fetch genuinely timed out** against the `AVATAR_RACE_DEADLINE_MS` (1000ms) race in `finalizeMaterializedBadge`.

Only case 3 is a transient condition where a retry might succeed and the cache write should be withheld. Cases 1 and 2 will never resolve differently on a subsequent request, so withholding the cache write there just meant every request for an affected handle repeated a full materialize + render, permanently on the cache-miss side of the 800ms/3000ms latency SLO (`docs/... "Badge latency SLO (#974)"`).

## Fix

Replaced the `avatarDataUri !== undefined` proxy with an explicit race outcome using a `Symbol` timeout sentinel in `Promise.race`, so we know definitively whether the deadline fired (`avatarFetchTimedOut`) vs. the avatar promise itself settled (regardless of whether it resolved to data or `undefined`). The SVG cache write now gates on `!avatarFetchTimedOut && verification` instead of `avatarResolved && verification`.

## Regression risk (from the issue)

> Must gate strictly on "the deadline fired," not "the fetch returned nothing," or a handle that would succeed on retry gets a bad/stale placeholder cached for 24h.

Verified: the existing timeout-withholding behavior (avatar fetch never settles, deadline fires) is preserved — a new regression test (`#1080: still withholds the SVG cache write when the avatar fetch genuinely times out against the deadline`) and the pre-existing `#1029` timeout test both pass.

## Test plan

- [x] New failing tests written first (TDD): no-`avatarUrl` case writes cache, hard-failure-before-deadline case writes cache, genuine-timeout case still withholds cache write.
- [x] `pnpm run test` — 526 files / 8915 tests passed
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean

## Scope note

This only fixes the `avatarResolved` gating logic described in #1080. Sibling issues #1088 (PE-M1) and #1089 (PE-M2, warm-cache never rendering SVG) are being handled separately and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)