### PR TITLE
docs(webmcp): link the agent-tested transcript and write-up (#1261)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ Registration uses the current `document.modelContext.registerTool(tool, { signal
 
 See the [WebMCP tool catalog and judge guide](docs/webmcp.md) and the [under-three-minute demo script and submission checklist](docs/webmcp-demo-script.md).
 
+The write-up [WebMCP, Explained. And What Happened When I Shipped It](docs/webmcp-explained-and-how-i-shipped-it.md) covers the design framework, the tested tool-map contract, and the rules that came out of shipping it. The [production demo transcript](docs/webmcp-demo-transcript.md) (2026-09-01, Chrome 151 with the WebMCP flag) records an agent driving all four surfaces end to end, and is linked from the landing page as the agent-tested proof. A companion note, [The WebMCP directories made me use a mouse](docs/webmcp-directories-are-not-webmcp-ready.md), records what the directory submissions taught.
+
 The catalog's [Design methodology](docs/webmcp.md#design-methodology) documents each user goal, initial state, role-play, and recovery path.
 
-Runtime status, 2026-08-27: a preview-only `chapa_hello` spike passed native registration, discovery, and execution in flagged Chrome 151. The completed tool catalog still needs final production verification after release and flag enablement. The ChatGPT in-app client was unavailable for the spike, so this README does not claim ChatGPT runtime validation.
+Runtime status: a preview-only `chapa_hello` spike passed native registration, discovery, and execution in flagged Chrome 151 on 2026-08-27, and the production preflight on 2026-09-01 found all 19 registrations across 18 distinct names on four surfaces (see the transcript above). Chapa is listed on [webmcp.com](https://webmcp.com), in the [official MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.juan294/chapa) as `io.github.juan294/chapa`, and as an ownership-verified [Glama connector](https://glama.ai/mcp/connectors/com.thecreativetoken.chapa/chapa). The ChatGPT in-app client was unavailable for the spike, so this README does not claim ChatGPT runtime validation.
 
 ### Prior work and submission-period work
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Registration uses the current `document.modelContext.registerTool(tool, { signal
 
 See the [WebMCP tool catalog and judge guide](docs/webmcp.md) and the [under-three-minute demo script and submission checklist](docs/webmcp-demo-script.md).
 
-The write-up [WebMCP, Explained. And What Happened When I Shipped It](docs/webmcp-explained-and-how-i-shipped-it.md) covers the design framework, the tested tool-map contract, and the rules that came out of shipping it. The [production demo transcript](docs/webmcp-demo-transcript.md) (2026-09-01, Chrome 151 with the WebMCP flag) records an agent driving all four surfaces end to end, and is linked from the landing page as the agent-tested proof. A companion note, [The WebMCP directories made me use a mouse](docs/webmcp-directories-are-not-webmcp-ready.md), records what the directory submissions taught.
+The write-up [WebMCP, Explained. And What Happened When I Shipped It](docs/webmcp-explained-and-how-i-shipped-it.md) (published on [X](https://x.com/JuanG294/status/2094005233990893844), LinkedIn and Medium) covers the design framework, the tested tool-map contract, and the rules that came out of shipping it. The [production demo transcript](docs/webmcp-demo-transcript.md) (2026-09-01, Chrome 151 with the WebMCP flag) records an agent driving all four surfaces end to end, and is linked from the landing page as the agent-tested proof. A companion note, [The WebMCP directories made me use a mouse](docs/webmcp-directories-are-not-webmcp-ready.md), records what the directory submissions taught.
 
 The catalog's [Design methodology](docs/webmcp.md#design-methodology) documents each user goal, initial state, role-play, and recovery path.
 

--- a/apps/web/app/LandingContent.tsx
+++ b/apps/web/app/LandingContent.tsx
@@ -23,6 +23,11 @@ const DIMENSION_STYLES = [
   { key: "craft", bar: "bg-dimension-craft" },
 ] as const;
 
+// #1261 — the production run recorded on 2026-09-01 (Chrome 151, flagged),
+// linked as the "agent-tested" proof beside the static catalog.
+const WEBMCP_TRANSCRIPT_URL =
+  "https://github.com/juan294/chapa/blob/main/docs/webmcp-demo-transcript.md";
+
 const SITE_TOOL_COUNT = new Set(
   SITE_TOOL_MAP.flatMap((entry) => entry.tools),
 ).size;
@@ -464,6 +469,18 @@ export function LandingContent({
             </div>
             <p className="mt-5 text-sm leading-relaxed text-pretty text-text-secondary">
               {agentTools.boundary}
+            </p>
+            <p className="mt-3 text-sm leading-relaxed text-pretty text-text-secondary">
+              {agentTools.transcriptBefore}{" "}
+              <a
+                href={WEBMCP_TRANSCRIPT_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-amber-text underline underline-offset-4 transition-colors hover:text-amber-light"
+              >
+                {agentTools.transcriptLink}
+              </a>{" "}
+              {agentTools.transcriptAfter}
             </p>
           </section>
         </div>

--- a/apps/web/app/[locale]/page.render.test.tsx
+++ b/apps/web/app/[locale]/page.render.test.tsx
@@ -194,6 +194,19 @@ describe("Home page render (en)", () => {
     }
   });
 
+  // #1261 — the catalog is a claim; the transcript is the proof. The landing
+  // page links the production run of an agent driving the tools end to end.
+  it("links the agent-tested production transcript from the tool catalog", async () => {
+    const { container } = await renderHome();
+    const link = container.querySelector(
+      '#agent-tools a[href$="/docs/webmcp-demo-transcript.md"]',
+    );
+
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute("target")).toBe("_blank");
+    expect(link?.getAttribute("rel")).toContain("noopener");
+  });
+
   it("renders error banner when error param present in the URL", async () => {
     window.history.pushState({}, "", "/?error=access_denied");
     await renderHome();

--- a/apps/web/lib/i18n/dictionaries/en.ts
+++ b/apps/web/lib/i18n/dictionaries/en.ts
@@ -200,6 +200,9 @@ export const en: Translations = {
     agentTools: {
       intro: 'This site speaks WebMCP. Open a page below in a WebMCP-capable browser to use its tools.',
       boundary: 'Read-only tools inspect public data. Creator Studio tools can change visible page state, but saving always waits for a human click.',
+      transcriptBefore: 'Agent-tested in production on 2026-09-01:',
+      transcriptLink: 'read the full tool-call transcript',
+      transcriptAfter: 'of an agent driving all four surfaces end to end.',
     },
     stats: [
       { value: '7', label: 'archetypes' },

--- a/apps/web/lib/i18n/dictionaries/es.ts
+++ b/apps/web/lib/i18n/dictionaries/es.ts
@@ -194,6 +194,9 @@ export const es: Translations = {
     agentTools: {
       intro: 'Este sitio habla WebMCP. Abre una página de la lista en un navegador compatible con WebMCP para usar sus herramientas.',
       boundary: 'Las herramientas de solo lectura consultan datos públicos. Las herramientas de Creator Studio pueden cambiar el estado visible de la página, pero guardar siempre espera el clic de una persona.',
+      transcriptBefore: 'Probado con un agente en producción el 2026-09-01:',
+      transcriptLink: 'lee la transcripción completa de llamadas a herramientas',
+      transcriptAfter: 'de un agente recorriendo las cuatro superficies de principio a fin.',
     },
     stats: [
       { value: '7', label: 'arquetipos' },

--- a/docs/webmcp-explained-and-how-i-shipped-it.md
+++ b/docs/webmcp-explained-and-how-i-shipped-it.md
@@ -185,7 +185,7 @@ Calling it opens a confirmation control on the page. It never touches the save A
 
 This was not a security requirement handed to me. It came from thinking about what the tool boundary means. Everything before the save is reversible and visible: change a color, watch it, change it back. The save writes the Studio configuration to the database, so it becomes the starting point when you come back. The reversible steps are a fine place for autonomy. The durable write is not.
 
-To be accurate about what that write currently reaches: it persists the Studio preview configuration, and it does not yet alter the public SVG badge. The public renderer does not consume that configuration today. Closing that split is its own piece of work, recorded in an architecture decision record, and it does not change the gating argument. A durable write is a durable write, and the moment it does drive the embedded badge, the gate is already in the right place.
+To be accurate about what that write reaches: when I first shipped the tools, the save persisted only the Studio preview configuration, and the public SVG renderer did not consume it. That split is closed now. There is one badge implementation, the saved configuration drives the embedded SVG, the share page and the social preview image, and a save invalidates every cached copy of them. The gating argument never depended on which it was. A durable write is a durable write, and now that it does drive the badge people embed in their READMEs, the gate is already in the right place.
 
 Concretely: an agent can redesign your entire badge in twelve tool calls, and you can undo all of it by refreshing the page. It cannot make one of those changes permanent without you.
 
@@ -292,7 +292,7 @@ Shipping the runtime tools did not make Chapa easy to find. I added four static 
 
 I also shipped a stateless [Streamable HTTP MCP endpoint](https://chapa.thecreativetoken.com/api/mcp) for clients that do not control a browser tab. It exposes nine public, read-only tools and calls the same application libraries as Chapa's public routes. Studio mutation tools stay browser-only because their value comes from shared, visible page state and the human confirmation gate.
 
-The endpoint is active in the [official MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.juan294/chapa) as `io.github.juan294/chapa` version `2.29.1`, and the [Glama connector listing](https://glama.ai/mcp/connectors/com.thecreativetoken.chapa/chapa) is live. I also submitted Chapa to WebMCP and `llms.txt` directories and to MCP Servers. Some directory reviews were still pending when I finished this article. One WebMCP scanner rejected the site because it looked for an older browser API signature instead of the current `document.modelContext` API. That result was useful: directory compatibility is another contract, and it can lag the runtime specification.
+The endpoint is active in the [official MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.juan294/chapa) as `io.github.juan294/chapa` (registry record version `2.29.0`), and the [Glama connector listing](https://glama.ai/mcp/connectors/com.thecreativetoken.chapa/chapa) is live. I also submitted Chapa to WebMCP and `llms.txt` directories and to MCP Servers. Some directory reviews were still pending when I finished this article. One WebMCP scanner rejected the site because it looked for an older browser API signature instead of the current `document.modelContext` API. That result was useful: directory compatibility is another contract, and it can lag the runtime specification.
 
 ### The evidence, and its limits
 
@@ -302,7 +302,9 @@ Verified: a hello-world tool passed **native registration, discovery, and execut
 
 Verified: the full browser catalog is implemented and tested, with each tool host carrying its own render test. The remote endpoint has a separate transport contract matrix and a parity assertion that keeps its nine tool names tied to the browser catalog.
 
-Verified: the browser code has shipped in every release since v2.24.0. The static discovery surfaces, telemetry, and remote MCP endpoint first shipped in v2.29.0. The current production endpoint identifies itself as Chapa v2.29.1 and lists all nine read-only tools.
+Verified: the browser code has shipped in every release since v2.24.0. The static discovery surfaces, telemetry, and remote MCP endpoint first shipped in v2.29.0. The current production endpoint identifies itself as Chapa v2.29.4 and lists all nine read-only tools.
+
+Verified: an agent drove the full catalog end to end on production on 2026-09-01, in Chrome 151 with the WebMCP flag: landing discovery, the demo Studio, the human save boundary, a public profile, and its verification record, including the altered-hash negative case. The [cleaned transcript](https://github.com/juan294/chapa/blob/main/docs/webmcp-demo-transcript.md) preserves every tool name, argument, route, boundary, and visible page effect. It is linked from Chapa's landing page as the agent-tested proof, because a tool catalog is a claim and a transcript is evidence.
 
 One more practical note if you are planning a demo. Chrome's WebMCP origin trial runs from Chrome 149 to 156 and ends **17 November 2026**. Without a trial token, your visitors need to enable the flag themselves. With a token, unflagged Chrome works. Decide which of those your audience is before you record anything.
 


### PR DESCRIPTION
## Summary

Repo-side half of #1261. The landing page's agent-tools section now links the 2026-09-01 production transcript as the "agent-tested" proof (both locales, with a render test). The README links the write-up, the transcript and the directories note, and its runtime-status paragraph reflects the production preflight and the live listings.

The write-up had drifted from production and is corrected before it goes anywhere public:
- It said a Studio save does not reach the public SVG. #1191 closed that split.
- It pinned the MCP Registry record and the live endpoint to v2.29.1. Probed today: the registry record is 2.29.0, the endpoint reports 2.29.4.
- Its evidence section now cites the transcript.

Outward publication (venue, images, public URL back-link) stays open on the issue.

## Verification

- `pnpm run test`: 506 files, 8371 tests passed (pre-commit).
- `pnpm run typecheck` and `pnpm run lint`: clean.
- `curl https://chapa.thecreativetoken.com/api/mcp` initialize reports `2.29.4`; registry search returns `2.29.0`, `active`.

Refs #1261

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnfhmLrHFuLNnHFKcZ3f7m
