### PR TITLE
fix(studio): materialize truthful owner preview

### DIFF
--- a/apps/web/app/studio/page.render.test.tsx
+++ b/apps/web/app/studio/page.render.test.tsx
@@ -9,10 +9,9 @@ const mocks = vi.hoisted(() => ({
   isStudioEnabled: vi.fn(),
   getOptionalServerSessionFromHeaders: vi.fn(),
   getSessionGitHubToken: vi.fn(),
-  materializePublicProfile: vi.fn(),
+  materializeDisplayProfile: vi.fn(),
   getPublicProfileVerification: vi.fn(),
   loadStudioConfig: vi.fn(),
-  computeImpactV6: vi.fn(),
   getServerLocale: vi.fn(),
   getServerT: vi.fn(),
 }));
@@ -39,17 +38,16 @@ vi.mock("@/lib/auth/github-session-token", () => ({
   getSessionGitHubToken: mocks.getSessionGitHubToken,
 }));
 
+vi.mock("@/lib/profile/materialize-profile", () => ({
+  materializeDisplayProfile: mocks.materializeDisplayProfile,
+}));
+
 vi.mock("@/lib/profile/public-profile", () => ({
-  materializePublicProfile: mocks.materializePublicProfile,
   getPublicProfileVerification: mocks.getPublicProfileVerification,
 }));
 
 vi.mock("@/lib/db/studio", () => ({
   loadStudioConfig: mocks.loadStudioConfig,
-}));
-
-vi.mock("@/lib/impact/v6", () => ({
-  computeImpactV6: mocks.computeImpactV6,
 }));
 
 vi.mock("@/lib/i18n/server", () => ({
@@ -119,6 +117,7 @@ const stats = {
 
 beforeEach(() => {
   cleanup();
+  vi.clearAllMocks();
   mocks.headers.mockResolvedValue(new Headers());
   mocks.redirect.mockImplementation((url: string) => {
     throw new Error(`redirect:${url}`);
@@ -126,16 +125,16 @@ beforeEach(() => {
   mocks.isStudioEnabled.mockResolvedValue(true);
   mocks.getOptionalServerSessionFromHeaders.mockReturnValue(session);
   mocks.getSessionGitHubToken.mockResolvedValue("gho_token");
-  mocks.materializePublicProfile.mockResolvedValue({
+  mocks.materializeDisplayProfile.mockResolvedValue({
     stats,
     displayImpact: { compositeScore: 80 },
+    statsComplete: true,
   });
   mocks.getPublicProfileVerification.mockReturnValue({
     hash: "abc123",
     date: "2026-08-26",
   });
   mocks.loadStudioConfig.mockResolvedValue({ theme: "saved-theme" });
-  mocks.computeImpactV6.mockReturnValue({ compositeScore: 80 });
   mocks.getServerLocale.mockResolvedValue("en");
   mocks.getServerT.mockReturnValue(
     (key: string) =>
@@ -186,36 +185,24 @@ describe("StudioPage render", () => {
     expect(client.getAttribute("data-verification")).toBe(
       "abc123:2026-08-26",
     );
-    expect(mocks.materializePublicProfile).toHaveBeenCalledWith("octocat", {
+    expect(mocks.materializeDisplayProfile).toHaveBeenCalledWith("octocat", {
       token: "gho_token",
-      readOnly: true,
     });
     expect(mocks.getPublicProfileVerification).toHaveBeenCalledWith(
       expect.objectContaining({ stats }),
     );
-    expect(mocks.computeImpactV6).not.toHaveBeenCalled();
     expect(mocks.loadStudioConfig).toHaveBeenCalledWith("octocat");
   });
 
-  it("falls back to empty stats and the default config", async () => {
-    mocks.materializePublicProfile.mockResolvedValue(null);
+  it("fails instead of rendering fabricated zero metrics when profile loading fails", async () => {
+    mocks.materializeDisplayProfile.mockResolvedValue(null);
     mocks.loadStudioConfig.mockResolvedValue(null);
     const { default: StudioPage } = await import("./page");
 
-    render(await StudioPage());
-
-    const client = screen.getByTestId("studio-client");
-    expect(client.getAttribute("data-commits")).toBe("0");
-    expect(mocks.computeImpactV6).toHaveBeenCalledWith(
-      expect.objectContaining({
-        handle: "octocat",
-        displayName: "Octo Cat",
-        commitsTotal: 0,
-        heatmapData: expect.arrayContaining([
-          expect.objectContaining({ count: 0 }),
-        ]),
-      }),
+    await expect(StudioPage()).rejects.toThrow(
+      "Unable to load Studio profile for octocat",
     );
+    expect(mocks.getPublicProfileVerification).not.toHaveBeenCalled();
   });
 
   it("is configured as a force-dynamic route", async () => {

--- a/apps/web/app/studio/page.tsx
+++ b/apps/web/app/studio/page.tsx
@@ -3,52 +3,16 @@ import { redirect } from "next/navigation";
 import type { Metadata } from "next";
 import { isStudioEnabled } from "@/lib/feature-flags";
 import { getOptionalServerSessionFromHeaders } from "@/lib/auth/session";
-import { computeImpactV6 } from "@/lib/impact/v6";
-import {
-  getPublicProfileVerification,
-  materializePublicProfile,
-} from "@/lib/profile/public-profile";
+import { materializeDisplayProfile } from "@/lib/profile/materialize-profile";
+import { getPublicProfileVerification } from "@/lib/profile/public-profile";
 import { loadStudioConfig } from "@/lib/db/studio";
 import { Navbar } from "@/components/Navbar";
-import { toDateString } from "@/lib/utils/date";
 import { StudioClient } from "./StudioClient";
-import type { BadgeConfig, StatsData } from "@chapa/shared";
+import type { BadgeConfig } from "@chapa/shared";
 import { DEFAULT_BADGE_CONFIG } from "@chapa/shared";
 import { getSessionGitHubToken } from "@/lib/auth/github-session-token";
 import { KeyboardShortcutsListener } from "@/components/KeyboardShortcutsListener";
 import { getServerLocale, getServerT } from "@/lib/i18n/server";
-
-function buildEmptyStats(session: {
-  login: string;
-  name: string | null;
-  avatar_url: string;
-}): StatsData {
-  const now = Date.now();
-  return {
-    handle: session.login,
-    displayName: session.name ?? undefined,
-    avatarUrl: session.avatar_url,
-    commitsTotal: 0,
-    activeDays: 0,
-    prsMergedCount: 0,
-    prsMergedWeight: 0,
-    reviewsSubmittedCount: 0,
-    issuesClosedCount: 0,
-    linesAdded: 0,
-    linesDeleted: 0,
-    reposContributed: 0,
-    topRepoShare: 0,
-    maxCommitsIn10Min: 0,
-    totalStars: 0,
-    totalForks: 0,
-    totalWatchers: 0,
-    heatmapData: Array.from({ length: 366 }, (_, i) => ({
-      date: toDateString(new Date(now - (365 - i) * 86400000)),
-      count: 0,
-    })),
-    fetchedAt: new Date(now).toISOString(),
-  };
-}
 
 export const dynamic = "force-dynamic";
 
@@ -80,19 +44,17 @@ export default async function StudioPage() {
     redirect("/api/auth/login");
   }
 
-  // Fetch data in parallel: read-only public profile + saved config
+  // Fetch the live owner display projection and saved config in parallel.
   const [materialized, savedConfig] = await Promise.all([
-    materializePublicProfile(session.login, { token, readOnly: true }),
+    materializeDisplayProfile(session.login, { token }),
     loadStudioConfig(session.login) as Promise<BadgeConfig | null>,
   ]);
 
-  // Compute fallback impact only when profile materialization failed.
-  const effectiveStats: StatsData = materialized?.stats ?? buildEmptyStats(session);
+  if (!materialized) {
+    throw new Error(`Unable to load Studio profile for ${session.login}`);
+  }
 
-  const impact = materialized?.displayImpact ?? computeImpactV6(effectiveStats);
-  const verification = materialized
-    ? getPublicProfileVerification(materialized)
-    : null;
+  const verification = getPublicProfileVerification(materialized);
   const initialConfig = savedConfig ?? DEFAULT_BADGE_CONFIG;
 
   const locale = await getServerLocale();
@@ -111,8 +73,8 @@ export default async function StudioPage() {
         <KeyboardShortcutsListener />
         <StudioClient
           initialConfig={initialConfig}
-          stats={effectiveStats}
-          impact={impact}
+          stats={materialized.stats}
+          impact={materialized.displayImpact}
           handle={session.login}
           verification={verification}
         />

--- a/apps/web/lib/impact/craft-propagation.test.ts
+++ b/apps/web/lib/impact/craft-propagation.test.ts
@@ -28,26 +28,18 @@ import path from "node:path";
 // Each entry MUST be a relative path from the repo root (with forward slashes
 // on all OSes) AND must come with a justification in the trailing comment.
 //
-// REVIEW: as of #680 these two call sites compute impact without craft, even
-// though the user may have insights. They are documented here so the test does
-// not regress further; whether they should pass craft is being tracked
-// separately. Both are non-user-visible / non-persistent paths:
+// REVIEW: as of #680 this call site computes impact without craft, even though
+// the user may have insights. It is documented here so the test does not
+// regress further; whether it should pass craft is being tracked separately.
+// It is a non-user-visible / non-persistent path:
 //   - /api/generate: warms the badge cache and discards the result; the badge
 //     route itself reads craft from cache via materializeProfile.
-//   - /studio/page.tsx: renders a customization preview for the badge owner
-//     based on their own GitHub stats. Insights come through the cached path
-//     once the user visits /u/<handle>.
 //
 const CRAFT_OPTOUTS: ReadonlyArray<{ file: string; reason: string }> = [
   {
     file: "apps/web/app/api/generate/route.ts",
     reason:
       "Cache warm only: result is discarded; user-visible badge reads craft via materializeProfile.",
-  },
-  {
-    file: "apps/web/app/studio/page.tsx",
-    reason:
-      "Studio preview computes a same-day display from primary stats; share page is the source of truth.",
   },
 ];
 

--- a/apps/web/lib/profile/materialize-profile.test.ts
+++ b/apps/web/lib/profile/materialize-profile.test.ts
@@ -3,6 +3,7 @@ import type { CraftResult } from "@chapa/shared";
 import { getTier } from "../impact/utils";
 import { makeFullStats, makeSnapshot } from "../test-helpers/fixtures";
 import {
+  materializeDisplayProfile,
   materializeImpactState,
   materializeProfile,
 } from "./materialize-profile";
@@ -252,6 +253,60 @@ describe("statsComplete (#1003 persist-boundary integrity gate)", () => {
     const result = materializeImpactState(stats);
 
     expect(result.statsComplete).toBe(true);
+  });
+});
+
+describe("materializeDisplayProfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads a live owner profile without trend-state reads", async () => {
+    const stats = makeFullStats({ handle: "testuser" });
+    const craftResult = makeCraftResult({ craftScore: 88 });
+    mockGetStats.mockResolvedValue(stats);
+    mockGetCachedCraftScore.mockResolvedValue(craftResult);
+
+    const result = await materializeDisplayProfile("testuser", {
+      token: "oauth-token",
+    });
+
+    expect(mockGetStats).toHaveBeenCalledWith("testuser", "oauth-token", {
+      readOnly: false,
+    });
+    expect(mockGetCachedCraftScore).toHaveBeenCalledWith("testuser");
+    expect(mockGetCachedLatestSnapshot).not.toHaveBeenCalled();
+    expect(mockIsStatsDirty).not.toHaveBeenCalled();
+    expect(result?.displayImpact).toBe(result?.rawImpact);
+    expect(result?.displayImpact.dimensions.craft).toBe(88);
+    expect(result?.statsComplete).toBe(true);
+    expect(result).not.toHaveProperty("snapshot");
+    expect(result).not.toHaveProperty("latestSnapshot");
+  });
+
+  it("preserves the completeness gate for poisoned stats", async () => {
+    mockGetStats.mockResolvedValue(
+      makeFullStats({
+        handle: "testuser",
+        prsMergedCount: 0,
+        commitsTotal: 15585,
+        issuesClosedCount: 0,
+      }),
+    );
+    mockGetCachedCraftScore.mockResolvedValue(null);
+
+    const result = await materializeDisplayProfile("testuser");
+
+    expect(result?.statsComplete).toBe(false);
+  });
+
+  it("returns null instead of fabricating stats when the live load fails", async () => {
+    mockGetStats.mockResolvedValue(null);
+    mockGetCachedCraftScore.mockResolvedValue(null);
+
+    const result = await materializeDisplayProfile("testuser");
+
+    expect(result).toBeNull();
   });
 });
 

--- a/apps/web/lib/profile/materialize-profile.ts
+++ b/apps/web/lib/profile/materialize-profile.ts
@@ -27,14 +27,10 @@ export interface MaterializeImpactStateOptions {
   inputsChanged?: boolean;
 }
 
-export interface MaterializedImpactState {
+export interface MaterializedDisplayState {
   craftResult: CraftResult | null;
-  latestSnapshot: SnapshotScoreInput | null;
   rawImpact: ImpactV6Result;
   displayImpact: ImpactV6Result;
-  snapshot: MetricsSnapshot;
-  /** True when scoring inputs have changed since today's snapshot (#826). */
-  inputsChanged: boolean;
   /**
    * #1003 — False when the served stats look like the corrupt "0 merged PRs
    * despite real commit/issue activity" shape (e.g. served from an old
@@ -43,6 +39,13 @@ export interface MaterializedImpactState {
    * is never attested, even though it can still be displayed.
    */
   statsComplete: boolean;
+}
+
+export interface MaterializedImpactState extends MaterializedDisplayState {
+  latestSnapshot: SnapshotScoreInput | null;
+  snapshot: MetricsSnapshot;
+  /** True when scoring inputs have changed since today's snapshot (#826). */
+  inputsChanged: boolean;
 }
 
 /**
@@ -80,6 +83,48 @@ export interface MaterializedProfile extends MaterializedImpactState {
   stats: StatsData;
 }
 
+export interface MaterializedDisplayProfile extends MaterializedDisplayState {
+  stats: StatsData;
+}
+
+interface DisplayInputs {
+  stats: StatsData;
+  craftResult: CraftResult | null;
+}
+
+function materializeDisplayState(
+  stats: StatsData,
+  craftResult: CraftResult | null,
+): MaterializedDisplayState {
+  const rawImpact = computeImpactV6(stats, craftResult?.craftScore);
+  return {
+    craftResult,
+    rawImpact,
+    displayImpact: rawImpact,
+    statsComplete: statsLookComplete(stats),
+  };
+}
+
+async function loadDisplayInputs(
+  handle: string,
+  token: string | undefined,
+  readOnly: boolean | undefined,
+): Promise<DisplayInputs | null> {
+  const [statsSettled, craftSettled] = await Promise.allSettled([
+    getStats(handle, token, { readOnly }),
+    getCachedCraftScore(handle),
+  ]);
+
+  const stats = statsSettled.status === "fulfilled" ? statsSettled.value : null;
+  if (!stats) return null;
+
+  return {
+    stats,
+    craftResult:
+      craftSettled.status === "fulfilled" ? craftSettled.value : null,
+  };
+}
+
 export function materializeImpactState(
   stats: StatsData,
   options: MaterializeImpactStateOptions = {},
@@ -87,7 +132,7 @@ export function materializeImpactState(
   const craftResult = options.craftResult ?? null;
   const latestSnapshot = options.latestSnapshot ?? null;
   const inputsChanged = options.inputsChanged ?? false;
-  const rawImpact = computeImpactV6(stats, craftResult?.craftScore);
+  const displayState = materializeDisplayState(stats, craftResult);
 
   // #1001 — The live headline shown to users (badge, dashboard, verification
   // record, emails) is the FRESH score, always internally consistent with the
@@ -98,23 +143,37 @@ export function materializeImpactState(
   // as the headline next to un-smoothed dimensions, so a real dimension change
   // (e.g. Delivery dropping) showed immediately on the radar while the headline
   // lagged for days — reading as "the number doesn't match the breakdown".
-  const smoothedImpact = applyImpactScorePolicy(rawImpact, latestSnapshot, {
+  const smoothedImpact = applyImpactScorePolicy(displayState.rawImpact, latestSnapshot, {
     policy: options.policy,
     today: options.today,
     inputsChanged,
   });
-  const displayImpact = rawImpact;
 
   return {
-    craftResult,
+    ...displayState,
     latestSnapshot,
-    rawImpact,
-    displayImpact,
     // Persist the smoothed composite so the history sparkline stays smooth and
     // tomorrow's EMA has a stable prior; the headline stays fresh.
     snapshot: buildSnapshot(stats, smoothedImpact, options.today),
     inputsChanged,
-    statsComplete: statsLookComplete(stats),
+  };
+}
+
+/**
+ * Materialize the live profile fields used by owner-only display surfaces.
+ * This deliberately omits snapshot and dirty-marker reads because the fresh
+ * display impact and verification HMAC do not depend on trend state.
+ */
+export async function materializeDisplayProfile(
+  handle: string,
+  options: { token?: string } = {},
+): Promise<MaterializedDisplayProfile | null> {
+  const inputs = await loadDisplayInputs(handle, options.token, false);
+  if (!inputs) return null;
+
+  return {
+    stats: inputs.stats,
+    ...materializeDisplayState(inputs.stats, inputs.craftResult),
   };
 }
 
@@ -127,10 +186,9 @@ export async function materializeProfile(
   // dominates; on cache hit, this saves a round-trip vs the previous serial
   // shape. Cache lookup failures fail open to defaults rather than rejecting
   // the whole profile fetch.
-  const [statsSettled, craftSettled, snapshotSettled, dirtySettled] =
+  const [displayInputsSettled, snapshotSettled, dirtySettled] =
     await Promise.allSettled([
-      getStats(handle, options.token, { readOnly: options.readOnly }),
-      getCachedCraftScore(handle),
+      loadDisplayInputs(handle, options.token, options.readOnly),
       // #930 — Skip snapshot lookup when the caller wants to force-recalculate
       // from scratch. Passing Promise.resolve(null) skips the Redis/Supabase
       // read so the EMA same-day lock never sees a stale today-snapshot.
@@ -138,14 +196,14 @@ export async function materializeProfile(
       isStatsDirty(handle),
     ]);
 
-  const stats = statsSettled.status === "fulfilled" ? statsSettled.value : null;
-  if (!stats) {
+  const displayInputs =
+    displayInputsSettled.status === "fulfilled"
+      ? displayInputsSettled.value
+      : null;
+  if (!displayInputs) {
     return null;
   }
-
-  const craftResult = craftSettled.status === "fulfilled"
-    ? craftSettled.value
-    : null;
+  const { stats, craftResult } = displayInputs;
   const latestSnapshot = options.ignoreSnapshot
     ? null
     : snapshotSettled.status === "fulfilled" ? snapshotSettled.value : null;

--- a/apps/web/lib/profile/public-profile.ts
+++ b/apps/web/lib/profile/public-profile.ts
@@ -54,7 +54,10 @@ export async function materializePublicProfile(
 }
 
 export function getPublicProfileVerification(
-  materialized: MaterializedProfile,
+  materialized: Pick<
+    MaterializedProfile,
+    "stats" | "displayImpact" | "statsComplete"
+  >,
 ): PublicVerificationCode | null {
   // #1003 — Never attest a verification record from stats that look
   // incomplete (e.g. served from an old poisoned `stats:stale` entry). This


### PR DESCRIPTION
Closes #1139\nCloses #1143\n\nRemoves fabricated cold-cache metrics and uses a Studio-focused display materialization path without trend-state reads.