### PR TITLE
fix(studio): stabilize preview updates and command actions

### DIFF
--- a/apps/web/app/studio/StudioClient.render.test.tsx
+++ b/apps/web/app/studio/StudioClient.render.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, cleanup, fireEvent, waitFor, act } from "@testing-library/react";
+import { useState } from "react";
 import { LanguageContext, type LanguageContextValue } from "@/lib/i18n";
 import { en } from "@/lib/i18n/dictionaries/en";
 import { es } from "@/lib/i18n/dictionaries/es";
@@ -65,6 +66,8 @@ vi.mock("@/lib/effects/defaults", () => ({
   ],
 }));
 
+const previewLifecycle = vi.hoisted(() => ({ nextInstanceId: 0 }));
+
 vi.mock("./BadgePreviewCard", () => ({
   BadgePreviewCard: ({
     config,
@@ -74,15 +77,19 @@ vi.mock("./BadgePreviewCard", () => ({
     config: Record<string, unknown>;
     interactive: boolean;
     verification?: { hash: string; date: string } | null;
-  }) => (
-    <div
-      data-testid="badge-preview"
-      data-interactive={String(interactive)}
-      data-verification={verification ? `${verification.hash}:${verification.date}` : "none"}
-    >
-      {JSON.stringify(config)}
-    </div>
-  ),
+  }) => {
+    const [instanceId] = useState(() => ++previewLifecycle.nextInstanceId);
+    return (
+      <div
+        data-testid="badge-preview"
+        data-instance-id={instanceId}
+        data-interactive={String(interactive)}
+        data-verification={verification ? `${verification.hash}:${verification.date}` : "none"}
+      >
+        {JSON.stringify(config)}
+      </div>
+    );
+  },
 }));
 
 vi.mock("./QuickControls", () => ({
@@ -374,6 +381,33 @@ describe("StudioClient render", () => {
       expect(screen.getByTestId("badge-preview").getAttribute("data-verification")).toBe(
         "abc123:2026-08-26",
       );
+    });
+
+    it("updates ordinary configuration without remounting the preview", async () => {
+      const { executeCommand } = await import(
+        "@/components/terminal/command-registry"
+      );
+      vi.mocked(executeCommand).mockReturnValue({
+        lines: [{ id: "set-background", type: "success", text: "Changed" }],
+        action: { type: "set", category: "background", value: "aurora" },
+      });
+
+      render(
+        <StudioClient
+          initialConfig={defaultConfig}
+          stats={stats}
+          impact={impact}
+        />,
+      );
+      const initialInstanceId = screen
+        .getByTestId("badge-preview")
+        .getAttribute("data-instance-id");
+
+      fireEvent.click(screen.getByTestId("qc-command"));
+
+      const preview = screen.getByTestId("badge-preview");
+      expect(preview.textContent).toContain('"background":"aurora"');
+      expect(preview.getAttribute("data-instance-id")).toBe(initialInstanceId);
     });
   });
 
@@ -1238,7 +1272,7 @@ describe("StudioClient render", () => {
       expect(screen.getByTestId("quick-controls").getAttribute("data-visible")).toBe("true");
     });
 
-    it("refresh-preview shortcut increments preview key", () => {
+    it("refresh-preview shortcut explicitly remounts the preview", () => {
       render(
         <StudioClient
           initialConfig={defaultConfig}
@@ -1247,14 +1281,17 @@ describe("StudioClient render", () => {
         />,
       );
 
-      // The BadgePreviewCard is rendered with key={previewKey}
-      // Refreshing should cause re-render (new key)
+      const initialInstanceId = screen
+        .getByTestId("badge-preview")
+        .getAttribute("data-instance-id");
+
       act(() => {
         capturedShortcutHandler?.("refresh-preview");
       });
 
-      // Component should still render correctly
-      expect(screen.getByTestId("badge-preview")).toBeDefined();
+      expect(
+        screen.getByTestId("badge-preview").getAttribute("data-instance-id"),
+      ).not.toBe(initialInstanceId);
     });
 
     it("cycle-preset shortcut cycles to next preset", async () => {

--- a/apps/web/app/studio/StudioClient.test.tsx
+++ b/apps/web/app/studio/StudioClient.test.tsx
@@ -53,5 +53,6 @@ describe("StudioClient", () => {
     it("passes previewKey as key to BadgePreviewCard", () => {
       expect(SOURCE).toContain("key={previewKey}");
     });
+
   });
 });

--- a/apps/web/app/studio/StudioClient.tsx
+++ b/apps/web/app/studio/StudioClient.tsx
@@ -9,7 +9,10 @@ import { useIsClient } from "@/hooks/useIsClient";
 import { BadgePreviewCard } from "./BadgePreviewCard";
 import type { PreviewVerification } from "./PreviewFooter";
 import { QuickControls } from "./QuickControls";
-import { useStudioCommands } from "./useStudioCommands";
+import {
+  useStudioCommands,
+  type StudioCommandAction,
+} from "./useStudioCommands";
 import { TerminalOutput } from "@/components/terminal/TerminalOutput";
 import { TerminalInput } from "@/components/terminal/TerminalInput";
 import { AutocompleteDropdown } from "@/components/terminal/AutocompleteDropdown";
@@ -17,7 +20,6 @@ import {
   executeCommand,
   makeLine,
   type OutputLine,
-  type CommandAction,
 } from "@/components/terminal/command-registry";
 import { useKeyboardShortcutsContext } from "@/components/KeyboardShortcutsListener";
 import { useTranslation, type LanguageContextValue } from "@/lib/i18n";
@@ -172,7 +174,6 @@ export function StudioClient({
         }
       }
       setConfig(newConfig);
-      setPreviewKey((k) => k + 1);
     },
     [config],
   );
@@ -238,16 +239,14 @@ export function StudioClient({
         setSaveState({ status: "dirty" });
       }
     }
-    setPreviewKey((k) => k + 1);
     trackEvent("effect_changed", { category: "reset", to: "default" });
   }, [config]);
 
   const handleAction = useCallback(
-    (action: CommandAction) => {
+    (action: StudioCommandAction) => {
       switch (action.type) {
         case "set": {
-          const key = action.category as keyof BadgeConfig;
-          handleConfigChange({ ...config, [key]: action.value });
+          handleConfigChange({ ...config, [action.category]: action.value });
           break;
         }
         case "preset": {

--- a/apps/web/app/studio/useStudioCommands.render.test.ts
+++ b/apps/web/app/studio/useStudioCommands.render.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, expectTypeOf, vi, afterEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { useStudioCommands } from "./useStudioCommands";
+import type { StudioCommandAction } from "./useStudioCommands";
 import type { BadgeConfig } from "@chapa/shared";
 import { createElement, type ComponentType, type ReactNode } from "react";
 import { LanguageProvider } from "@/lib/i18n";
@@ -51,6 +52,24 @@ function findCommand(name: string, commands = getCommands()) {
 }
 
 describe("useStudioCommands (render)", () => {
+  it("narrows set action categories to BadgeConfig keys", () => {
+    type SetCategory = Extract<
+      StudioCommandAction,
+      { type: "set" }
+    >["category"];
+
+    expectTypeOf<SetCategory>().toEqualTypeOf<keyof BadgeConfig>();
+  });
+
+  it("narrows set action values to BadgeConfig values", () => {
+    type SetValue = Extract<
+      StudioCommandAction,
+      { type: "set" }
+    >["value"];
+
+    expectTypeOf<SetValue>().toEqualTypeOf<BadgeConfig[keyof BadgeConfig]>();
+  });
+
   it("returns an array of 9 command definitions", () => {
     const commands = getCommands();
     expect(commands).toHaveLength(9);

--- a/apps/web/app/studio/useStudioCommands.ts
+++ b/apps/web/app/studio/useStudioCommands.ts
@@ -11,6 +11,7 @@ import {
   CATEGORY_KEY_TO_ALIAS,
   makeLine,
   resolveCategory,
+  type CommandAction,
   type CommandDef,
 } from "@/components/terminal/command-registry";
 import { getBaseUrl } from "@/lib/env";
@@ -23,11 +24,24 @@ interface UseStudioCommandsOptions {
   saving?: boolean;
 }
 
+export type StudioCommandAction =
+  | Extract<
+      CommandAction,
+      { type: "clear" | "preset" | "save" | "reset" }
+    >
+  | {
+      type: "set";
+      category: keyof BadgeConfig;
+      value: BadgeConfig[keyof BadgeConfig];
+    };
+
+export type StudioCommandDef = CommandDef<StudioCommandAction>;
+
 export function useStudioCommands({
   config,
   handle,
   saving = false,
-}: UseStudioCommandsOptions): CommandDef[] {
+}: UseStudioCommandsOptions): StudioCommandDef[] {
   const { t } = useTranslation();
   return useMemo(() => {
     const text = (key: string) => t(key) as string;
@@ -36,7 +50,7 @@ export function useStudioCommands({
     const base = getBaseUrl();
     const profileUrl = `${base}/u/${handle}`;
     const badgeUrl = `${profileUrl}/badge.svg`;
-    const commands: CommandDef[] = [
+    const commands: StudioCommandDef[] = [
       {
         name: "/set",
         description: text("studio.commands.setDescription"),
@@ -96,7 +110,11 @@ export function useStudioCommands({
 
           return {
             lines: [makeLine("success", `${resolved} → ${value}`)],
-            action: { type: "set", category: resolved, value },
+            action: {
+              type: "set",
+              category: resolved,
+              value: value as BadgeConfig[keyof BadgeConfig],
+            },
           };
         },
       },

--- a/apps/web/components/terminal/command-registry.ts
+++ b/apps/web/components/terminal/command-registry.ts
@@ -15,9 +15,11 @@ export interface OutputLine {
   text: string;
 }
 
-export interface CommandResult {
+export interface CommandResult<
+  TAction extends CommandAction = CommandAction,
+> {
   lines: OutputLine[];
-  action?: CommandAction;
+  action?: TAction;
 }
 
 export type CommandAction =
@@ -29,12 +31,14 @@ export type CommandAction =
   | { type: "reset" }
   | { type: "custom"; event: string; detail?: Record<string, unknown> };
 
-export interface CommandDef {
+export interface CommandDef<
+  TAction extends CommandAction = CommandAction,
+> {
   name: string;
   aliases?: string[];
   description: string;
   usage?: string;
-  execute: (args: string[]) => CommandResult;
+  execute: (args: string[]) => CommandResult<TAction>;
 }
 
 export type CommandDescriptions = Partial<Record<string, string>>;
@@ -49,7 +53,7 @@ export function makeLine(
 }
 
 /** Category short aliases for /set */
-export const CATEGORY_ALIASES: Record<string, string> = {
+export const CATEGORY_ALIASES = {
   bg: "background",
   card: "cardStyle",
   border: "border",
@@ -59,19 +63,29 @@ export const CATEGORY_ALIASES: Record<string, string> = {
   stats: "statsDisplay",
   tier: "tierTreatment",
   celebrate: "celebration",
-};
+} as const satisfies Readonly<Record<string, string>>;
 
-export const CATEGORY_KEY_TO_ALIAS: Record<string, string> = Object.fromEntries(
+type CategoryAlias = keyof typeof CATEGORY_ALIASES;
+export type CategoryKey = (typeof CATEGORY_ALIASES)[CategoryAlias];
+
+export const CATEGORY_KEY_TO_ALIAS = Object.fromEntries(
   Object.entries(CATEGORY_ALIASES).map(([alias, key]) => [key, alias]),
-);
+) as Record<CategoryKey, CategoryAlias>;
+
+function resolveCategoryFromAliases<TCategory extends string>(
+  input: string,
+  aliases: Readonly<Record<string, TCategory>>,
+): TCategory | null {
+  if (Object.hasOwn(aliases, input)) {
+    return aliases[input] ?? null;
+  }
+
+  return Object.values(aliases).find((category) => category === input) ?? null;
+}
 
 /** Resolve a short alias or full key to the config key */
-export function resolveCategory(input: string): string | null {
-  if (Object.hasOwn(CATEGORY_ALIASES, input)) {
-    return CATEGORY_ALIASES[input] ?? null;
-  }
-  if (Object.hasOwn(CATEGORY_KEY_TO_ALIAS, input)) return input;
-  return null;
+export function resolveCategory(input: string): CategoryKey | null {
+  return resolveCategoryFromAliases(input, CATEGORY_ALIASES);
 }
 
 /** Sort field aliases for /sort command (alias → SortField) */
@@ -399,10 +413,10 @@ export function parseCommand(input: string): { name: string; args: string[] } | 
   return { name, args };
 }
 
-export function executeCommand(
+export function executeCommand<TAction extends CommandAction = CommandAction>(
   input: string,
-  commands: CommandDef[],
-): CommandResult {
+  commands: CommandDef<TAction>[],
+): CommandResult<TAction> {
   const parsed = parseCommand(input);
 
   if (!parsed) {
@@ -426,10 +440,12 @@ export function executeCommand(
   return cmd.execute(parsed.args);
 }
 
-export function getMatchingCommands(
+export function getMatchingCommands<
+  TAction extends CommandAction = CommandAction,
+>(
   partial: string,
-  commands: CommandDef[],
-): CommandDef[] {
+  commands: CommandDef<TAction>[],
+): CommandDef<TAction>[] {
   const lower = partial.toLowerCase();
   if (!lower.startsWith("/")) return [];
 


### PR DESCRIPTION
## Summary
- keep the preview component mounted during ordinary config changes and resets
- retain explicit refresh as the only animation replay remount
- narrow Studio command categories and values to BadgeConfig metadata
- reuse the canonical category resolver

## Verification
- 479 test files, 7,888 tests passed in the combined Wave 2 candidate
- typecheck passed
- lint passed
- production build passed

Closes #1150
Closes #1151