### PR TITLE
fix(e2e): share-verification probe reads rendered state and the full hash (#1279)

### DIFF
--- a/apps/web/e2e/helpers/deployment-probes.ts
+++ b/apps/web/e2e/helpers/deployment-probes.ts
@@ -1,9 +1,12 @@
 import { execFileSync } from "node:child_process";
 import {
   expect,
+  test,
   type APIRequestContext,
   type Page,
 } from "@playwright/test";
+import { writeFile } from "node:fs/promises";
+import { hasRenderedText, verifyHashFromHtml } from "./probe-html";
 
 export const smokeProfilePath = "/u/octocat?__chapa_smoke=1";
 export const smokeBadgePath = "/u/octocat/badge.svg?__chapa_smoke=1";
@@ -16,7 +19,6 @@ export const smokeBadgePath = "/u/octocat/badge.svg?__chapa_smoke=1";
 // preview happens to be under test.
 const PRODUCTION_ORIGIN = "https://chapa.thecreativetoken.com";
 
-const VERIFY_HASH_PATTERN = /\/verify\/([0-9a-f]{8}|[0-9a-f]{16}|[0-9a-f]{32})/;
 
 export async function assertCoreDependencies(
   request: APIRequestContext,
@@ -102,31 +104,56 @@ export async function assertRollbackReadiness(
  * links to /verify/{hash}, and that page must render the verified success
  * state (not the not-found or invalid-hash states).
  */
+/**
+ * Keep the response body when an assertion on it fails, so a transient
+ * (the share page once rendered without its verify link about a minute
+ * after a deployment went live, #1279) is diagnosable from the artifact
+ * instead of lost with the run.
+ */
+async function withBodyAttachment<T>(
+  name: string,
+  body: string,
+  assertions: () => T,
+): Promise<T> {
+  try {
+    return assertions();
+  } catch (error) {
+    // Written to the test's output directory as well as attached, so the
+    // body survives a plain `--reporter=list` run, not only an HTML report.
+    const path = test.info().outputPath(name);
+    await writeFile(path, body);
+    await test.info().attach(name, { path, contentType: "text/html" });
+    throw error;
+  }
+}
+
 export async function assertShareVerification(
   request: APIRequestContext,
 ): Promise<void> {
   const response = await request.get(`${smokeProfilePath}&lang=en`);
   expect(response.status()).toBe(200);
   const body = await response.text();
-  expect(body).toContain("Embed this badge");
-
-  const match = VERIFY_HASH_PATTERN.exec(body);
-  expect(match, "share page did not render a /verify/{hash} link").not.toBeNull();
-  const hash = match![1];
+  const hash = await withBodyAttachment("share-page.html", body, () => {
+    expect(body).toContain("Embed this badge");
+    // #1279 — the previous pattern tried the 8-character alternative first
+    // and verified the first 8 characters of a 32-character hash.
+    const hash = verifyHashFromHtml(body);
+    expect(hash, "share page did not render a /verify/{hash} link").not.toBeNull();
+    return hash!;
+  });
 
   const verifyResponse = await request.get(`/verify/${hash}?lang=en`);
   expect(verifyResponse.status()).toBe(200);
   const verifyBody = await verifyResponse.text();
-  expect(verifyBody).toContain("Badge verified");
-  expect(verifyBody).not.toContain("Invalid hash");
-  expect(verifyBody).not.toContain("Not found");
+  // #1279 — rendered state, not document substrings: the page also ships
+  // its translation dictionary, which names every state it can render.
+  await withBodyAttachment("verify-page.html", verifyBody, () => {
+    expect(hasRenderedText(verifyBody, "Badge verified"), "verify page did not render the verified state").toBe(true);
+    expect(hasRenderedText(verifyBody, "Invalid hash"), "verify page rendered the invalid-hash callout").toBe(false);
+    expect(hasRenderedText(verifyBody, "Not found"), "verify page rendered the not-found callout").toBe(false);
+  });
 }
 
-/**
- * #1190 — the share page must render correctly in both supported locales.
- * Two plain HTTP requests, matching the release checklist's manual "switch
- * Spanish to English and back" step.
- */
 export async function assertLocales(request: APIRequestContext): Promise<void> {
   // #1217 replaced the sr-only, localized h1 with a visible one carrying the
   // profile identity, which reads the same in both locales. The badge's

--- a/apps/web/e2e/helpers/probe-html.test.ts
+++ b/apps/web/e2e/helpers/probe-html.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { hasRenderedText, renderedTextPattern, verifyHashFromHtml } from "./probe-html";
+
+// #1279 — the share-verification probe read HTML as a string twice over and
+// failed on every deployment: negative assertions matched the serialized
+// translation dictionary, and the hash pattern captured 8 of 32 characters.
+describe("hasRenderedText", () => {
+  const dictionaryOnly =
+    '<script>self.__next_f.push(["{\\"notFoundTitle\\":\\"Not found\\",\\"invalidHashTitle\\":\\"Invalid hash\\"}"])</script><h1>Badge verified</h1>';
+
+  it("matches a text node rendered between tags", () => {
+    expect(hasRenderedText(dictionaryOnly, "Badge verified")).toBe(true);
+  });
+
+  it("does not match the same words inside a serialized dictionary string", () => {
+    expect(hasRenderedText(dictionaryOnly, "Not found")).toBe(false);
+    expect(hasRenderedText(dictionaryOnly, "Invalid hash")).toBe(false);
+  });
+
+  it("matches a rendered not-found or invalid-hash callout", () => {
+    expect(hasRenderedText('<p class="x">\n  Not found\n</p>', "Not found")).toBe(true);
+    expect(hasRenderedText("<h1>Invalid hash</h1>", "Invalid hash")).toBe(true);
+  });
+
+  it("does not treat a longer title as the callout", () => {
+    expect(hasRenderedText("<title>Invalid hash — Chapa</title>", "Invalid hash")).toBe(false);
+  });
+
+  it("escapes regex metacharacters in the label", () => {
+    expect(renderedTextPattern("A (b) c?").test("<span>A (b) c?</span>")).toBe(true);
+    expect(renderedTextPattern("A (b) c?").test("<span>A b c</span>")).toBe(false);
+  });
+});
+
+describe("verifyHashFromHtml", () => {
+  const full = "86852ccc3516f34b14f7353de0233167";
+
+  it("captures the whole 32-character hash, not its first 8 characters", () => {
+    expect(verifyHashFromHtml(`<a href="/verify/${full}">Verify</a>`)).toBe(full);
+  });
+
+  it("accepts the shorter historical hash lengths", () => {
+    expect(verifyHashFromHtml('<a href="/verify/0123456789abcdef">x</a>')).toBe("0123456789abcdef");
+    expect(verifyHashFromHtml('<a href="/verify/01234567">x</a>')).toBe("01234567");
+  });
+
+  it("returns null when the page carries only the bare /verify landing link", () => {
+    expect(verifyHashFromHtml('<a href="/verify">Verify a badge</a>')).toBeNull();
+  });
+
+  it("takes the first hash link when several are present", () => {
+    const html = `<a href="/verify/${full}"></a><a href="https://chapa.thecreativetoken.com/verify/${full}"></a>`;
+    expect(verifyHashFromHtml(html)).toBe(full);
+  });
+});

--- a/apps/web/e2e/helpers/probe-html.ts
+++ b/apps/web/e2e/helpers/probe-html.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure helpers for deployed HTML probes (#1279).
+ *
+ * Two defects hid inside `profile.share-verification` for weeks, both about
+ * reading HTML as a string:
+ *
+ * 1. A label can appear as a text node the visitor sees, or inside the
+ *    serialized translation dictionary the page ships for hydration.
+ *    `toContain("Not found")` cannot tell them apart, so the probe failed on
+ *    every verified page. `hasRenderedText` matches only a text node: the
+ *    label alone between a `>` and a `<`, whitespace allowed.
+ * 2. `/verify\/([0-9a-f]{8}|[0-9a-f]{16}|[0-9a-f]{32})/` tries the shortest
+ *    alternative first, so a 32-character hash was captured as its first 8
+ *    characters and the probe then verified a hash that does not exist.
+ *    `verifyHashFromHtml` tries the longest form first and refuses a match
+ *    followed by more hex.
+ */
+export function renderedTextPattern(label: string): RegExp {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`>\\s*${escaped}\\s*<`);
+}
+
+export function hasRenderedText(html: string, label: string): boolean {
+  return renderedTextPattern(label).test(html);
+}
+
+const VERIFY_HASH_PATTERN = /\/verify\/([0-9a-f]{32}|[0-9a-f]{16}|[0-9a-f]{8})(?![0-9a-f])/;
+
+/** The full verification hash of the first `/verify/{hash}` link, or null. */
+export function verifyHashFromHtml(html: string): string | null {
+  return VERIFY_HASH_PATTERN.exec(html)?.[1] ?? null;
+}


### PR DESCRIPTION
## Summary

`profile.share-verification` (deep mode only) failed on every deployment for two reasons, found by `/prodplaybook v2.29.5`:

1. Negative assertions ran against the whole verify-page HTML, which ships its translation dictionary for hydration, so "Invalid hash" and "Not found" are present on every verified page.
2. The hash regex tried `{8}` before `{32}` and captured the first 8 characters of the 32-character hash, then verified a hash that does not exist.

## Changes

- `e2e/helpers/probe-html.ts` (new, pure): `hasRenderedText` matches a label only as a text node between tags; `verifyHashFromHtml` extracts the longest hash with a trailing boundary. 9 unit tests, including the dictionary-string and 8-of-32 negative cases.
- `assertShareVerification` uses both, and on failure writes the response body to the test output directory and attaches it to the report.

## Verification

- Unit tests, typecheck, lint clean.
- Deep probes against production v2.29.5 with this helper: 6/6 passed.

Fixes #1279

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnfhmLrHFuLNnHFKcZ3f7m
