### PR TITLE
fix(studio): harden config persistence

### DIFF
--- a/apps/web/app/api/studio/config/route.contract.test.ts
+++ b/apps/web/app/api/studio/config/route.contract.test.ts
@@ -14,6 +14,10 @@ const { mockDbUpsertStudioConfig, mockRequireRequestSession } = vi.hoisted(() =>
   })),
 }));
 
+vi.mock("@/lib/cache/redis", () => ({
+  rateLimit: vi.fn(async () => ({ allowed: true, current: 1, limit: 30 })),
+}));
+
 vi.mock("@/lib/auth/session", () => ({
   getOptionalRequestSession: vi.fn(() => ({
     login: "octocat",
@@ -25,9 +29,9 @@ vi.mock("@/lib/auth/session", () => ({
 }));
 
 vi.mock("@/lib/db/studio", () => ({
-  STUDIO_CONFIG_TTL: 31536000,
+  cacheStudioConfig: vi.fn(async () => undefined),
   dbUpsertStudioConfig: mockDbUpsertStudioConfig,
-  loadStudioConfig: vi.fn(async () => null),
+  loadStudioConfig: vi.fn(async () => ({ status: "not_found" })),
 }));
 
 import { PUT } from "./route";

--- a/apps/web/app/api/studio/config/route.test.ts
+++ b/apps/web/app/api/studio/config/route.test.ts
@@ -10,7 +10,7 @@ const {
   mockGetOptionalRequestSession,
   mockGetSessionSecret,
   mockRequireRequestSession,
-  mockCacheSet,
+  mockCacheStudioConfig,
   mockRateLimit,
   mockDbUpsertStudioConfig,
   mockLoadStudioConfig,
@@ -19,7 +19,7 @@ const {
     mockGetOptionalRequestSession: vi.fn(),
     mockGetSessionSecret: vi.fn(),
     mockRequireRequestSession: vi.fn(),
-    mockCacheSet: vi.fn(),
+    mockCacheStudioConfig: vi.fn(),
     mockRateLimit: vi.fn(),
     mockDbUpsertStudioConfig: vi.fn(),
     mockLoadStudioConfig: vi.fn(),
@@ -32,12 +32,11 @@ vi.mock("@/lib/auth/session", () => ({
 }));
 
 vi.mock("@/lib/cache/redis", () => ({
-  cacheSet: mockCacheSet,
   rateLimit: mockRateLimit,
 }));
 
 vi.mock("@/lib/db/studio", () => ({
-  STUDIO_CONFIG_TTL: 31536000,
+  cacheStudioConfig: mockCacheStudioConfig,
   dbUpsertStudioConfig: mockDbUpsertStudioConfig,
   loadStudioConfig: mockLoadStudioConfig,
 }));
@@ -96,8 +95,8 @@ describe("GET /api/studio/config", () => {
     vi.clearAllMocks();
     vi.stubEnv("NEXTAUTH_SECRET", "test-secret-32-characters-valid-ok");
     mockGetSessionSecret.mockReturnValue("test-secret-32-characters-valid-ok");
-    mockCacheSet.mockResolvedValue(undefined);
-    mockLoadStudioConfig.mockResolvedValue(null);
+    mockCacheStudioConfig.mockResolvedValue(undefined);
+    mockLoadStudioConfig.mockResolvedValue({ status: "not_found" });
   });
 
   it("returns 401 when no session", async () => {
@@ -118,7 +117,10 @@ describe("GET /api/studio/config", () => {
   it("returns the config from the shared load helper", async () => {
     mockGetOptionalRequestSession.mockReturnValue(SESSION);
     const savedConfig = { ...DEFAULT_BADGE_CONFIG, background: "aurora" };
-    mockLoadStudioConfig.mockResolvedValue(savedConfig);
+    mockLoadStudioConfig.mockResolvedValue({
+      status: "found",
+      config: savedConfig,
+    });
 
     const res = await GET(makeGetRequest("session=abc"));
     expect(res.status).toBe(200);
@@ -134,6 +136,31 @@ describe("GET /api/studio/config", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ config: null });
   });
+
+  it("returns 503 when the durable config store is unavailable", async () => {
+    mockGetOptionalRequestSession.mockReturnValue(SESSION);
+    mockLoadStudioConfig.mockResolvedValue({ status: "unavailable" });
+
+    const res = await GET(makeGetRequest("session=abc"));
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("30");
+    expect(await res.json()).toEqual({
+      error: "Storage temporarily unavailable",
+    });
+  });
+
+  it("returns 500 when the persisted config is malformed", async () => {
+    mockGetOptionalRequestSession.mockReturnValue(SESSION);
+    mockLoadStudioConfig.mockResolvedValue({ status: "invalid" });
+
+    const res = await GET(makeGetRequest("session=abc"));
+
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({
+      error: "Invalid persisted studio config",
+    });
+  });
 });
 
 describe("PUT /api/studio/config", () => {
@@ -142,7 +169,7 @@ describe("PUT /api/studio/config", () => {
     mockRequireRequestSession.mockReturnValue({ session: SESSION });
     mockRateLimit.mockResolvedValue({ allowed: true, current: 1, limit: 30 });
     mockDbUpsertStudioConfig.mockResolvedValue({ ok: true });
-    mockCacheSet.mockResolvedValue(undefined);
+    mockCacheStudioConfig.mockResolvedValue(undefined);
   });
 
   it("returns 401 when no session", async () => {
@@ -182,13 +209,13 @@ describe("PUT /api/studio/config", () => {
     expect(res.status).toBe(429);
   });
 
-  it("saves valid config to Redis with 365-day TTL", async () => {
+  it("publishes a valid config to the shared Redis helper", async () => {
     const config = { ...DEFAULT_BADGE_CONFIG, background: "aurora" as const };
     const res = await PUT(makePutRequest(config, "session=abc"));
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ success: true });
-    expect(mockCacheSet).toHaveBeenCalledWith("config:juan294", config, 31536000);
+    expect(mockCacheStudioConfig).toHaveBeenCalledWith("juan294", config);
   });
 
   it("persists config to Supabase alongside Redis (BE-H1)", async () => {
@@ -197,6 +224,70 @@ describe("PUT /api/studio/config", () => {
 
     expect(res.status).toBe(200);
     expect(mockDbUpsertStudioConfig).toHaveBeenCalledWith("juan294", config);
+  });
+
+  it("publishes to Redis only after the durable write succeeds", async () => {
+    const operations: string[] = [];
+    mockDbUpsertStudioConfig.mockImplementation(async () => {
+      operations.push("durable");
+      return { ok: true };
+    });
+    mockCacheStudioConfig.mockImplementation(async () => {
+      operations.push("cache");
+    });
+
+    const res = await PUT(makePutRequest(DEFAULT_BADGE_CONFIG, "session=abc"));
+
+    expect(res.status).toBe(200);
+    expect(operations).toEqual(["durable", "cache"]);
+  });
+
+  it("serializes concurrent saves for one handle so the last request wins everywhere", async () => {
+    const operations: string[] = [];
+    let releaseFirstWrite!: () => void;
+    const firstWrite = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+    mockDbUpsertStudioConfig.mockImplementation(
+      async (_handle: string, value: { background: string }) => {
+        operations.push(`durable:${value.background}`);
+        if (value.background === "aurora") await firstWrite;
+        return { ok: true };
+      },
+    );
+    mockCacheStudioConfig.mockImplementation(
+      async (_handle: string, value: { background: string }) => {
+        operations.push(`cache:${value.background}`);
+      },
+    );
+    const firstConfig = {
+      ...DEFAULT_BADGE_CONFIG,
+      background: "aurora" as const,
+    };
+    const secondConfig = {
+      ...DEFAULT_BADGE_CONFIG,
+      background: "particles" as const,
+    };
+
+    const firstResponse = PUT(makePutRequest(firstConfig, "session=abc"));
+    await vi.waitFor(() => {
+      expect(operations).toEqual(["durable:aurora"]);
+    });
+    const secondResponse = PUT(makePutRequest(secondConfig, "session=abc"));
+    await vi.waitFor(() => {
+      expect(mockRateLimit).toHaveBeenCalledTimes(2);
+    });
+    expect(mockDbUpsertStudioConfig).toHaveBeenCalledTimes(1);
+    releaseFirstWrite();
+
+    expect((await firstResponse).status).toBe(200);
+    expect((await secondResponse).status).toBe(200);
+    expect(operations).toEqual([
+      "durable:aurora",
+      "cache:aurora",
+      "durable:particles",
+      "cache:particles",
+    ]);
   });
 
   it("returns 400 when Supabase rejects the config with a constraint error", async () => {
@@ -214,6 +305,7 @@ describe("PUT /api/studio/config", () => {
       success: false,
       error: "Invalid badge config",
     });
+    expect(mockCacheStudioConfig).not.toHaveBeenCalled();
   });
 
   it("returns 503 with Retry-After when Supabase is unavailable", async () => {
@@ -230,6 +322,7 @@ describe("PUT /api/studio/config", () => {
       success: false,
       error: "Storage temporarily unavailable",
     });
+    expect(mockCacheStudioConfig).not.toHaveBeenCalled();
   });
 
   it("returns 500 when Supabase fails unexpectedly", async () => {
@@ -246,10 +339,10 @@ describe("PUT /api/studio/config", () => {
       success: false,
       error: "Failed to persist studio config",
     });
+    expect(mockCacheStudioConfig).not.toHaveBeenCalled();
   });
 
-  it("returns 200 when Redis write fails but Supabase succeeds (Redis best-effort)", async () => {
-    mockCacheSet.mockRejectedValue(new Error("Redis down"));
+  it("returns 200 when the best-effort cache publisher completes", async () => {
     mockDbUpsertStudioConfig.mockResolvedValue({ ok: true });
 
     const config = { ...DEFAULT_BADGE_CONFIG, background: "aurora" as const };
@@ -258,6 +351,7 @@ describe("PUT /api/studio/config", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ success: true });
     expect(mockDbUpsertStudioConfig).toHaveBeenCalledTimes(1);
+    expect(mockCacheStudioConfig).toHaveBeenCalledTimes(1);
   });
 
   it("rate limits by user login", async () => {

--- a/apps/web/app/api/studio/config/route.ts
+++ b/apps/web/app/api/studio/config/route.ts
@@ -4,16 +4,39 @@ import {
   getSessionSecret,
   requireRequestSession,
 } from "@/lib/auth/session";
-import { cacheSet, rateLimit } from "@/lib/cache/redis";
+import { rateLimit } from "@/lib/cache/redis";
 import { isValidBadgeConfig } from "@/lib/validation";
 import { isStudioEnabled } from "@/lib/feature-flags";
 import {
-  STUDIO_CONFIG_TTL,
+  cacheStudioConfig,
   dbUpsertStudioConfig,
   loadStudioConfig,
 } from "@/lib/db/studio";
-import type { BadgeConfig } from "@chapa/shared";
 import { withErrorCapture } from "@/lib/analytics/server-errors";
+
+const studioConfigWriteTails = new Map<string, Promise<void>>();
+
+async function serializeStudioConfigWrite<T>(
+  login: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const key = login.toLowerCase();
+  const previous = studioConfigWriteTails.get(key) ?? Promise.resolve();
+  const current = previous.catch(() => undefined).then(operation);
+  const tail = current.then(
+    () => undefined,
+    () => undefined,
+  );
+  studioConfigWriteTails.set(key, tail);
+
+  try {
+    return await current;
+  } finally {
+    if (studioConfigWriteTails.get(key) === tail) {
+      studioConfigWriteTails.delete(key);
+    }
+  }
+}
 
 /**
  * GET /api/studio/config — Load the authenticated user's badge config.
@@ -38,7 +61,22 @@ export const GET = withErrorCapture("/api/studio/config", async (request: NextRe
   }
 
   const config = await loadStudioConfig(session.login);
-  return NextResponse.json({ config });
+  if (config.status === "found") {
+    return NextResponse.json({ config: config.config });
+  }
+  if (config.status === "not_found") {
+    return NextResponse.json({ config: null });
+  }
+  if (config.status === "unavailable") {
+    return NextResponse.json(
+      { error: "Storage temporarily unavailable" },
+      { status: 503, headers: { "Retry-After": "30" } },
+    );
+  }
+  return NextResponse.json(
+    { error: "Invalid persisted studio config" },
+    { status: 500 },
+  );
 });
 
 /**
@@ -76,21 +114,20 @@ export const PUT = withErrorCapture("/api/studio/config", async (request: NextRe
     );
   }
 
-  const cacheKey = `config:${session.login}`;
+  const normalizedLogin = session.login.toLowerCase();
+  const dbResult = await serializeStudioConfigWrite(
+    normalizedLogin,
+    async () => {
+      // Commit durable state before publishing it to the hot cache. A rejected
+      // Supabase write must never make an uncommitted config visible in Redis.
+      const result = await dbUpsertStudioConfig(normalizedLogin, body);
+      if (!result.ok) return result;
 
-  // Write to Supabase (durable) AND Redis (hot read path).
-  // Supabase is the success criterion — Redis is best-effort.
-  const [, dbResult] = await Promise.all([
-    cacheSet(cacheKey, body as BadgeConfig, STUDIO_CONFIG_TTL).catch(
-      (err: unknown) => {
-        console.warn(
-          "[studio/config] Redis write failed (best-effort):",
-          (err as Error).message,
-        );
-      },
-    ),
-    dbUpsertStudioConfig(session.login, body),
-  ]);
+      await cacheStudioConfig(normalizedLogin, body);
+
+      return result;
+    },
+  );
 
   if (!dbResult.ok && dbResult.reason === "constraint") {
     return NextResponse.json(

--- a/apps/web/app/studio/page.render.test.tsx
+++ b/apps/web/app/studio/page.render.test.tsx
@@ -74,14 +74,15 @@ vi.mock("./StudioClient", () => ({
   }: {
     handle: string;
     stats: StatsData;
-    initialConfig: { theme: string };
+    initialConfig: { theme?: string; background?: string };
     verification: { hash: string; date: string } | null;
   }) => (
     <section
       data-testid="studio-client"
       data-handle={handle}
       data-commits={String(stats.commitsTotal)}
-      data-config-theme={initialConfig.theme}
+      data-config-theme={initialConfig.theme ?? "none"}
+      data-config-background={initialConfig.background ?? "none"}
       data-verification={verification ? `${verification.hash}:${verification.date}` : "none"}
     />
   ),
@@ -134,7 +135,10 @@ beforeEach(() => {
     hash: "abc123",
     date: "2026-08-26",
   });
-  mocks.loadStudioConfig.mockResolvedValue({ theme: "saved-theme" });
+  mocks.loadStudioConfig.mockResolvedValue({
+    status: "found",
+    config: { theme: "saved-theme" },
+  });
   mocks.getServerLocale.mockResolvedValue("en");
   mocks.getServerT.mockReturnValue(
     (key: string) =>
@@ -196,13 +200,24 @@ describe("StudioPage render", () => {
 
   it("fails instead of rendering fabricated zero metrics when profile loading fails", async () => {
     mocks.materializeDisplayProfile.mockResolvedValue(null);
-    mocks.loadStudioConfig.mockResolvedValue(null);
+    mocks.loadStudioConfig.mockResolvedValue({ status: "not_found" });
     const { default: StudioPage } = await import("./page");
 
     await expect(StudioPage()).rejects.toThrow(
       "Unable to load Studio profile for octocat",
     );
     expect(mocks.getPublicProfileVerification).not.toHaveBeenCalled();
+  });
+
+  it("fails open to the default config when persisted storage is unavailable", async () => {
+    mocks.loadStudioConfig.mockResolvedValue({ status: "unavailable" });
+    const { default: StudioPage } = await import("./page");
+
+    render(await StudioPage());
+
+    expect(
+      screen.getByTestId("studio-client").getAttribute("data-config-background"),
+    ).toBe("solid");
   });
 
   it("is configured as a force-dynamic route", async () => {

--- a/apps/web/app/studio/page.tsx
+++ b/apps/web/app/studio/page.tsx
@@ -8,7 +8,6 @@ import { getPublicProfileVerification } from "@/lib/profile/public-profile";
 import { loadStudioConfig } from "@/lib/db/studio";
 import { Navbar } from "@/components/Navbar";
 import { StudioClient } from "./StudioClient";
-import type { BadgeConfig } from "@chapa/shared";
 import { DEFAULT_BADGE_CONFIG } from "@chapa/shared";
 import { getSessionGitHubToken } from "@/lib/auth/github-session-token";
 import { KeyboardShortcutsListener } from "@/components/KeyboardShortcutsListener";
@@ -45,9 +44,9 @@ export default async function StudioPage() {
   }
 
   // Fetch the live owner display projection and saved config in parallel.
-  const [materialized, savedConfig] = await Promise.all([
+  const [materialized, savedConfigResult] = await Promise.all([
     materializeDisplayProfile(session.login, { token }),
-    loadStudioConfig(session.login) as Promise<BadgeConfig | null>,
+    loadStudioConfig(session.login),
   ]);
 
   if (!materialized) {
@@ -55,7 +54,9 @@ export default async function StudioPage() {
   }
 
   const verification = getPublicProfileVerification(materialized);
-  const initialConfig = savedConfig ?? DEFAULT_BADGE_CONFIG;
+  const initialConfig = savedConfigResult.status === "found"
+    ? savedConfigResult.config
+    : DEFAULT_BADGE_CONFIG;
 
   const locale = await getServerLocale();
   const t = getServerT(locale);

--- a/apps/web/lib/db/studio.contract.test.ts
+++ b/apps/web/lib/db/studio.contract.test.ts
@@ -1,0 +1,44 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_BADGE_CONFIG } from "@chapa/shared";
+import { getServiceClient } from "@/test/contract/invoke";
+import { dbGetStudioConfig, dbUpsertStudioConfig } from "./studio";
+
+const HANDLE = `contract-studio-${randomUUID()}`;
+
+describe("Studio config durable boundary (contract)", () => {
+  beforeEach(async () => {
+    const db = getServiceClient();
+    await db.from("studio_configs").delete().eq("handle", HANDLE);
+  });
+
+  afterAll(async () => {
+    const db = getServiceClient();
+    await db.from("studio_configs").delete().eq("handle", HANDLE);
+  });
+
+  it("persists and reads a validated BadgeConfig through PostgREST", async () => {
+    const config = { ...DEFAULT_BADGE_CONFIG, background: "aurora" as const };
+
+    await expect(dbUpsertStudioConfig(HANDLE, config)).resolves.toEqual({
+      ok: true,
+    });
+    await expect(dbGetStudioConfig(HANDLE)).resolves.toEqual({
+      status: "found",
+      config,
+    });
+  });
+
+  it("reports malformed persisted JSON instead of returning it to callers", async () => {
+    const db = getServiceClient();
+    const { error } = await db.from("studio_configs").insert({
+      handle: HANDLE,
+      config: { ...DEFAULT_BADGE_CONFIG, background: "invalid" },
+    });
+    expect(error).toBeNull();
+
+    await expect(dbGetStudioConfig(HANDLE)).resolves.toEqual({
+      status: "invalid",
+    });
+  });
+});

--- a/apps/web/lib/db/studio.test.ts
+++ b/apps/web/lib/db/studio.test.ts
@@ -4,11 +4,13 @@ import { DEFAULT_BADGE_CONFIG } from "@chapa/shared";
 const mockUpsert = vi.fn();
 const mockSelect = vi.fn();
 const mockEq = vi.fn();
-const { mockCacheGet, mockCacheSet } = vi.hoisted(() => ({
+const { mockCacheDel, mockCacheGet, mockCacheSet } = vi.hoisted(() => ({
+  mockCacheDel: vi.fn(),
   mockCacheGet: vi.fn(),
   mockCacheSet: vi.fn(),
 }));
 let terminalResolve: { data: unknown; error: unknown };
+let terminalNeverResolves = false;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockFrom = vi.fn((): any => {
@@ -24,6 +26,7 @@ const mockFrom = vi.fn((): any => {
   };
   chain.maybeSingle = () => ({
     then: (resolve: (v: unknown) => void, reject: (e: unknown) => void) => {
+      if (terminalNeverResolves) return;
       if (terminalResolve.error) reject(terminalResolve.error);
       else resolve(terminalResolve);
     },
@@ -36,13 +39,18 @@ vi.mock("./supabase", () => ({
 }));
 
 vi.mock("../cache/redis", () => ({
+  cacheDel: mockCacheDel,
   cacheGet: mockCacheGet,
   cacheSet: mockCacheSet,
 }));
 
 import { getSupabase } from "./supabase";
 import {
+  STUDIO_CONFIG_NEGATIVE_CACHE_ENTRY,
+  STUDIO_CONFIG_NEGATIVE_TTL,
+  STUDIO_CONFIG_READ_TIMEOUT_MS,
   STUDIO_CONFIG_TTL,
+  cacheStudioConfig,
   dbGetStudioConfig,
   dbUpsertStudioConfig,
   loadStudioConfig,
@@ -53,11 +61,14 @@ const config = { ...DEFAULT_BADGE_CONFIG, background: "aurora" as const };
 beforeEach(() => {
   vi.clearAllMocks();
   terminalResolve = { data: null, error: null };
+  terminalNeverResolves = false;
   mockCacheGet.mockResolvedValue(null);
   mockCacheSet.mockResolvedValue(true);
+  mockCacheDel.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -151,6 +162,30 @@ describe("dbUpsertStudioConfig", () => {
   });
 });
 
+describe("cacheStudioConfig", () => {
+  it("publishes a committed config under the normalized handle", async () => {
+    await cacheStudioConfig("Juan294", config);
+
+    expect(mockCacheSet).toHaveBeenCalledWith(
+      "config:juan294",
+      config,
+      STUDIO_CONFIG_TTL,
+    );
+  });
+
+  it("logs a false Redis result without rejecting the committed save", async () => {
+    mockCacheSet.mockResolvedValue(false);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(cacheStudioConfig("juan294", config)).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      "[studio/config] Redis write failed (best-effort):",
+      "cacheSet returned false",
+    );
+    expect(mockCacheDel).toHaveBeenCalledWith("config:juan294");
+  });
+});
+
 describe("dbGetStudioConfig", () => {
   it("returns the config on hit", async () => {
     terminalResolve = {
@@ -160,7 +195,7 @@ describe("dbGetStudioConfig", () => {
 
     const result = await dbGetStudioConfig("juan294");
 
-    expect(result).toEqual(config);
+    expect(result).toEqual({ status: "found", config });
   });
 
   it("queries by lowercased handle", async () => {
@@ -169,27 +204,50 @@ describe("dbGetStudioConfig", () => {
     expect(mockEq).toHaveBeenCalledWith("handle", "juan294");
   });
 
-  it("returns null on miss", async () => {
+  it("returns not_found on miss", async () => {
     terminalResolve = { data: null, error: null };
-    expect(await dbGetStudioConfig("nobody")).toBeNull();
+    expect(await dbGetStudioConfig("nobody")).toEqual({ status: "not_found" });
   });
 
-  it("returns null when DB is unavailable", async () => {
+  it("returns unavailable when DB is not configured", async () => {
     vi.mocked(getSupabase).mockReturnValueOnce(null);
-    expect(await dbGetStudioConfig("juan294")).toBeNull();
+    expect(await dbGetStudioConfig("juan294")).toEqual({ status: "unavailable" });
   });
 
-  it("returns null on error without throwing", async () => {
+  it("returns unavailable on a query error without throwing", async () => {
     terminalResolve = { data: null, error: new Error("DB error") };
-    expect(await dbGetStudioConfig("juan294")).toBeNull();
+    expect(await dbGetStudioConfig("juan294")).toEqual({ status: "unavailable" });
   });
 
-  it("returns null when row is missing config field", async () => {
+  it("returns invalid when the row is missing its config field", async () => {
     terminalResolve = {
       data: { handle: "juan294", updated_at: "2026-06-25T00:00:00Z" },
       error: null,
     };
-    expect(await dbGetStudioConfig("juan294")).toBeNull();
+    expect(await dbGetStudioConfig("juan294")).toEqual({ status: "invalid" });
+  });
+
+  it("returns invalid when the persisted config fails BadgeConfig validation", async () => {
+    terminalResolve = {
+      data: {
+        handle: "juan294",
+        config: { ...config, background: "not-a-background" },
+        updated_at: "2026-06-25T00:00:00Z",
+      },
+      error: null,
+    };
+
+    expect(await dbGetStudioConfig("juan294")).toEqual({ status: "invalid" });
+  });
+
+  it("fails open with unavailable when the Supabase read exceeds its deadline", async () => {
+    vi.useFakeTimers();
+    terminalNeverResolves = true;
+
+    const result = dbGetStudioConfig("juan294");
+    await vi.advanceTimersByTimeAsync(STUDIO_CONFIG_READ_TIMEOUT_MS + 1);
+
+    await expect(result).resolves.toEqual({ status: "unavailable" });
   });
 });
 
@@ -197,7 +255,10 @@ describe("loadStudioConfig", () => {
   it("returns a Redis cache hit without querying Supabase", async () => {
     mockCacheGet.mockResolvedValue(config);
 
-    await expect(loadStudioConfig("juan294")).resolves.toEqual(config);
+    await expect(loadStudioConfig("juan294")).resolves.toEqual({
+      status: "found",
+      config,
+    });
 
     expect(mockCacheGet).toHaveBeenCalledWith("config:juan294");
     expect(mockFrom).not.toHaveBeenCalled();
@@ -209,7 +270,10 @@ describe("loadStudioConfig", () => {
       error: null,
     };
 
-    await expect(loadStudioConfig("juan294")).resolves.toEqual(config);
+    await expect(loadStudioConfig("juan294")).resolves.toEqual({
+      status: "found",
+      config,
+    });
 
     expect(mockCacheSet).toHaveBeenCalledWith(
       "config:juan294",
@@ -218,10 +282,57 @@ describe("loadStudioConfig", () => {
     );
   });
 
-  it("returns null when both Redis and Supabase miss", async () => {
-    await expect(loadStudioConfig("nobody")).resolves.toBeNull();
+  it("returns not_found and caches a typed sentinel when both stores miss", async () => {
+    await expect(loadStudioConfig("nobody")).resolves.toEqual({
+      status: "not_found",
+    });
 
-    expect(mockCacheSet).not.toHaveBeenCalled();
+    expect(mockCacheSet).toHaveBeenCalledWith(
+      "config:nobody",
+      STUDIO_CONFIG_NEGATIVE_CACHE_ENTRY,
+      STUDIO_CONFIG_NEGATIVE_TTL,
+    );
+  });
+
+  it("returns a typed negative-cache hit without querying Supabase", async () => {
+    mockCacheGet.mockResolvedValue(STUDIO_CONFIG_NEGATIVE_CACHE_ENTRY);
+
+    await expect(loadStudioConfig("nobody")).resolves.toEqual({
+      status: "not_found",
+    });
+
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed cached data and repairs it from Supabase", async () => {
+    mockCacheGet.mockResolvedValue({ ...config, background: "invalid" });
+    terminalResolve = {
+      data: { handle: "juan294", config, updated_at: "2026-06-25T00:00:00Z" },
+      error: null,
+    };
+
+    await expect(loadStudioConfig("juan294")).resolves.toEqual({
+      status: "found",
+      config,
+    });
+    expect(mockFrom).toHaveBeenCalledWith("studio_configs");
+    expect(mockCacheDel).toHaveBeenCalledWith("config:juan294");
+    expect(mockCacheSet).toHaveBeenCalledWith(
+      "config:juan294",
+      config,
+      STUDIO_CONFIG_TTL,
+    );
+  });
+
+  it("returns unavailable after a bounded cache read and database outage", async () => {
+    vi.useFakeTimers();
+    mockCacheGet.mockImplementation(() => new Promise(() => undefined));
+    vi.mocked(getSupabase).mockReturnValueOnce(null);
+
+    const result = loadStudioConfig("juan294");
+    await vi.advanceTimersByTimeAsync(STUDIO_CONFIG_READ_TIMEOUT_MS + 1);
+
+    await expect(result).resolves.toEqual({ status: "unavailable" });
   });
 
   it("swallows a best-effort Redis rehydration rejection", async () => {
@@ -232,10 +343,33 @@ describe("loadStudioConfig", () => {
     mockCacheSet.mockRejectedValue(new Error("Redis down"));
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
-    await expect(loadStudioConfig("juan294")).resolves.toEqual(config);
+    await expect(loadStudioConfig("juan294")).resolves.toEqual({
+      status: "found",
+      config,
+    });
     expect(warn).toHaveBeenCalledWith(
       "[studio/config] Redis rehydration failed (best-effort):",
       "Redis down",
     );
+  });
+
+  it("logs when Redis returns false while rehydrating a durable config", async () => {
+    terminalResolve = {
+      data: { handle: "juan294", config, updated_at: "2026-06-25T00:00:00Z" },
+      error: null,
+    };
+    mockCacheSet.mockResolvedValue(false);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(loadStudioConfig("juan294")).resolves.toEqual({
+      status: "found",
+      config,
+    });
+    await vi.waitFor(() => {
+      expect(warn).toHaveBeenCalledWith(
+        "[studio/config] Redis rehydration failed (best-effort):",
+        "cacheSet returned false",
+      );
+    });
   });
 });

--- a/apps/web/lib/db/studio.ts
+++ b/apps/web/lib/db/studio.ts
@@ -12,9 +12,18 @@
 
 import { getSupabase } from "./supabase";
 import { parseRow } from "./parse-row";
-import { cacheGet, cacheSet } from "../cache/redis";
+import { cacheDel, cacheGet, cacheSet } from "../cache/redis";
+import { withTimeout } from "../async/with-timeout";
+import { isValidBadgeConfig } from "../validation";
+import type { BadgeConfig } from "@chapa/shared";
 
 export const STUDIO_CONFIG_TTL = 31536000;
+export const STUDIO_CONFIG_NEGATIVE_TTL = 60;
+export const STUDIO_CONFIG_READ_TIMEOUT_MS = 2_000;
+export const STUDIO_CONFIG_NEGATIVE_CACHE_ENTRY = {
+  kind: "studio-config-not-found",
+  version: 1,
+} as const;
 
 export type StudioConfigUpsertResult =
   | { ok: true }
@@ -23,6 +32,12 @@ export type StudioConfigUpsertResult =
       reason: "unavailable" | "constraint" | "error";
       code?: string;
     };
+
+export type StudioConfigReadResult =
+  | { status: "found"; config: BadgeConfig }
+  | { status: "not_found" }
+  | { status: "unavailable" }
+  | { status: "invalid" };
 
 interface StudioConfigRow {
   handle: string;
@@ -35,6 +50,75 @@ const REQUIRED_KEYS: readonly (keyof StudioConfigRow & string)[] = [
   "config",
   "updated_at",
 ];
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return error.message;
+  }
+  return String(error);
+}
+
+function isNegativeCacheEntry(
+  value: unknown,
+): value is typeof STUDIO_CONFIG_NEGATIVE_CACHE_ENTRY {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const entry = value as Record<string, unknown>;
+  return (
+    entry.kind === STUDIO_CONFIG_NEGATIVE_CACHE_ENTRY.kind &&
+    entry.version === STUDIO_CONFIG_NEGATIVE_CACHE_ENTRY.version
+  );
+}
+
+async function setCacheBestEffort(
+  cacheKey: string,
+  value: unknown,
+  ttl: number,
+  operation: string,
+): Promise<boolean> {
+  try {
+    const stored = await cacheSet(cacheKey, value, ttl);
+    if (!stored) {
+      console.warn(
+        `[studio/config] Redis ${operation} failed (best-effort):`,
+        "cacheSet returned false",
+      );
+    }
+    return stored;
+  } catch (error) {
+    console.warn(
+      `[studio/config] Redis ${operation} failed (best-effort):`,
+      errorMessage(error),
+    );
+    return false;
+  }
+}
+
+/** Publish a committed Studio config to Redis without changing API success. */
+export async function cacheStudioConfig(
+  login: string,
+  config: BadgeConfig,
+): Promise<void> {
+  const cacheKey = `config:${login.toLowerCase()}`;
+  const stored = await setCacheBestEffort(
+    cacheKey,
+    config,
+    STUDIO_CONFIG_TTL,
+    "write",
+  );
+  if (!stored) {
+    // A failed publication must not leave an older year-long value
+    // authoritative after Redis recovers.
+    await cacheDel(cacheKey);
+  }
+}
 
 /**
  * Upsert a studio config for a handle. One row per handle — the latest save
@@ -74,19 +158,9 @@ export async function dbUpsertStudioConfig(
 
     if (code === "23505") return { ok: true };
 
-    const message =
-      error instanceof Error
-        ? error.message
-        : typeof error === "object" &&
-            error !== null &&
-            "message" in error &&
-            typeof error.message === "string"
-          ? error.message
-          : String(error);
-
     console.error(
       "[db] dbUpsertStudioConfig failed:",
-      message,
+      errorMessage(error),
     );
 
     if (code === "23502" || code === "22P02" || code === "22003") {
@@ -100,46 +174,101 @@ export async function dbUpsertStudioConfig(
 }
 
 /**
- * Fetch the persisted studio config for a handle. Returns null on miss or
- * when Supabase is unavailable.
+ * Fetch and validate the persisted Studio config while preserving distinct
+ * miss, unavailable, and invalid outcomes.
  */
-export async function dbGetStudioConfig(handle: string): Promise<unknown | null> {
+export async function dbGetStudioConfig(
+  handle: string,
+): Promise<StudioConfigReadResult> {
   const db = getSupabase();
-  if (!db) return null;
+  if (!db) return { status: "unavailable" };
 
   try {
-    const { data, error } = await db
-      .from("studio_configs")
-      .select("handle, config, updated_at")
-      .eq("handle", handle.toLowerCase())
-      .maybeSingle();
+    const { data, error } = await withTimeout(
+      Promise.resolve(
+        db
+          .from("studio_configs")
+          .select("handle, config, updated_at")
+          .eq("handle", handle.toLowerCase())
+          .maybeSingle(),
+      ),
+      STUDIO_CONFIG_READ_TIMEOUT_MS,
+      "dbGetStudioConfig",
+    );
 
     if (error) throw error;
-    if (!data) return null;
+    if (!data) return { status: "not_found" };
 
     const row = parseRow<StudioConfigRow>(data, REQUIRED_KEYS, "studio_configs");
-    return row ? row.config : null;
+    if (!row || !isValidBadgeConfig(row.config)) {
+      console.error(
+        "[STUDIO_CONFIG_FALLBACK] Invalid persisted Studio configuration",
+        { handle: handle.toLowerCase() },
+      );
+      return { status: "invalid" };
+    }
+
+    return { status: "found", config: row.config };
   } catch (error) {
-    console.error("[db] dbGetStudioConfig failed:", (error as Error).message);
-    return null;
+    console.error(
+      "[STUDIO_CONFIG_FALLBACK] dbGetStudioConfig failed:",
+      errorMessage(error),
+    );
+    return { status: "unavailable" };
   }
 }
 
-/** Load a studio config from Redis, falling back to its durable Supabase row. */
-export async function loadStudioConfig(login: string): Promise<unknown | null> {
-  const cacheKey = `config:${login}`;
-  const cached = await cacheGet<unknown>(cacheKey);
-  if (cached !== null) return cached;
+/** Load and validate a Studio config from Redis, then durable Supabase storage. */
+export async function loadStudioConfig(
+  login: string,
+): Promise<StudioConfigReadResult> {
+  const normalizedLogin = login.toLowerCase();
+  const cacheKey = `config:${normalizedLogin}`;
+  let cached: unknown = null;
 
-  const dbConfig = await dbGetStudioConfig(login);
-  if (dbConfig === null) return null;
-
-  void cacheSet(cacheKey, dbConfig, STUDIO_CONFIG_TTL).catch((error: unknown) => {
-    console.warn(
-      "[studio/config] Redis rehydration failed (best-effort):",
-      error instanceof Error ? error.message : String(error),
+  try {
+    cached = await withTimeout(
+      cacheGet<unknown>(cacheKey),
+      STUDIO_CONFIG_READ_TIMEOUT_MS,
+      "loadStudioConfig cache read",
     );
-  });
+  } catch (error) {
+    console.error(
+      "[STUDIO_CONFIG_FALLBACK] Studio config cache read failed:",
+      errorMessage(error),
+    );
+  }
 
-  return dbConfig;
+  if (isNegativeCacheEntry(cached)) return { status: "not_found" };
+  if (cached !== null) {
+    if (isValidBadgeConfig(cached)) {
+      return { status: "found", config: cached };
+    }
+    console.error(
+      "[STUDIO_CONFIG_FALLBACK] Invalid cached Studio configuration",
+      { handle: normalizedLogin },
+    );
+    await cacheDel(cacheKey);
+  }
+
+  const dbResult = await dbGetStudioConfig(normalizedLogin);
+  if (dbResult.status === "not_found") {
+    void setCacheBestEffort(
+      cacheKey,
+      STUDIO_CONFIG_NEGATIVE_CACHE_ENTRY,
+      STUDIO_CONFIG_NEGATIVE_TTL,
+      "negative-cache write",
+    );
+    return dbResult;
+  }
+  if (dbResult.status !== "found") return dbResult;
+
+  void setCacheBestEffort(
+    cacheKey,
+    dbResult.config,
+    STUDIO_CONFIG_TTL,
+    "rehydration",
+  );
+
+  return dbResult;
 }

--- a/apps/web/lib/validation.ts
+++ b/apps/web/lib/validation.ts
@@ -56,11 +56,11 @@ export function isValidEmuHandle(handle: string): boolean {
  * @param value - The candidate object to validate
  * @returns `true` if the object matches the expected BadgeConfig schema exactly
  */
-import { BADGE_CONFIG_OPTIONS } from "@chapa/shared";
+import { BADGE_CONFIG_OPTIONS, type BadgeConfig } from "@chapa/shared";
 
 const BADGE_CONFIG_KEYS = Object.keys(BADGE_CONFIG_OPTIONS) as (keyof typeof BADGE_CONFIG_OPTIONS)[];
 
-export function isValidBadgeConfig(value: unknown): boolean {
+export function isValidBadgeConfig(value: unknown): value is BadgeConfig {
   if (value == null || typeof value !== "object" || Array.isArray(value)) return false;
   const obj = value as Record<string, unknown>;
 


### PR DESCRIPTION
Closes #1141\nCloses #1142\nCloses #1144\n\nMakes Supabase durable-before-cache, validates read payloads, adds bounded reads and negative caching, and invalidates stale cache entries after failed publication.