### PR TITLE
fix(badge): cache short-TTL placeholder for handles with no avatar (#1088)

### DIFF
--- a/apps/web/app/u/[handle]/badge.svg/route.test.ts
+++ b/apps/web/app/u/[handle]/badge.svg/route.test.ts
@@ -474,6 +474,79 @@ describe("GET /u/[handle]/badge.svg", () => {
     });
   });
 
+  // #1088 (PE-M1) — a handle whose stats carry NO avatarUrl at all (a
+  // permanent condition, not a race-timeout) was previously gated by the
+  // same `avatarResolved` check as a genuine in-flight race loss, so the
+  // shared SVG cache was NEVER populated for it — every single request
+  // forced a full materialize+render forever. This must be distinguished
+  // from the genuine race-timeout case above (#1029), which still must NOT
+  // write the cache.
+  describe("permanent avatar absence caching (#1088)", () => {
+    const NO_AVATAR_MATERIALIZED = {
+      ...FAKE_MATERIALIZED,
+      stats: { ...FAKE_MATERIALIZED.stats, avatarUrl: undefined },
+    };
+
+    it("writes a short-TTL cache entry when stats.avatarUrl is absent (not attempted, not a race-timeout)", async () => {
+      mockMaterializePublicProfile.mockResolvedValue(NO_AVATAR_MATERIALIZED);
+
+      const [req, ctx] = makeRequest("testuser", { "x-forwarded-for": "1.2.3.4" });
+      const res = await GET(req, ctx);
+
+      expect(res.status).toBe(200);
+      // No avatarUrl to fetch — getAvatarBase64 must never be called.
+      expect(mockGetAvatarBase64).not.toHaveBeenCalled();
+      expect(mockCacheSet).toHaveBeenCalledWith(
+        expect.stringMatching(new RegExp(`^badge:${CACHE_VERSION}:testuser:${BADGE_RENDER_VARIANT}:`)),
+        FAKE_SVG,
+        expect.any(Number),
+      );
+      const ttl = mockCacheSet.mock.calls[0]![2] as number;
+      // Short-TTL placeholder (15-30 min), not the full 24h+jitter write a
+      // resolved avatar gets, and not zero/no-write like a race-timeout.
+      expect(ttl).toBeGreaterThanOrEqual(900);
+      expect(ttl).toBeLessThanOrEqual(1800);
+    });
+
+    it("the short-TTL write does not exceed a normal full-day write's TTL floor", async () => {
+      mockMaterializePublicProfile.mockResolvedValue(NO_AVATAR_MATERIALIZED);
+
+      const [req, ctx] = makeRequest("testuser", { "x-forwarded-for": "1.2.3.4" });
+      await GET(req, ctx);
+
+      const ttl = mockCacheSet.mock.calls[0]![2] as number;
+      expect(ttl).toBeLessThan(86400);
+    });
+
+    it("does not write the cache at all for a genuine race-timeout (avatarUrl present, fetch too slow) — unaffected by the permanent-absence path", async () => {
+      vi.useFakeTimers();
+      mockGetAvatarBase64.mockImplementation(
+        () => new Promise<string | undefined>(() => undefined),
+      );
+
+      try {
+        const [req, ctx] = makeRequest("testuser", { "x-forwarded-for": "1.2.3.4" });
+        const responsePromise = GET(req, ctx);
+        await vi.advanceTimersByTimeAsync(1000);
+        await responsePromise;
+
+        expect(mockCacheSet).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("skips the cache write entirely when unverified, even with a permanently-absent avatar", async () => {
+      mockMaterializePublicProfile.mockResolvedValue(NO_AVATAR_MATERIALIZED);
+      mockGetPublicProfileVerification.mockReturnValue(null);
+
+      const [req, ctx] = makeRequest("testuser", { "x-forwarded-for": "1.2.3.4" });
+      await GET(req, ctx);
+
+      expect(mockCacheSet).not.toHaveBeenCalled();
+    });
+  });
+
   describe("SVG full-response cache (#717)", () => {
     it("returns cached SVG on cache hit without calling materialize or render", async () => {
       const CACHED_SVG = '<svg xmlns="http://www.w3.org/2000/svg">CACHED</svg>';

--- a/apps/web/app/u/[handle]/badge.svg/route.ts
+++ b/apps/web/app/u/[handle]/badge.svg/route.ts
@@ -11,6 +11,7 @@ import {
   rateLimit,
 } from "@/lib/cache/redis";
 import {
+  AVATAR_ABSENT_CACHE_TTL_SECONDS,
   buildBadgeSvgCacheKey,
   buildBadgeSvgRenderLockKey,
   readBadgeSvgCache,
@@ -190,7 +191,16 @@ async function finalizeMaterializedBadge(
 }> {
   let avatarDataUri: string | undefined;
   let avatarResolved = false;
+  // #1088 — true only when the handle's stats carry no `avatarUrl` at all: a
+  // PERMANENT condition (until the next stats refetch), never a genuine
+  // in-flight race loss on a real fetch. The two used to be conflated by
+  // `avatarResolved` alone (false in both cases), which gated the shared SVG
+  // cache write shut for both — starving a permanently-absent-avatar handle
+  // of ANY cache population, forcing a full materialize+render on every
+  // single request forever (the bug this fixes).
+  let avatarPermanentlyAbsent = false;
   if (!options.readOnly) {
+    avatarPermanentlyAbsent = !materialized.stats.avatarUrl;
     const avatarPromise = materialized.stats.avatarUrl
       ? getAvatarBase64(handle, materialized.stats.avatarUrl).catch(() => undefined)
       : Promise.resolve(undefined);
@@ -218,8 +228,23 @@ async function finalizeMaterializedBadge(
   // A missing verification record can be temporary when the first public
   // fetch is incomplete. Do not make that unverified render the terminal
   // 24-hour cache value; a later complete fetch must be able to heal it.
-  if (!options.readOnly && avatarResolved && verification) {
-    await writeBadgeSvgCache(options.svgCacheKey, svg, handle);
+  if (!options.readOnly && verification) {
+    if (avatarResolved) {
+      await writeBadgeSvgCache(options.svgCacheKey, svg, handle);
+    } else if (avatarPermanentlyAbsent) {
+      // #1088 — short-TTL placeholder write: populates the cache (so a
+      // README embed with real traffic stops forcing a full
+      // materialize+render on every request) without shadowing a later good
+      // render — e.g. avatarUrl reappearing on a subsequent stats refetch —
+      // for anywhere near the 24h+jitter a normal write gets.
+      await writeBadgeSvgCache(options.svgCacheKey, svg, handle, {
+        ttlSeconds: AVATAR_ABSENT_CACHE_TTL_SECONDS,
+      });
+    }
+    // else: avatarUrl exists but its fetch lost the race against
+    // AVATAR_RACE_DEADLINE_MS (#1029) — a genuinely transient condition — do
+    // not cache; the next request gets a fresh fetch attempt instead of
+    // being stuck behind a stale avatar-less placeholder.
   }
 
   return { svg, verification, renderMs };

--- a/apps/web/app/u/[handle]/page.test.tsx
+++ b/apps/web/app/u/[handle]/page.test.tsx
@@ -15,6 +15,7 @@ const {
   mockGetTrendData,
   mockHeaders,
   mockGetOptionalServerSessionFromHeaders,
+  mockWriteBadgeSvgCache,
 } = vi.hoisted(() => ({
   mockMaterializePublicProfile: vi.fn(),
   mockGetPublicProfileVerification: vi.fn(),
@@ -30,6 +31,7 @@ const {
   mockGetTrendData: vi.fn(),
   mockHeaders: vi.fn(),
   mockGetOptionalServerSessionFromHeaders: vi.fn(),
+  mockWriteBadgeSvgCache: vi.fn(),
 }));
 
 vi.mock("@/lib/profile/public-profile", () => ({
@@ -70,6 +72,19 @@ vi.mock("@/lib/render/avatar", () => ({
 vi.mock("@/lib/render/BadgeSvg", () => ({
   renderBadgeSvg: (...args: unknown[]) => mockRenderBadgeSvg(...args),
 }));
+
+// #1088 — writeBadgeSvgCache is mocked so tests can assert on its TTL
+// argument directly; buildBadgeSvgCacheKey/readBadgeSvgCache stay real
+// (readBadgeSvgCache falls through to the real, unmocked `@/lib/cache/redis`
+// module, which no-ops without Redis credentials in the test env — matching
+// this file's existing always-cache-miss behavior).
+vi.mock("@/lib/render/badge-svg-cache", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/render/badge-svg-cache")>();
+  return {
+    ...actual,
+    writeBadgeSvgCache: (...args: unknown[]) => mockWriteBadgeSvgCache(...args),
+  };
+});
 
 vi.mock("@/lib/env", () => ({
   getBaseUrl: () => "https://chapa.thecreativetoken.com",
@@ -211,6 +226,7 @@ describe("SharePage /u/[handle]", () => {
     mockDeferProfileCacheWork.mockResolvedValue(undefined);
     mockGetAvatarBase64.mockResolvedValue("data:image/png;base64,abc123");
     mockRenderBadgeSvg.mockReturnValue(FAKE_SVG);
+    mockWriteBadgeSvgCache.mockResolvedValue(true);
     mockGetServerLocale.mockResolvedValue("en");
     mockGetTrendData.mockResolvedValue({ trend: null, diff: null });
     mockHeaders.mockResolvedValue({ get: () => null });
@@ -522,6 +538,50 @@ describe("SharePage /u/[handle]", () => {
       FAKE_MATERIALIZED.displayImpact,
       expect.objectContaining({ avatarDataUri: undefined }),
     );
+  });
+
+  // #1088 (PE-M1) — same root cause as the badge.svg route: a handle whose
+  // stats carry no avatarUrl at all is a PERMANENT condition, distinct from
+  // a genuine race-timeout on a real fetch. The share page's own SVG-cache
+  // write must not stay silent for it forever either.
+  describe("permanent avatar absence caching (#1088)", () => {
+    const NO_AVATAR_MATERIALIZED = {
+      ...FAKE_MATERIALIZED,
+      stats: { ...FAKE_MATERIALIZED.stats, avatarUrl: undefined },
+    };
+
+    it("writes a short-TTL cache entry when stats.avatarUrl is absent", async () => {
+      mockMaterializePublicProfile.mockResolvedValue(NO_AVATAR_MATERIALIZED);
+
+      await renderPage();
+
+      expect(mockAfter).toHaveBeenCalledTimes(1);
+      const callback = mockAfter.mock.calls[0][0];
+      await callback();
+
+      expect(mockGetAvatarBase64).not.toHaveBeenCalled();
+      expect(mockWriteBadgeSvgCache).toHaveBeenCalledWith(
+        expect.any(String),
+        FAKE_SVG,
+        "testuser",
+        expect.objectContaining({ ttlSeconds: expect.any(Number) }),
+      );
+      const ttlArg = mockWriteBadgeSvgCache.mock.calls[0]![3] as { ttlSeconds: number };
+      expect(ttlArg.ttlSeconds).toBeGreaterThanOrEqual(900);
+      expect(ttlArg.ttlSeconds).toBeLessThanOrEqual(1800);
+    });
+
+    it("does not write the cache for a genuine avatar fetch failure (transient, avatarUrl present)", async () => {
+      mockGetAvatarBase64.mockRejectedValue(new Error("avatar down"));
+
+      await renderPage();
+
+      expect(mockAfter).toHaveBeenCalledTimes(1);
+      const callback = mockAfter.mock.calls[0][0];
+      await callback();
+
+      expect(mockWriteBadgeSvgCache).not.toHaveBeenCalled();
+    });
   });
 
   // ----------------------------------------------------------------

--- a/apps/web/app/u/[handle]/page.tsx
+++ b/apps/web/app/u/[handle]/page.tsx
@@ -13,6 +13,7 @@ import { renderJsonLd } from "@/lib/jsonld";
 import { toDateString } from "@/lib/utils/date";
 import { renderBadgeSvg } from "@/lib/render/BadgeSvg";
 import {
+  AVATAR_ABSENT_CACHE_TTL_SECONDS,
   buildBadgeSvgCacheKey,
   readBadgeSvgCache,
   writeBadgeSvgCache,
@@ -197,6 +198,11 @@ export async function SharePageContent({
   let inlineSvg: string | null = cachedSvg;
   let renderedFresh = false;
   let avatarResolved = false;
+  // #1088 — true only when stats carry no avatarUrl at all: a PERMANENT
+  // condition (until the next stats refetch), never a genuine race loss on a
+  // real fetch. See the identical distinction in the badge.svg route's
+  // `finalizeMaterializedBadge` for the full rationale.
+  let avatarPermanentlyAbsent = false;
 
   if (!cachedSvg && stats && impact) {
     // Cache miss — render inline. Avatar fetch is best-effort with a tight
@@ -204,6 +210,7 @@ export async function SharePageContent({
     // TTFB. The /u/[handle]/badge.svg route awaits the avatar fully on its
     // own first render and writes the avatar-bearing SVG to the same
     // cache, so warm visits to the share page get the real avatar.
+    avatarPermanentlyAbsent = !readOnly && !stats.avatarUrl;
     const avatarPromise = !readOnly && stats.avatarUrl
       ? getAvatarBase64(handle, stats.avatarUrl).catch(() => undefined)
       : Promise.resolve(undefined);
@@ -229,15 +236,30 @@ export async function SharePageContent({
   // cache renders that fell back to a placeholder avatar or lack a
   // verification record. Either state can be temporary, and caching it would
   // prevent a later complete fetch from healing the SVG for up to 24h. (#800)
+  //
+  // #1088 — a handle with NO avatarUrl at all is different: that absence
+  // won't resolve itself on a retry within this request, so gating the write
+  // shut the same way as a genuine race-timeout meant it NEVER got cached.
+  // It still gets a write, just a short-TTL one, so it doesn't shadow a
+  // later good render for the full 24h+jitter a normal write would use.
   if (materialized && inlineSvg && !readOnly) {
-    const svgToCache =
-      renderedFresh && avatarResolved && verification ? inlineSvg : null;
+    const cacheEligible = renderedFresh && !!verification && (avatarResolved || avatarPermanentlyAbsent);
+    const svgToCache = cacheEligible ? inlineSvg : null;
+    // Short-TTL only for the permanent-absence case; a resolved avatar keeps
+    // the standard 24h+jitter TTL (writeBadgeSvgCache's own default).
+    const svgCacheTtlSeconds =
+      cacheEligible && !avatarResolved ? AVATAR_ABSENT_CACHE_TTL_SECONDS : undefined;
     const shouldRunDeferred = await persistProfileSnapshot(handle, materialized, {
       readOnly,
     });
     after(() => {
       if (svgToCache) {
-        void writeBadgeSvgCache(svgCacheKey, svgToCache, handle);
+        void writeBadgeSvgCache(
+          svgCacheKey,
+          svgToCache,
+          handle,
+          svgCacheTtlSeconds !== undefined ? { ttlSeconds: svgCacheTtlSeconds } : undefined,
+        );
       }
       if (!shouldRunDeferred) return;
       return deferProfileCacheWork(handle, materialized, { verification });

--- a/apps/web/lib/render/badge-svg-cache.test.ts
+++ b/apps/web/lib/render/badge-svg-cache.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/lib/cache/redis", () => ({
 }));
 
 import {
+  AVATAR_ABSENT_CACHE_TTL_SECONDS,
   BADGE_RENDER_VARIANT,
   buildBadgeSvgCacheKey,
   buildBadgeSvgRenderLockKey,
@@ -159,6 +160,46 @@ describe("badge-svg-cache", () => {
       await expect(
         writeBadgeSvgCache("k", "<svg/>", "testuser"),
       ).resolves.not.toThrow();
+    });
+
+    // #1088 — a handle whose avatar is permanently absent (no avatarUrl at
+    // all, not a race-timeout) needs a short-TTL cache write instead of
+    // either the full 24h+jitter write or no write at all, so a README embed
+    // with real traffic stops forcing a full materialize+render on every
+    // single request while a later good render (avatarUrl reappearing on a
+    // subsequent stats refetch) isn't shadowed for anywhere near a full day.
+    describe("ttlSeconds override (#1088)", () => {
+      it("honors an explicit ttlSeconds override instead of the 24h+jitter default", async () => {
+        cacheSet.mockResolvedValueOnce(true);
+        await writeBadgeSvgCache(
+          "badge:v2:octocat:warm-amber:2026-05-01",
+          "<svg>placeholder</svg>",
+          "octocat",
+          { ttlSeconds: AVATAR_ABSENT_CACHE_TTL_SECONDS },
+        );
+
+        expect(cacheSet).toHaveBeenCalledWith(
+          "badge:v2:octocat:warm-amber:2026-05-01",
+          "<svg>placeholder</svg>",
+          AVATAR_ABSENT_CACHE_TTL_SECONDS,
+        );
+      });
+
+      it("the short TTL constant is well under an hour so it never shadows a good render or survives a daily key rollover", () => {
+        expect(AVATAR_ABSENT_CACHE_TTL_SECONDS).toBeGreaterThanOrEqual(900); // >= 15 min
+        expect(AVATAR_ABSENT_CACHE_TTL_SECONDS).toBeLessThanOrEqual(1800); // <= 30 min
+      });
+
+      it("without an override, still falls back to the standard 24h+jitter TTL", async () => {
+        cacheSet.mockResolvedValueOnce(true);
+        await writeBadgeSvgCache(
+          "badge:v2:octocat:warm-amber:2026-05-01",
+          "<svg>fresh</svg>",
+          "octocat",
+        );
+        const ttl = cacheSet.mock.calls[0]![2] as number;
+        expect(ttl).toBeGreaterThanOrEqual(86400);
+      });
     });
   });
 

--- a/apps/web/lib/render/badge-svg-cache.ts
+++ b/apps/web/lib/render/badge-svg-cache.ts
@@ -35,6 +35,20 @@ const CACHE_TTL_BASE_SECONDS = 86_400; // 24h
 const CACHE_TTL_JITTER_MAX_SECONDS = 7_200; // up to +2h jitter (PE-S1)
 
 /**
+ * #1088 (PE-M1) — short TTL for a placeholder SVG cache write on a handle
+ * whose stats carry no `avatarUrl` at all (a permanent condition until the
+ * next stats refetch — distinct from a race-timeout on a real fetch, see
+ * `finalizeMaterializedBadge` in the badge.svg route). Long enough to stop
+ * every single request for such a handle from forcing a full
+ * materialize+render (the bug — a README embed with real traffic never got
+ * ANY cache population). Short enough that it can't shadow a later good
+ * render (e.g. avatarUrl reappearing on a subsequent stats refetch) for
+ * anywhere near the 24h+jitter a normal write gets, and far short of the
+ * next UTC daily key rollover the cache key itself already encodes.
+ */
+export const AVATAR_ABSENT_CACHE_TTL_SECONDS = 20 * 60; // 20 minutes
+
+/**
  * Compute a stable per-handle jitter offset (0 to CACHE_TTL_JITTER_MAX_SECONDS).
  *
  * Uses a simple sum-of-char-codes hash so that different handles get different
@@ -128,13 +142,18 @@ export async function readBadgeSvgCacheWithStatus(
  * @param key  - Cache key built by {@link buildBadgeSvgCacheKey}
  * @param svg  - Rendered SVG string
  * @param handle - The GitHub handle (used to derive the jitter offset)
+ * @param options.ttlSeconds - #1088 — explicit TTL override, used for a
+ *   short-lived placeholder write (see {@link AVATAR_ABSENT_CACHE_TTL_SECONDS}).
+ *   When omitted, falls back to the standard 24h+jitter TTL.
  */
 export async function writeBadgeSvgCache(
   key: string,
   svg: string,
   handle: string,
+  options?: { ttlSeconds?: number },
 ): Promise<boolean> {
-  const ttl = CACHE_TTL_BASE_SECONDS + handleCacheJitterSeconds(handle);
+  const ttl =
+    options?.ttlSeconds ?? CACHE_TTL_BASE_SECONDS + handleCacheJitterSeconds(handle);
   return withCacheFallback(
     cacheSet(key, svg, ttl),
     false,


### PR DESCRIPTION
## Summary

Fixes #1088 (PE-M1): a handle whose stats carry no `avatarUrl` at all (permanent absence) was gated by the same `avatarResolved` check as a genuine in-flight avatar-fetch race-timeout, so the shared badge SVG cache was **never** populated for it — every single request forced a full materialize+render forever. A README embed with real traffic drove this on every hit, with only the 30s render lock standing between it and a stampede.

## Root cause

In `finalizeMaterializedBadge` (`apps/web/app/u/[handle]/badge.svg/route.ts`), `avatarResolved` is `avatarDataUri !== undefined`. That's `false` in two very different cases:
1. **Permanent absence** — `materialized.stats.avatarUrl` is falsy, so nothing was ever fetched (nothing to wait for).
2. **Genuine race-timeout** — `avatarUrl` exists but `getAvatarBase64` didn't resolve within `AVATAR_RACE_DEADLINE_MS` (a real, transient condition — the CDN might answer a moment later).

The SVG-cache write was gated on `avatarResolved` alone, so case 1 could *never* populate the cache — there's no future retry that will make a nonexistent `avatarUrl` resolve.

The share page (`apps/web/app/u/[handle]/page.tsx`) has the identical pattern in its own inline-render cache write and the identical bug.

## Fix

- `writeBadgeSvgCache` (`apps/web/lib/render/badge-svg-cache.ts`) gains an optional `{ ttlSeconds }` override; without it, behavior is unchanged (24h + per-handle jitter).
- New shared constant `AVATAR_ABSENT_CACHE_TTL_SECONDS` (20 minutes — within the issue's recommended 15–30 min window).
- Both `finalizeMaterializedBadge` (route.ts) and the share page's inline-render cache-write branch now compute `avatarPermanentlyAbsent` (`!stats.avatarUrl`) separately from `avatarResolved`, and:
  - avatar resolved → standard full-TTL write (unchanged)
  - avatarUrl present but fetch lost the race → **no write** (unchanged — #1029's original regression guard, this is still a genuinely transient case)
  - avatarUrl absent entirely → **short-TTL (20 min) write** (new) — populates the cache so a README embed stops forcing a full materialize on every request, while expiring long before it could shadow a later good render (e.g. `avatarUrl` reappearing on a subsequent stats refetch) or survive anywhere near the next UTC daily key rollover.

## Coordination with #1080

#1080 (being fixed concurrently in a sibling worktree/agent) targets the exact same `avatarResolved` gating logic in this file, for a distinct but related bug. At the time this PR was opened, **#1080 had no PR/branch on origin yet**, so there was nothing to build on top of or defer to — I could not verify whether its fix would already resolve this issue's cache-population problem.

Given that, I implemented the full distinction needed here (`avatarPermanentlyAbsent` vs. `avatarResolved`) directly, since the short-TTL placeholder behavior this issue asks for is impossible to implement without first making that same distinction.

**This PR overlaps with #1080 on the same lines** (`finalizeMaterializedBadge`'s avatar-resolution and cache-write-gating block in `apps/web/app/u/[handle]/badge.svg/route.ts`). Two PRs touching the same lines will need manual reconciliation — whichever lands second should rebase onto the first rather than re-deriving the same `avatarPermanentlyAbsent`/timeout distinction. The net behavior this PR establishes:
- `avatarResolved` → full-TTL cache write
- `avatarUrl` present, fetch timed out → no write
- `avatarUrl` absent → short-TTL (20 min) write

If #1080 restructures the boolean differently (e.g. renames/refactors the gating), the reconciling PR should preserve this three-way branch and the `AVATAR_ABSENT_CACHE_TTL_SECONDS` short-TTL write for the permanent-absence case specifically, since that's this issue's core ask.

## Test plan

TDD — tests written first, confirmed red, then made green:
- [x] `apps/web/lib/render/badge-svg-cache.test.ts` — `writeBadgeSvgCache` honors an explicit `ttlSeconds` override; `AVATAR_ABSENT_CACHE_TTL_SECONDS` is between 15–30 min; omitting the override still falls back to the standard 24h+jitter TTL.
- [x] `apps/web/app/u/[handle]/badge.svg/route.test.ts` — new `describe("permanent avatar absence caching (#1088)")`: writes a short-TTL (900–1800s) entry when `stats.avatarUrl` is absent (and never calls `getAvatarBase64`); short TTL stays well under the 24h floor; a genuine race-timeout (avatarUrl present, fetch too slow) still performs **no** cache write; an unverified render still skips the cache write entirely regardless of avatar state.
- [x] `apps/web/app/u/[handle]/page.test.tsx` — parallel coverage for the share page's own inline-render cache write.
- [x] Full suite: `pnpm run test` — 526 files / 8921 tests passing.
- [x] `pnpm run typecheck` — clean.
- [x] `pnpm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)