### PR TITLE
fix(cache): exclude EMU sources from warm-cache registry

### DIFF
--- a/apps/web/lib/db/users.contract.test.ts
+++ b/apps/web/lib/db/users.contract.test.ts
@@ -23,13 +23,26 @@ import {
  */
 
 const RUN_ID = randomUUID();
-const HANDLE_PREFIX = `chapa-e2e-${RUN_ID}-user-`;
+const HANDLE_PREFIX = `chapa-e2e-${RUN_ID.slice(0, 8)}-user-`;
+const EMU_SOURCE_HANDLE = `chapa-emu-${RUN_ID.slice(0, 8)}_source`;
 const TOTAL_USERS = 1001;
 
 describe("user accessors past the 1000-row max_rows cap (contract)", () => {
   afterAll(async () => {
     const db = getServiceClient();
     await db.from("users").delete().like("handle", `${HANDLE_PREFIX}%`);
+    await db.from("users").delete().eq("handle", EMU_SOURCE_HANDLE);
+  });
+
+  it("excludes an EMU source row from the primary warm-cache registry", async () => {
+    const db = getServiceClient();
+    const { error } = await db.from("users").insert({
+      handle: EMU_SOURCE_HANDLE,
+    });
+    expect(error).toBeNull();
+
+    const allHandles = await dbGetAllUserHandles();
+    expect(allHandles).not.toContain(EMU_SOURCE_HANDLE);
   });
 
   it("seeds past the max_rows cap and returns every row from both accessors", async () => {

--- a/apps/web/lib/db/users.test.ts
+++ b/apps/web/lib/db/users.test.ts
@@ -153,6 +153,13 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("dbUpsertUser", () => {
+  it("does not register an EMU source handle as a primary user", async () => {
+    await dbUpsertUser("Juan-GonzalezPonce_avoltagh");
+
+    expect(mockFrom).not.toHaveBeenCalled();
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
   it("upserts user with lowercase handle", async () => {
     mockUpsert.mockResolvedValue({ error: null });
 
@@ -418,6 +425,19 @@ describe("dbGetUserHandlePage", () => {
 });
 
 describe("dbGetAllUserHandles", () => {
+  it("excludes EMU source handles from the warm-cache registry", async () => {
+    handlePageResolver = () => ({
+      data: [
+        { handle: "alice" },
+        { handle: "juan-gonzalezponce_avoltagh" },
+        { handle: "bob" },
+      ],
+      error: null,
+    });
+
+    await expect(dbGetAllUserHandles()).resolves.toEqual(["alice", "bob"]);
+  });
+
   it("selects only handles and crosses the 1000-row boundary by handle", async () => {
     const first = Array.from({ length: 1000 }, (_, index) => ({
       handle: `user-${String(index).padStart(4, "0")}`,

--- a/apps/web/lib/db/users.ts
+++ b/apps/web/lib/db/users.ts
@@ -8,6 +8,7 @@
 import { getSupabase } from "./supabase";
 import { parseRows } from "./parse-row";
 import { SUPABASE_MAX_ROWS } from "./paginate";
+import { isValidHandle } from "@/lib/validation";
 
 // ---------------------------------------------------------------------------
 // Row type
@@ -95,6 +96,12 @@ export async function dbUpsertUser(
   handle: string,
   opts?: UpsertUserOpts,
 ): Promise<void> {
+  // The permanent users registry contains primary GitHub identities only.
+  // EMU source handles can contain underscores and are stored separately as
+  // supplemental data; registering one here makes warm-cache retry an account
+  // the server token cannot resolve on every hourly run.
+  if (!isValidHandle(handle)) return;
+
   const db = getSupabase();
   if (!db) return;
 
@@ -259,7 +266,12 @@ export async function dbGetAllUserHandles(): Promise<string[]> {
         USER_HANDLE_REQUIRED_KEYS,
         "users",
       );
-      handles.push(...rows.map((row) => row.handle));
+      // Filter legacy EMU source rows while retaining the raw last row as the
+      // pagination cursor below. Advancing by the filtered list could stall a
+      // page made entirely of invalid primary handles.
+      for (const row of rows) {
+        if (isValidHandle(row.handle)) handles.push(row.handle);
+      }
       if (rows.length < SUPABASE_MAX_ROWS) return handles;
 
       const nextAfter = rows.at(-1)?.handle;


### PR DESCRIPTION
## Summary
- reject EMU-only source handles when writing the primary users registry
- filter legacy EMU rows from the warm-cache handle list without breaking pagination
- add unit and local Supabase contract regressions

## Verification
- pnpm run typecheck
- pnpm run lint
- pnpm run test (8,333 tests)
- pnpm run check:circular
- pnpm run test:contract:local (68 tests)