### PR TITLE
fix(infra): give warm-cache a wall-clock time budget with safe partial-rotation persistence

### DIFF
--- a/apps/web/app/api/cron/warm-cache/route.test.ts
+++ b/apps/web/app/api/cron/warm-cache/route.test.ts
@@ -858,4 +858,134 @@ describe("GET /api/cron/warm-cache", () => {
       );
     });
   });
+
+  // #1095: warm-cache had no wall-clock budget check, unlike process-campaigns'
+  // 30s-reserved-buffer pattern. A hard platform timeout mid-run meant the
+  // rotation offset and heartbeat never got written, and — since it's not a
+  // thrown error — no cron_failure alert fired either.
+  describe("time budget (#1095)", () => {
+    const BUDGET_MS = (300 - 30) * 1000; // maxDuration=300, mirrors process-campaigns' 30s buffer
+
+    it("stops processing further handles once the time budget is exhausted, defers the rest, writes the heartbeat, and does not throw", async () => {
+      mockDbGetUsers.mockResolvedValue(
+        Array.from({ length: 80 }, (_, index) => user(`user${index}`)),
+      );
+      mockCacheGet.mockResolvedValue(10); // offset=10, no priority handles -> toWarm = user10..user59 (50)
+
+      const T0 = 1_000_000;
+      const nowSpy = vi.spyOn(Date, "now");
+      nowSpy
+        .mockReturnValueOnce(T0) // start
+        .mockReturnValueOnce(T0) // time-budget check before batch 0 (elapsed 0) -> proceed
+        .mockReturnValueOnce(T0 + BUDGET_MS) // check before batch 1 -> exceeded -> stop
+        .mockReturnValue(T0 + BUDGET_MS); // durationMs / heartbeat / any further calls
+
+      const res = await GET(makeRequest());
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.timedOut).toBe(true);
+      // Only the first batch (5 handles) was actually processed before the budget check tripped.
+      expect(body.processedCount).toBe(5);
+      expect(body.warmed).toBe(5);
+      expect(body.deferredCount).toBe(45);
+      expect(mockMaterializeOrchestratedProfile).toHaveBeenCalledTimes(5);
+      // Heartbeat still written despite the early stop — graceful degradation, not a crash.
+      expect(mockCacheSet).toHaveBeenCalledWith(
+        "cron:lastrun:warm-cache",
+        expect.any(Number),
+        172800,
+      );
+
+      nowSpy.mockRestore();
+    });
+
+    it("advances the rotation offset only past the genuinely-completed handles, not the full intended slice (#750)", async () => {
+      mockDbGetUsers.mockResolvedValue(
+        Array.from({ length: 80 }, (_, index) => user(`user${index}`)),
+      );
+      mockCacheGet.mockResolvedValue(10);
+
+      const T0 = 1_000_000;
+      const nowSpy = vi.spyOn(Date, "now");
+      nowSpy
+        .mockReturnValueOnce(T0)
+        .mockReturnValueOnce(T0)
+        .mockReturnValueOnce(T0 + BUDGET_MS)
+        .mockReturnValue(T0 + BUDGET_MS);
+
+      const res = await GET(makeRequest());
+      const body = await res.json();
+
+      // Only 5 of the intended 50 rotation handles (offset 10..59) actually completed
+      // (user10..user14) -> next offset must be 15, NOT 60 (the full intended slice).
+      expect(body.rotation.nextOffset).toBe(15);
+      expect(mockCacheSet).toHaveBeenCalledWith("cron:warm-cache:offset", 15, 0);
+
+      nowSpy.mockRestore();
+    });
+
+    it("does not advance the offset at all when the budget is exhausted before any rotation handle completes", async () => {
+      // Priority handles fill the first batch; the budget runs out before any
+      // rotation-scanned handle is processed.
+      vi.stubEnv("WARM_CACHE_PRIORITY_HANDLES", "user70,user71,user72,user73,user74");
+      mockDbGetUsers.mockResolvedValue(
+        Array.from({ length: 80 }, (_, index) => user(`user${index}`)),
+      );
+      mockCacheGet.mockResolvedValue(10);
+
+      const T0 = 1_000_000;
+      const nowSpy = vi.spyOn(Date, "now");
+      nowSpy
+        .mockReturnValueOnce(T0)
+        .mockReturnValueOnce(T0) // check before batch 0 (priority handles) -> proceed
+        .mockReturnValueOnce(T0 + BUDGET_MS) // check before batch 1 (first rotation batch) -> exceeded
+        .mockReturnValue(T0 + BUDGET_MS);
+
+      const res = await GET(makeRequest());
+      const body = await res.json();
+
+      expect(body.processedCount).toBe(5);
+      expect(body.rotation.nextOffset).toBe(10); // unchanged from stored offset
+      expect(mockCacheSet).toHaveBeenCalledWith("cron:warm-cache:offset", 10, 0);
+
+      nowSpy.mockRestore();
+    });
+
+    it("emits a P2 operational alert when the time budget is exhausted, without throwing", async () => {
+      mockDbGetUsers.mockResolvedValue(
+        Array.from({ length: 80 }, (_, index) => user(`user${index}`)),
+      );
+      mockCacheGet.mockResolvedValue(10);
+
+      const T0 = 1_000_000;
+      const nowSpy = vi.spyOn(Date, "now");
+      nowSpy
+        .mockReturnValueOnce(T0)
+        .mockReturnValueOnce(T0)
+        .mockReturnValueOnce(T0 + BUDGET_MS)
+        .mockReturnValue(T0 + BUDGET_MS);
+
+      const res = await GET(makeRequest());
+
+      expect(res.status).toBe(200);
+      expect(mockCaptureOperationalAlert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          signal: "warm_cache_time_budget_exceeded",
+          severity: "P2",
+          route: "/api/cron/warm-cache",
+        }),
+      );
+
+      nowSpy.mockRestore();
+    });
+
+    it("reports timedOut: false and zero deferrals when the run completes within budget", async () => {
+      const res = await GET(makeRequest());
+      const body = await res.json();
+
+      expect(body.timedOut).toBe(false);
+      expect(body.deferredCount).toBe(0);
+    });
+  });
 });

--- a/apps/web/app/api/cron/warm-cache/route.ts
+++ b/apps/web/app/api/cron/warm-cache/route.ts
@@ -57,6 +57,17 @@ const MAX_HANDLES = 50;
 /** Number of handles to process concurrently per batch. */
 const BATCH_SIZE = 5;
 
+/**
+ * Leave a buffer before `maxDuration` so there's time left to finish the
+ * in-flight batch, persist the rotation offset, write the heartbeat, and
+ * return a response before the platform kills the invocation mid-flight.
+ * Mirrors the same pattern in `/api/cron/process-campaigns` (#1095) — without
+ * this, a hard timeout mid-run meant the rotation offset and heartbeat never
+ * got written, and — since a platform-killed invocation isn't a thrown error
+ * this route can catch — no `cron_failure` alert fired either.
+ */
+const TIME_BUDGET_MS = (maxDuration - 30) * 1000;
+
 /** Redis key storing the rotation offset for round-robin handle processing. */
 const ROTATION_KEY = "cron:warm-cache:offset";
 const HEARTBEAT_KEY = "cron:lastrun:warm-cache";
@@ -106,13 +117,23 @@ export const GET = withErrorCapture("/api/cron/warm-cache", async (request: Next
   // priority handle that is also in the rotation would otherwise underfill the run.
   const priorityHandles = parsePriorityHandles(allHandles);
   let toWarm: string[];
-  let nextOffset: number;
+  // Number of leading toWarm entries reserved for priority handles (processed
+  // first, before any rotation-scanned handle). Used below to determine how
+  // many *rotation* handles — not just handles overall — actually completed
+  // when a time-budget stop cuts the run short (#1095/#750).
+  let reservedPriorityCount: number;
+  // For the k-th rotation handle appended to toWarm (1-indexed), the
+  // `inspected` scan-step count at the moment it was added. This lets the
+  // offset be recomputed as of any completed prefix of rotation handles,
+  // not just the full intended slice.
+  const rotationCheckpoints: number[] = [];
   if (allHandles.length <= MAX_HANDLES) {
     // All users fit in one run — no rotation needed
     toWarm = [...allHandles];
-    nextOffset = 0;
+    reservedPriorityCount = toWarm.length;
   } else {
     toWarm = priorityHandles.slice(0, MAX_HANDLES);
+    reservedPriorityCount = toWarm.length;
     const warmSet = new Set(toWarm);
     let inspected = 0;
     while (toWarm.length < MAX_HANDLES && inspected < allHandles.length) {
@@ -122,9 +143,9 @@ export const GET = withErrorCapture("/api/cron/warm-cache", async (request: Next
       if (!warmSet.has(handle)) {
         warmSet.add(handle);
         toWarm.push(handle);
+        rotationCheckpoints.push(inspected);
       }
     }
-    nextOffset = (offset + inspected) % allHandles.length;
   }
 
   // Pre-fetch all previous snapshots in one batch query (instead of N+1 individual calls)
@@ -135,16 +156,35 @@ export const GET = withErrorCapture("/api/cron/warm-cache", async (request: Next
   let snapshots = 0;
   let notifications = 0;
 
-  // Process handles in parallel batches for throughput.
-  // processInBatches returns { succeeded, failed } so we can identify which handles failed.
-  const { succeeded: warmResults, failed: warmFailures } = await processInBatches(
-    toWarm,
-    BATCH_SIZE,
-    async (handle) => {
-      const result = await warmHandle(handle, previousSnapshots, requestId);
-      return { handle, ...result };
-    },
-  );
+  // Process handles in parallel batches for throughput, checking the time
+  // budget before starting each batch (#1095, mirrors process-campaigns).
+  // completedCount tracks exactly how many of toWarm's handles were actually
+  // attempted this run — the rest are deferred to the next invocation rather
+  // than risking a hard platform timeout with nothing persisted.
+  type WarmOutcome = { handle: string } & HandleResult;
+  const warmResults: WarmOutcome[] = [];
+  const warmFailures: Array<{ item: string; error: Error }> = [];
+  let completedCount = 0;
+  let timedOut = false;
+
+  for (let i = 0; i < toWarm.length; i += BATCH_SIZE) {
+    if (Date.now() - start >= TIME_BUDGET_MS) {
+      timedOut = true;
+      break;
+    }
+    const batch = toWarm.slice(i, i + BATCH_SIZE);
+    const { succeeded, failed } = await processInBatches(
+      batch,
+      BATCH_SIZE,
+      async (handle) => {
+        const result = await warmHandle(handle, previousSnapshots, requestId);
+        return { handle, ...result };
+      },
+    );
+    warmResults.push(...succeeded);
+    warmFailures.push(...failed);
+    completedCount += batch.length;
+  }
 
   // Aggregate succeeded results
   for (const { warmed: w, snapshotRecorded, notified } of warmResults) {
@@ -155,11 +195,48 @@ export const GET = withErrorCapture("/api/cron/warm-cache", async (request: Next
     }
   }
 
-  // Only advance rotation after processInBatches completes, and only if at least one
-  // handle was processed — prevents a timeout from advancing the offset past handles
-  // that were never warmed (#750).
-  if (warmResults.length > 0) {
+  // Recompute the offset to advance to based on how many *rotation-scanned*
+  // handles actually completed this run — not the full intended slice.
+  // Priority handles never affect rotation position. A time-budget stop that
+  // lands before any rotation handle completes leaves the offset unchanged;
+  // one that lands partway through advances only as far as the last
+  // completed rotation handle's scan checkpoint (#1095/#750: never advance
+  // past handles never warmed).
+  let nextOffset = offset;
+  if (allHandles.length <= MAX_HANDLES) {
+    nextOffset = 0;
+  } else {
+    const completedRotationCount = completedCount - reservedPriorityCount;
+    if (completedRotationCount > 0) {
+      const checkpointIndex = Math.min(completedRotationCount, rotationCheckpoints.length) - 1;
+      const inspectedAtCheckpoint = rotationCheckpoints[checkpointIndex]!;
+      nextOffset = (offset + inspectedAtCheckpoint) % allHandles.length;
+    }
+  }
+
+  // Only advance rotation after the processing loop completes, and only if at
+  // least one handle was actually attempted — prevents a run that processed
+  // nothing (e.g. an empty user list) from persisting a spurious offset (#750).
+  if (completedCount > 0) {
     await cacheSet(ROTATION_KEY, nextOffset, 0);
+  }
+
+  // #1095: a time-budget stop is graceful degradation, not a crash — but it's
+  // still worth paging on if runs are consistently timing out, since a
+  // persistently-timing-out run means the rotation offset creeps forward far
+  // more slowly than the ceiling math above assumes.
+  if (timedOut) {
+    void captureOperationalAlert({
+      signal: "warm_cache_time_budget_exceeded",
+      severity: "P2",
+      summary: `warm-cache: time budget exceeded after ${completedCount}/${toWarm.length} handles — ${toWarm.length - completedCount} deferred to next run`,
+      route: "/api/cron/warm-cache",
+      properties: {
+        completedCount,
+        selectedCount: toWarm.length,
+        deferredCount: toWarm.length - completedCount,
+      },
+    });
   }
 
   // Log unexpected hard failures (warmHandle catches internally; these guard against
@@ -179,7 +256,11 @@ export const GET = withErrorCapture("/api/cron/warm-cache", async (request: Next
     ...warmResults.filter((r) => !r.warmed).map((r) => ({ handle: r.handle, reason: "warm returned false" })),
   ];
   const failed = failures.length;
-  const processedCount = toWarm.length;
+  // processedCount reflects handles actually attempted this run — equal to
+  // toWarm.length except when the time budget cut the run short (#1095), in
+  // which case the deferred tail was never attempted and must not count.
+  const processedCount = completedCount;
+  const deferredCount = toWarm.length - completedCount;
 
   // DO-L1 (#751): P2 alert when failure rate exceeds 50% of processed handles.
   // A cron run where every handle silently fails returns HTTP 200 with a non-empty
@@ -267,7 +348,9 @@ export const GET = withErrorCapture("/api/cron/warm-cache", async (request: Next
       expiredMergeOpsDeleted,
       expiredSnapshotsDeleted,
       processedCount,
-      processedSample: toWarm.slice(0, 10),
+      processedSample: toWarm.slice(0, Math.min(completedCount, 10)),
+      timedOut,
+      deferredCount,
       rotation: {
         offset,
         nextOffset,


### PR DESCRIPTION
## Summary
`warm-cache` had no elapsed-time check, unlike `process-campaigns` (which reserves a 30s buffer against `maxDuration`). A hard platform timeout mid-run meant the rotation offset and heartbeat never got written, and wasn't a thrown error, so no `cron_failure` alert fired. If runs consistently time out as the user base grows, the rotation offset freezes forever — the first ~50 handles get re-warmed hourly and everyone past the offset never warms again, silently.

## Fix
Mirrors the `process-campaigns` time-budget pattern: the per-handle loop now checks elapsed time against a wall-clock budget (with the same kind of buffer), and on exhaustion persists `nextOffset` for handles actually completed and writes the heartbeat, rather than dying silently mid-run.

## Regression risk addressed
Preserves the #750 invariant — the offset advances only to the genuinely-completed boundary, never past handles that were never warmed.

Fixes #1095

## Test plan
- [x] New/updated tests covering budget exhaustion mid-run, correct partial-offset persistence, and heartbeat write
- [x] `pnpm run test`, `pnpm run typecheck`, `pnpm run lint` all green (enforced by pre-commit hook)

Note: this PR and #1132 (fixing #1089 in the same file, `apps/web/app/api/cron/warm-cache/route.ts`) were developed concurrently in separate worktrees — expect a merge conflict between them that needs manual reconciliation.