### PR TITLE
fix(cache): warm the badge SVG cache during warm-cache cron (#1089)

### DIFF
--- a/apps/web/app/api/cron/warm-cache/route.test.ts
+++ b/apps/web/app/api/cron/warm-cache/route.test.ts
@@ -20,6 +20,10 @@ const {
   mockCaptureServerError,
   mockCaptureServerEvent,
   mockCaptureOperationalAlert,
+  mockRenderBadgeSvg,
+  mockGetPublicProfileVerification,
+  mockBuildBadgeSvgCacheKey,
+  mockWriteBadgeSvgCache,
 } = vi.hoisted(() => ({
   mockVerifyCronSecret: vi.fn(),
   mockDbGetUsers: vi.fn(),
@@ -38,6 +42,10 @@ const {
   mockCaptureServerError: vi.fn(),
   mockCaptureServerEvent: vi.fn(),
   mockCaptureOperationalAlert: vi.fn(),
+  mockRenderBadgeSvg: vi.fn(),
+  mockGetPublicProfileVerification: vi.fn(),
+  mockBuildBadgeSvgCacheKey: vi.fn(),
+  mockWriteBadgeSvgCache: vi.fn(),
 }));
 
 vi.mock("@/lib/auth/cron", () => ({
@@ -89,6 +97,20 @@ vi.mock("@/lib/render/avatar", () => ({
   getAvatarBase64: (...args: unknown[]) => mockGetAvatarBase64(...args),
 }));
 
+vi.mock("@/lib/render/BadgeSvg", () => ({
+  renderBadgeSvg: (...args: unknown[]) => mockRenderBadgeSvg(...args),
+}));
+
+vi.mock("@/lib/profile/public-profile", () => ({
+  getPublicProfileVerification: (...args: unknown[]) =>
+    mockGetPublicProfileVerification(...args),
+}));
+
+vi.mock("@/lib/render/badge-svg-cache", () => ({
+  buildBadgeSvgCacheKey: (...args: unknown[]) => mockBuildBadgeSvgCacheKey(...args),
+  writeBadgeSvgCache: (...args: unknown[]) => mockWriteBadgeSvgCache(...args),
+}));
+
 vi.mock("@/lib/analytics/server-errors", () => ({
   captureServerError: (...args: unknown[]) => mockCaptureServerError(...args),
   captureServerEvent: (...args: unknown[]) => mockCaptureServerEvent(...args),
@@ -125,6 +147,7 @@ const FAKE_MATERIALIZED = {
     computedAt: "2026-04-17T12:00:00.000Z",
   },
   snapshot: { date: "2026-04-17", adjustedComposite: 66, tier: "Solid" },
+  statsComplete: true,
 };
 
 function makeRequest(): NextRequest {
@@ -157,6 +180,15 @@ describe("GET /api/cron/warm-cache", () => {
     mockCaptureServerError.mockResolvedValue(undefined);
     mockCaptureServerEvent.mockResolvedValue(undefined);
     mockCaptureOperationalAlert.mockResolvedValue(undefined);
+    mockRenderBadgeSvg.mockReturnValue("<svg>rendered</svg>");
+    mockGetPublicProfileVerification.mockReturnValue({
+      hash: "verified-hash",
+      date: "2026-04-17",
+    });
+    mockBuildBadgeSvgCacheKey.mockImplementation(
+      (handle: string, date: string) => `badge:v1:${handle}:warm-amber-v3:${date}`,
+    );
+    mockWriteBadgeSvgCache.mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -572,6 +604,95 @@ describe("GET /api/cron/warm-cache", () => {
     // Warm still succeeds — avatar failure is fire-and-forget
     expect(body.warmed).toBe(2);
     expect(body.failed).toBe(0);
+  });
+
+  // #1089 (PE-M2): the cron previously never rendered/wrote the badge SVG
+  // cache, guaranteeing a cold miss for every handle at the UTC date
+  // rollover. warmHandle must now render and write the SVG, gated by the
+  // exact same quality gates that protect the request-path write in
+  // finalizeMaterializedBadge (apps/web/app/u/[handle]/badge.svg/route.ts):
+  // the avatar must have resolved AND a verification record must exist
+  // (which itself requires materialized.statsComplete).
+  describe("badge SVG cache warming (#1089)", () => {
+    it("renders and writes the badge SVG cache when the avatar resolves and stats look complete", async () => {
+      const res = await GET(makeRequest());
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.warmed).toBe(2);
+
+      expect(mockRenderBadgeSvg).toHaveBeenCalledWith(
+        FAKE_MATERIALIZED.stats,
+        FAKE_MATERIALIZED.displayImpact,
+        expect.objectContaining({
+          avatarDataUri: "data:image/png;base64,abc",
+          verificationHash: "verified-hash",
+          verificationDate: "2026-04-17",
+          disableAnimation: true,
+        }),
+      );
+      expect(mockWriteBadgeSvgCache).toHaveBeenCalledWith(
+        expect.stringContaining("alice"),
+        "<svg>rendered</svg>",
+        "alice",
+      );
+      expect(mockWriteBadgeSvgCache).toHaveBeenCalledWith(
+        expect.stringContaining("bob"),
+        "<svg>rendered</svg>",
+        "bob",
+      );
+    });
+
+    it("withholds the SVG cache write when verification is null (degraded/incomplete stats)", async () => {
+      mockGetPublicProfileVerification.mockReturnValue(null);
+
+      const res = await GET(makeRequest());
+      const body = await res.json();
+
+      // The warm itself still succeeds — only the SVG publish is gated.
+      expect(res.status).toBe(200);
+      expect(body.warmed).toBe(2);
+      expect(mockWriteBadgeSvgCache).not.toHaveBeenCalled();
+      expect(mockRenderBadgeSvg).not.toHaveBeenCalled();
+    });
+
+    it("withholds the SVG cache write when the avatar fails to resolve", async () => {
+      mockGetAvatarBase64.mockRejectedValue(new Error("avatar fetch timeout"));
+
+      const res = await GET(makeRequest());
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.warmed).toBe(2);
+      expect(mockWriteBadgeSvgCache).not.toHaveBeenCalled();
+      expect(mockRenderBadgeSvg).not.toHaveBeenCalled();
+    });
+
+    it("withholds the SVG cache write when the handle has no avatarUrl (mirrors the request path's avatarResolved gate)", async () => {
+      mockMaterializeOrchestratedProfile.mockResolvedValue({
+        ...FAKE_MATERIALIZED,
+        stats: { ...FAKE_MATERIALIZED.stats, avatarUrl: null },
+      });
+
+      const res = await GET(makeRequest());
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.warmed).toBe(2);
+      expect(mockGetAvatarBase64).not.toHaveBeenCalled();
+      expect(mockWriteBadgeSvgCache).not.toHaveBeenCalled();
+    });
+
+    it("does not let a badge SVG render/write failure fail the warm", async () => {
+      mockWriteBadgeSvgCache.mockRejectedValue(new Error("redis write boom"));
+
+      const res = await GET(makeRequest());
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.warmed).toBe(2);
+      expect(body.failed).toBe(0);
+    });
   });
 
   // DO-M5: PostHog cron_warm_cache_complete event

--- a/apps/web/app/api/cron/warm-cache/route.ts
+++ b/apps/web/app/api/cron/warm-cache/route.ts
@@ -12,7 +12,6 @@ import { notifyScoreBump } from "@/lib/email/score-bump";
 import { dbCleanExpiredVerifications } from "@/lib/db/verification";
 import { dbCleanExpiredMergeOperations } from "@/lib/db/telemetry";
 import { cacheGet, cacheSet } from "@/lib/cache/redis";
-import { fireAndForget } from "@/lib/async/fire-and-forget";
 import { processInBatches } from "@/lib/async/process-in-batches";
 import {
   captureServerError,
@@ -22,10 +21,17 @@ import {
 } from "@/lib/analytics/server-errors";
 import { getRequestId } from "@/lib/log";
 import { getAvatarBase64 } from "@/lib/render/avatar";
+import { renderBadgeSvg } from "@/lib/render/BadgeSvg";
+import {
+  buildBadgeSvgCacheKey,
+  writeBadgeSvgCache,
+} from "@/lib/render/badge-svg-cache";
+import { toDateString } from "@/lib/utils/date";
 import {
   materializeOrchestratedProfile,
   persistOrchestratedSnapshot,
 } from "@/lib/profile/orchestrated-profile";
+import { getPublicProfileVerification } from "@/lib/profile/public-profile";
 
 /** Vercel Pro allows up to 300s for serverless functions. */
 export const maxDuration = 300;
@@ -314,13 +320,38 @@ async function warmHandle(
     let snapshotRecorded = false;
     let notified = false;
 
-    // Pre-warm avatar cache opportunistically for later public renders.
-    const avatarUrl = materialized.stats.avatarUrl;
-    if (avatarUrl) {
-      fireAndForget(
-        () => getAvatarBase64(handle, avatarUrl),
-        () => undefined,
-      );
+    // #1089 (PE-M2): render and publish the badge SVG cache entry here so the
+    // first real visitor after the UTC date rollover gets a cache hit instead
+    // of paying the full materialize+render cost the cron already just paid.
+    // Gated by the exact same quality checks that protect the request-path
+    // write in finalizeMaterializedBadge (apps/web/app/u/[handle]/badge.svg/
+    // route.ts): the avatar must have resolved AND a verification record must
+    // exist (which itself requires materialized.statsComplete, #1003) — a
+    // degraded cron fetch must never publish a lower-quality badge for 24h.
+    // The avatar fetch is awaited (not fire-and-forget as before) since its
+    // result now feeds the render; its own internal fetch abort bounds this.
+    try {
+      const avatarUrl = materialized.stats.avatarUrl;
+      const avatarDataUri = avatarUrl
+        ? await getAvatarBase64(handle, avatarUrl).catch(() => undefined)
+        : undefined;
+      const avatarResolved = avatarDataUri !== undefined;
+      const verification = getPublicProfileVerification(materialized);
+
+      if (avatarResolved && verification) {
+        const svg = renderBadgeSvg(materialized.stats, materialized.displayImpact, {
+          avatarDataUri,
+          verificationHash: verification.hash,
+          verificationDate: verification.date,
+          // Mirrors the request path — this SVG is served to <img> embeds,
+          // where SMIL <animate> never runs.
+          disableAnimation: true,
+        });
+        const today = toDateString(new Date());
+        await writeBadgeSvgCache(buildBadgeSvgCacheKey(handle, today), svg, handle);
+      }
+    } catch {
+      // Badge SVG warming is opportunistic — never fail the warm over it.
     }
 
     // Record daily metrics snapshot (fire-and-forget, deduplicates by date)


### PR DESCRIPTION
## Summary

- `warmHandle` (the per-handle worker inside the `/api/cron/warm-cache` cron) materialized stats and prewarmed the avatar cache, but never rendered/wrote the badge SVG itself. Because the SVG cache key embeds today's UTC date, every handle's key changed at 00:00 UTC and the first real visitor after rollover paid the full materialize+render cost the cron had already just paid — guaranteeing a cold miss for every handle on every date rollover.
- `warmHandle` now renders the badge SVG and writes it to the shared SVG cache (`writeBadgeSvgCache` / `buildBadgeSvgCacheKey` from `apps/web/lib/render/badge-svg-cache.ts`) after materializing, so the cache is warm before real traffic arrives.

## Quality gates (replicated from the request path, not invented)

Read `apps/web/app/u/[handle]/badge.svg/route.ts`'s `finalizeMaterializedBadge` to find the exact conditions that already gate the request-path SVG cache write:

```ts
if (!options.readOnly && avatarResolved && verification) {
  await writeBadgeSvgCache(options.svgCacheKey, svg, handle);
}
```
where `verification = getPublicProfileVerification(materialized)`, which itself returns `null` unless `materialized.statsComplete` is true (#1003 — never attest a verification record from stats that look degraded/poisoned).

The cron path replicates the same two gates:
- **`avatarResolved`** — the avatar fetch is now `await`ed (previously fire-and-forget) so its result can feed the render; `avatarResolved = avatarDataUri !== undefined`, matching the request path exactly (including: no `avatarUrl` on the stats → `avatarResolved` stays `false`, same as today's request-path behavior).
- **`verification !== null`** — calls the same `getPublicProfileVerification(materialized)` helper, so a degraded/incomplete-stats cron fetch (`statsComplete === false`) is gated identically and can never publish a lower-quality badge into the 24h cache.

Both the render call and the cache write are skipped together when either gate fails — no separate/looser gate was introduced. Failures in this new opportunistic path (avatar fetch, render, cache write) are caught and swallowed so they never fail the warm itself (same resilience pattern as the rest of `warmHandle`).

## Test plan

- [x] TDD: added failing tests first (`apps/web/app/api/cron/warm-cache/route.test.ts`, new `describe("badge SVG cache warming (#1089)")` block) covering: successful render+write, withheld write on null verification, withheld write on avatar-resolve failure, withheld write when `avatarUrl` is absent, and that a cache-write failure doesn't fail the warm — then implemented until green.
- [x] `pnpm run test` — full suite green (8917 tests, 526 files)
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mh3Sf2VV6M4zJCzMppYqog