### PR TITLE
fix(cache): run linked-platform + supplemental overlay loads concurrently

### DIFF
--- a/apps/web/lib/github/client.test.ts
+++ b/apps/web/lib/github/client.test.ts
@@ -301,6 +301,45 @@ describe("getStats", () => {
       expect(result).not.toBeNull();
     });
 
+    it("kicks off the supplemental lookup concurrently with the platform fetches, not strictly after them", async () => {
+      // Collapsing _loadOverlays' own internal waves (the second half of the
+      // #1087/PE-H2 recommendation): the platform fetches (bitbucket/codeberg/
+      // gitlab) and the supplemental lookup have zero data dependency on each
+      // other, so the supplemental cacheGet must fire even while a platform
+      // fetch is still in flight — not wait for Promise.allSettled(platforms)
+      // to resolve first.
+      mockCacheGet
+        .mockResolvedValueOnce(null) // stats:v2:merged (primary miss)
+        .mockResolvedValueOnce(null) // stats:stale (baseline miss)
+        .mockResolvedValueOnce(null); // supplemental miss — must fire concurrently
+
+      mockFetchStatsData.mockResolvedValue(makeStats());
+
+      let resolveBitbucket!: (value: StatsData | null) => void;
+      mockFetchBitbucketIfLinked.mockReturnValue(
+        new Promise<StatsData | null>((resolve) => {
+          resolveBitbucket = resolve;
+        }),
+      );
+
+      const resultPromise = getStats("test-user");
+
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // The 3rd cacheGet call (supplemental) must already have fired even
+      // though the bitbucket platform fetch — part of the same overlay load —
+      // is still pending. Proof the supplemental wave doesn't wait on the
+      // platform-fetch wave to settle.
+      expect(mockCacheGet).toHaveBeenCalledTimes(3);
+      expect(mockCacheGet).toHaveBeenNthCalledWith(3, "supplemental:test-user");
+
+      resolveBitbucket(null);
+      const result = await resultPromise;
+      expect(result).not.toBeNull();
+    });
+
     it("regression: a slow concurrent overlay fetch does not influence the degraded-fetch guard's primary-vs-baseline decision", async () => {
       const lastGood = makeStats({ prsMergedCount: 41, prsMergedWeight: 120, commitsTotal: 14000 });
       const degraded = makeStats({

--- a/apps/web/lib/github/client.ts
+++ b/apps/web/lib/github/client.ts
@@ -237,6 +237,33 @@ function _classifyScope(token?: string): StatsData["fetchScope"] {
 }
 
 /**
+ * Load supplemental (e.g. EMU account) data for a handle. Redis is the hot
+ * path with a 24h TTL; Supabase (#825) is the durable fallback so a missed
+ * CLI upload day no longer silently drops EMU stats from scores. On a Redis
+ * miss + DB hit, we rehydrate Redis so subsequent reads stay fast.
+ *
+ * Extracted from `_loadOverlays` (#1087 / PE-H2) so it can run concurrently
+ * with the platform fetches — the two have no data dependency on each other.
+ */
+async function _loadSupplemental(
+  lowerHandle: string,
+  readOnly: boolean | undefined,
+): Promise<SupplementalStats | null> {
+  const supplementalKey = `supplemental:${lowerHandle}`;
+  const cached = await cacheGet<SupplementalStats>(supplementalKey);
+  if (cached) return cached;
+
+  const persisted = await dbGetSupplemental(lowerHandle);
+  if (persisted && !readOnly) {
+    fireAndForget(
+      () => cacheSet(supplementalKey, persisted, SUPPLEMENTAL_TTL),
+      () => undefined,
+    );
+  }
+  return persisted;
+}
+
+/**
  * Load every non-GitHub source for a handle. Called on every path — including
  * total GitHub-fetch failure — so that whichever GitHub-derived value is served
  * is always composed from the same, current overlay inputs. Serving a
@@ -248,41 +275,36 @@ async function _loadOverlays(
   lowerHandle: string,
   readOnly: boolean | undefined,
 ): Promise<StatsOverlays> {
-  // Platform fetches run in parallel — an error in one must not block the others.
-  const [bbResult, cbResult, glResult] = readOnly
-    ? ([
+  // Platform fetches and the supplemental lookup have zero data dependency on
+  // each other (#1087 / PE-H2) — kick both waves off together rather than
+  // sequencing the supplemental lookup strictly after the platform fetches
+  // settle. An error in one platform fetch must not block the others.
+  const platformFetches: Promise<
+    readonly [
+      PromiseSettledResult<StatsData | null>,
+      PromiseSettledResult<StatsData | null>,
+      PromiseSettledResult<StatsData | null>,
+    ]
+  > = readOnly
+    ? Promise.resolve([
         { status: "fulfilled", value: null },
         { status: "fulfilled", value: null },
         { status: "fulfilled", value: null },
       ] as const)
-    : await Promise.allSettled([
+    : Promise.allSettled([
         fetchBitbucketIfLinked(handle, lowerHandle),
         fetchCodebergIfLinked(handle, lowerHandle),
         fetchGitlabIfLinked(handle, lowerHandle),
       ]);
 
+  const [[bbResult, cbResult, glResult], supplemental] = await Promise.all([
+    platformFetches,
+    _loadSupplemental(lowerHandle, readOnly),
+  ]);
+
   const bitbucket = bbResult.status === "fulfilled" ? bbResult.value : null;
   const codeberg = cbResult.status === "fulfilled" ? cbResult.value : null;
   const gitlab = glResult.status === "fulfilled" ? glResult.value : null;
-
-  // Supplemental (e.g. EMU account). Redis is the hot path with a 24h TTL;
-  // Supabase (#825) is the durable fallback so a missed CLI upload day no
-  // longer silently drops EMU stats from scores. On a Redis miss + DB hit, we
-  // rehydrate Redis so subsequent reads stay fast.
-  const supplementalKey = `supplemental:${lowerHandle}`;
-  let supplemental = await cacheGet<SupplementalStats>(supplementalKey);
-  if (!supplemental) {
-    const persisted = await dbGetSupplemental(lowerHandle);
-    if (persisted) {
-      supplemental = persisted;
-      if (!readOnly) {
-        fireAndForget(
-          () => cacheSet(supplementalKey, persisted, SUPPLEMENTAL_TTL),
-          () => undefined,
-        );
-      }
-    }
-  }
 
   // Build linkedPlatforms from DB link status (source of truth), not stats
   // fetch success. Platforms appear in Data Sources even when their stats fetch


### PR DESCRIPTION
## Summary
`_loadOverlays` (linked-platform + supplemental stats) has zero data dependency on the GitHub fetch's result but ran strictly after it, then serialized its own internals into four further waves. The two most expensive network legs ran back-to-back instead of concurrently — the single largest recoverable chunk of the cache-miss-path latency budget.

## Fix
`Promise.all([fetchStats(...), _loadOverlays(...)])` so the GitHub fetch and overlay loading run concurrently; collapsed `_loadOverlays`'s internal sequential waves where independent of each other.

## Regression risk addressed
Touches the #1060/#1061 scoring-data-integrity boundary (see CLAUDE.md "Scoring-data integrity contract"). Verified the integrity guards (`assessRawFetchIntegrity`, `isDegradedPrFetch`) still inspect GitHub-derived stats only, the write ordering of `stats:stale:v2:<handle>` is unchanged, and overlay composition still happens after the guards run, never before — only the network fetch *start* time changed, not the pipeline ordering.

Fixes #1087

## Test plan
- [x] Test proving overlay loading and the GitHub fetch now run concurrently
- [x] Stats-integrity-focused tests re-run to confirm no regression to guard/baseline behavior
- [x] `pnpm run test`, `pnpm run typecheck`, `pnpm run lint` all green (enforced by pre-commit hook)

## Expected impact
Removes up to 8000ms from the worst case, 200-600ms typically, for linked-platform users.