### PR TITLE
Release v2.29.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.29.3] - 2026-09-03
+
+### Fixed
+
+- **Profile comparisons now give agents a truthful recovery path.** When a
+  requested handle has no public Chapa profile, browser and remote MCP tools
+  now explain that the profile owner must sign in before the comparison can
+  succeed. The tool catalog also limits comparisons to existing public Chapa
+  profiles instead of promising that any public GitHub handle is comparable.
+
 ## [2.29.2] - 2026-09-01
 
 ### Fixed

--- a/apps/web/app/llms-full.txt/route.ts
+++ b/apps/web/app/llms-full.txt/route.ts
@@ -67,7 +67,7 @@ Chapa registers browser-native WebMCP tools through \`document.modelContext\`. T
 ### Landing page: \`/\`
 
 - \`get_site_capabilities\` (read-only): Describes Chapa, its page-scoped tool map, entry points, and human-action boundaries.
-- \`find_profile\` (read-only): Validates a public GitHub handle and returns canonical share-page and badge URLs without making a request.
+- \`find_profile\` (read-only): Validates a public GitHub handle and returns canonical share-page and badge URLs without making a request; public profile tools require the owner to have signed in.
 
 ### Creator Studio: \`/studio\` and \`/studio?demo=1\`
 
@@ -89,7 +89,7 @@ Demo mode at \`/studio?demo=1\` needs no login and uses fixed local data. Tools 
 - \`get_impact_history\` (read-only): Fetches public snapshots and trend data with friendly missing-data and rate-limit messages.
 - \`verify_badge\` (read-only): Returns the public verification record and verification URL when the profile has a hash.
 - \`explain_dimension\` (read-only): Explains a dimension using the current public page data.
-- \`compare_profiles\` (read-only): Compares the on-page profile with another public profile and returns score and dimension differences.
+- \`compare_profiles\` (read-only): Compares the on-page profile with another existing public Chapa profile and returns score and dimension differences.
 - \`get_embed_snippet\` (read-only): Returns canonical Markdown and HTML snippets for the live badge.
 
 ### Verification page: \`/verify/{hash}\`

--- a/apps/web/app/u/[handle]/SharePageWebMcpTools.render.test.tsx
+++ b/apps/web/app/u/[handle]/SharePageWebMcpTools.render.test.tsx
@@ -149,6 +149,9 @@ describe("SharePageWebMcpTools", () => {
       inputSchema: WEBMCP_EMPTY_INPUT_SCHEMA,
       annotations: WEBMCP_READ_ONLY_UNTRUSTED_ANNOTATIONS,
     });
+    expect(getTool("compare_profiles").description).toBe(
+      "Compare this impact profile with another existing public Chapa profile, identified by GitHub handle.",
+    );
     expect(mocks.createExplainDimensionTool).toHaveBeenCalledOnce();
   });
 
@@ -348,7 +351,7 @@ describe("SharePageWebMcpTools", () => {
     expect(fetch).toHaveBeenCalledWith("/api/profile/other-user", { signal });
   });
 
-  it("guides the agent to generate a missing comparison profile and retry", async () => {
+  it("explains that a missing comparison profile requires owner sign-in", async () => {
     respondWith({ error: "request failed" }, 404);
     const { getTool } = renderHost();
 
@@ -356,10 +359,11 @@ describe("SharePageWebMcpTools", () => {
       other_handle: "other-user",
     });
 
-    expect(output).toContain(
-      "https://chapa.thecreativetoken.com/u/other-user",
+    expect(output).toBe(
+      "No public Chapa impact profile exists for @other-user. Its owner must sign in to Chapa before this handle can be compared.",
     );
-    expect(output).toContain("retry this comparison");
+    expect(output).not.toContain("first visit");
+    expect(output).not.toContain("retry");
   });
 
   it("returns a friendly compare response when rate limited", async () => {

--- a/apps/web/app/u/[handle]/SharePageWebMcpTools.tsx
+++ b/apps/web/app/u/[handle]/SharePageWebMcpTools.tsx
@@ -162,7 +162,8 @@ export function SharePageWebMcpTools({
 
     const compareProfiles: WebMcpTool = {
       name: "compare_profiles",
-      description: "Compare this impact profile with another public GitHub handle.",
+      description:
+        "Compare this impact profile with another existing public Chapa profile, identified by GitHub handle.",
       inputSchema: COMPARE_PROFILES_INPUT_SCHEMA,
       annotations: WEBMCP_READ_ONLY_UNTRUSTED_ANNOTATIONS,
       execute: async (inputs, { signal }) => {
@@ -181,7 +182,7 @@ export function SharePageWebMcpTools({
           { signal },
         );
         if (response.status === 404) {
-          return `No public impact profile was found for @${otherHandle}. A profile is generated on first visit: ask the user to open https://chapa.thecreativetoken.com/u/${otherHandle} once, then retry this comparison.`;
+          return `No public Chapa impact profile exists for @${otherHandle}. Its owner must sign in to Chapa before this handle can be compared.`;
         }
         if (response.status === 429) {
           return "Profile comparison is temporarily rate limited. Please try again later.";

--- a/apps/web/components/LandingWebMcpTools.render.test.tsx
+++ b/apps/web/components/LandingWebMcpTools.render.test.tsx
@@ -128,7 +128,10 @@ describe("LandingWebMcpTools", () => {
       badgeSvgUrl:
         "https://chapa.thecreativetoken.com/u/developer/badge.svg",
     });
-    expect(result.notes.join(" ")).toMatch(/generated on first visit/i);
+    expect(result.notes).toContain(
+      "Share and badge URLs can render public GitHub activity, but public profile tools require the handle's owner to have signed in to Chapa.",
+    );
+    expect(result.notes.join(" ")).not.toMatch(/generated on first visit/i);
     expect(result.notes.join(" ")).toMatch(/share page registers six more tools/i);
   });
 });

--- a/apps/web/components/LandingWebMcpTools.tsx
+++ b/apps/web/components/LandingWebMcpTools.tsx
@@ -6,6 +6,7 @@ import { isValidHandle } from "@/lib/validation";
 import {
   FIND_PROFILE_INPUT_SCHEMA,
   PRODUCTION_BASE_URL,
+  PUBLIC_PROFILE_SIGN_IN_NOTE,
   SITE_CAPABILITIES,
 } from "@/lib/webmcp/catalog";
 import {
@@ -58,7 +59,7 @@ export function LandingWebMcpTools() {
             badgeSvgUrl:
               `${PRODUCTION_BASE_URL}/u/${encodedHandle}/badge.svg`,
             notes: [
-              "The profile is generated on first visit if it does not exist yet.",
+              PUBLIC_PROFILE_SIGN_IN_NOTE,
               "Opening the share page registers six more tools, including get_impact_profile and get_embed_snippet.",
             ],
           });

--- a/apps/web/lib/webmcp/catalog.ts
+++ b/apps/web/lib/webmcp/catalog.ts
@@ -16,6 +16,9 @@ import { SITE_TOOL_MAP } from "./site-tool-map";
 
 export const PRODUCTION_BASE_URL = "https://chapa.thecreativetoken.com";
 
+export const PUBLIC_PROFILE_SIGN_IN_NOTE =
+  "Share and badge URLs can render public GitHub activity, but public profile tools require the handle's owner to have signed in to Chapa.";
+
 export const FIND_PROFILE_INPUT_SCHEMA = {
   type: "object",
   properties: {

--- a/apps/web/lib/webmcp/server-tools.test.ts
+++ b/apps/web/lib/webmcp/server-tools.test.ts
@@ -161,6 +161,12 @@ describe("remote MCP server tools", () => {
     expect(profile.sharePageUrl).toBe(
       "https://chapa.thecreativetoken.com/u/octocat",
     );
+    expect(profile.notes).toContain(
+      "Share and badge URLs can render public GitHub activity, but public profile tools require the handle's owner to have signed in to Chapa.",
+    );
+    expect(profile.notes).not.toContain(
+      "The profile is generated on first visit if it does not exist yet.",
+    );
   });
 
   it.each([
@@ -245,11 +251,25 @@ describe("remote MCP server tools", () => {
     }
   });
 
-  it("returns actionable missing-record messages", async () => {
+  it("explains that missing public profiles require owner sign-in", async () => {
     mocks.getCachedLatestSnapshot.mockResolvedValueOnce(null);
     await expect(
       tool("get_impact_profile").execute({ handle: "missing-user" }),
-    ).resolves.toContain("open https://chapa.thecreativetoken.com/u/missing-user");
+    ).resolves.toBe(
+      "No public Chapa impact profile exists for @missing-user. Its owner must sign in to Chapa before public profile tools can use this handle.",
+    );
+
+    mocks.getCachedLatestSnapshot
+      .mockResolvedValueOnce(snapshot)
+      .mockResolvedValueOnce(null);
+    await expect(
+      tool("compare_profiles").execute({
+        handle: "octocat",
+        other_handle: "missing-user",
+      }),
+    ).resolves.toBe(
+      "No public Chapa impact profile exists for @missing-user. Its owner must sign in to Chapa before public profile tools can use this handle.",
+    );
 
     mocks.getVerificationRecord.mockResolvedValueOnce(null);
     await expect(

--- a/apps/web/lib/webmcp/server-tools.ts
+++ b/apps/web/lib/webmcp/server-tools.ts
@@ -19,6 +19,7 @@ import {
   EXPLAIN_DIMENSION_SERVER_INPUT_SCHEMA,
   FIND_PROFILE_INPUT_SCHEMA,
   PRODUCTION_BASE_URL,
+  PUBLIC_PROFILE_SIGN_IN_NOTE,
   SITE_CAPABILITIES,
   VERIFICATION_EXPLANATION,
   VERIFY_BADGE_SERVER_INPUT_SCHEMA,
@@ -104,7 +105,7 @@ function validateInputKeys(
 }
 
 function missingProfile(handle: string): string {
-  return `No public impact profile was found for @${handle}. Ask the user to open ${PRODUCTION_BASE_URL}/u/${encodeURIComponent(handle)} once, then retry.`;
+  return `No public Chapa impact profile exists for @${handle}. Its owner must sign in to Chapa before public profile tools can use this handle.`;
 }
 
 function unavailable(tool: string): string {
@@ -237,7 +238,7 @@ const findProfile: ServerMcpTool = {
       sharePageUrl: `${PRODUCTION_BASE_URL}/u/${encodedHandle}`,
       badgeSvgUrl: `${PRODUCTION_BASE_URL}/u/${encodedHandle}/badge.svg`,
       notes: [
-        "The profile is generated on first visit if it does not exist yet.",
+        PUBLIC_PROFILE_SIGN_IN_NOTE,
         "The remote endpoint exposes the public read-only profile tools without browser page state.",
       ],
     });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chapa/web",
-  "version": "2.29.2",
+  "version": "2.29.3",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/docs/chatgpt-app-submission.md
+++ b/docs/chatgpt-app-submission.md
@@ -57,7 +57,7 @@ Initial release notes:
 ### Starter prompts
 
 - What is my Chapa impact score? My GitHub handle is juan294.
-- Compare juan294 with octocat.
+- Compare juan294 with frivas.
 - Is this badge verified? Hash: 84567a48984e0c2e287acb78d1404a57.
 - How is the Delivery dimension calculated for juan294?
 - Give me the README embed for juan294.
@@ -110,12 +110,12 @@ Run these tests against the production MCP server after the endpoint and challen
 
 ### Positive 2: profile comparison
 
-- Prompt: **Compare juan294 with octocat.**
+- Prompt: **Compare juan294 with frivas.**
 - Expected tool: `compare_profiles`
-- Tool input: `{"handle":"juan294","other_handle":"octocat"}`
+- Tool input: `{"handle":"juan294","other_handle":"frivas"}`
 - Expected behavior: The assistant compares the two public profiles and explains the score and dimension differences.
 - Expected result shape: JSON with `current`, `other`, and `differences`; both profile objects contain `handle`, `score`, `tier`, and `dimensions`; `differences` contains `score` and `dimensions`.
-- Fixtures: `https://chapa.thecreativetoken.com/u/juan294` and `https://chapa.thecreativetoken.com/u/octocat`
+- Fixtures: `https://chapa.thecreativetoken.com/u/juan294` and `https://chapa.thecreativetoken.com/u/frivas`
 - Pass condition: The tool succeeds and the assistant identifies which profile leads overall and on relevant dimensions without exposing confidence data.
 
 ### Positive 3: badge verification
@@ -163,9 +163,9 @@ Run these tests against the production MCP server after the endpoint and challen
 - Prompt: **What is the Chapa impact score for chapa-no-profile-1260?**
 - Expected tool: `get_impact_profile`
 - Tool input: `{"handle":"chapa-no-profile-1260"}`
-- Expected fallback: The tool returns the friendly `No public impact profile was found` message and directs the user to open `https://chapa.thecreativetoken.com/u/chapa-no-profile-1260` once before retrying.
+- Expected fallback: The tool reports that no public Chapa impact profile exists and explains that the handle's owner must sign in before public profile tools can use it.
 - Reason: The handle is syntactically valid, but Chapa has no stored public profile data for it.
-- Pass condition: The assistant reports that there is no profile yet and gives the recovery URL. It does not invent a score.
+- Pass condition: The assistant reports that there is no profile, identifies owner sign-in as the missing prerequisite, and does not invent a score or claim that opening the public URL will create one.
 
 ### Negative 3: mutation request
 

--- a/docs/webmcp.md
+++ b/docs/webmcp.md
@@ -29,7 +29,7 @@ These tools orient and navigate only. They fetch no data and do not wrap the pub
 | Tool | Input | `readOnlyHint` | Behavior |
 | --- | --- | --- | --- |
 | `get_site_capabilities` | `EMPTY` | yes | Describes Chapa and returns the exact page-scoped tool map, canonical entry points, and human-action boundaries. |
-| `find_profile` | `HANDLE` | yes | Validates a public GitHub handle and returns its canonical share-page and badge URLs plus navigation notes. It makes no request. |
+| `find_profile` | `HANDLE` | yes | Validates a public GitHub handle and returns its canonical share-page and badge URLs plus navigation notes. It makes no request and does not claim the handle has a persisted public Chapa profile; public profile tools require the owner to have signed in. |
 
 ### Creator Studio: `/studio` and `/studio?demo=1`
 
@@ -55,7 +55,7 @@ These tools receive the same server-computed public data as the rendered page. V
 | `get_impact_history` | `EMPTY` | yes | Fetches `/api/history/[handle]?include=snapshots,trend` with the tool cancellation signal. It returns friendly messages for missing or rate-limited data. |
 | `verify_badge` | `EMPTY` | yes | If the page has a verification hash, fetches `/api/verify/[hash]` and returns status, record, and `verifyUrl`. Otherwise it reports that the profile has no verification record. |
 | `explain_dimension` | `DIMENSION` | yes | Uses the same shared explanation tool as Studio. It operates on the current public page data. |
-| `compare_profiles` | `COMPARE` | yes | Validates the other public GitHub handle, fetches `/api/profile/[other_handle]`, and returns the two public profiles with numeric score and dimension differences. The differences are other profile minus the on-page profile. Missing and rate-limited profiles get friendly messages. |
+| `compare_profiles` | `COMPARE` | yes | Validates the other GitHub handle, fetches `/api/profile/[other_handle]`, and compares it when an existing public Chapa profile is available. The differences are other profile minus the on-page profile. A missing profile explains that its owner must sign in to Chapa; rate-limited profiles get a retry-later message. |
 | `get_embed_snippet` | `EMPTY` | yes | Returns the page's canonical Markdown and HTML embed snippets for the live badge. |
 
 ### Verification page: `/verify/[hash]`
@@ -127,10 +127,10 @@ Chapa follows the framework in Chrome's [Build your user's agentic workflows wit
 | --- | --- | --- |
 | Wrong state / missing prerequisite | `save_badge_config` with nothing dirty | `No unsaved changes. The current configuration is already saved.` |
 | Invalid parameters | `apply_badge_style` with a malformed token | `Invalid input for apply_badge_style: category and value must be single non-empty tokens; call list_style_options for valid categories and values.` |
-| Unexpected upstream data | `compare_profiles` when the other handle has no snapshot | `No public impact profile was found for @<handle>. A profile is generated on first visit: ask the user to open https://chapa.thecreativetoken.com/u/<handle> once, then retry this comparison.` |
+| Missing prerequisite | `compare_profiles` when the other handle has no public Chapa profile | `No public Chapa impact profile exists for @<handle>. Its owner must sign in to Chapa before this handle can be compared.` |
 | Business-rule violation | `save_badge_config` in any state | The save API is never called by the agent. Only the on-page human confirmation can continue. |
 
-The new `apply_badge_style` invalid-input response names `list_style_options` as the next call. Wrong-state save responses explain why no action is needed or name `preview_badge` as the next tool. The new `compare_profiles` 404 response gives the profile-generation URL and tells the agent to retry.
+The `apply_badge_style` invalid-input response names `list_style_options` as the next call. Wrong-state save responses explain why no action is needed or name `preview_badge` as the next tool. The `compare_profiles` 404 response explains that only the profile owner can satisfy the missing sign-in prerequisite; opening a public share or badge URL does not create a persisted public profile.
 
 ## Three drivers, one Studio state
 

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/juan294/chapa",
     "source": "github"
   },
-  "version": "2.29.2",
+  "version": "2.29.3",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
## v2.29.3

Patch release for #1263.

- Corrects browser and remote MCP recovery guidance when a requested comparison profile does not exist.
- Limits comparison descriptions to existing public Chapa profiles.
- Adds regression coverage and synchronizes the public MCP documentation.

Release run: `release-b6ebab596296`
Candidate: `b6ebab596296a258e68701f1f56580e86b7a99c9`
Candidate tree: `b15ae2d1367b5a51577250986a65deee2a39d356`
Rollback reference: `v2.29.2`
Immutable preview: https://chapa-57tazr9m9-thecreativetoken.vercel.app
Preview proof: https://github.com/juan294/chapa/actions/runs/33739634936
Migrations: none.